### PR TITLE
Move server lock webhook to CountReached state

### DIFF
--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/2_BattleRoyaleCountReached.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/2_BattleRoyaleCountReached.c
@@ -20,6 +20,15 @@ class BattleRoyaleCountReached: BattleRoyaleDebugState
     	BattleRoyaleUtils.Debug(string.Format("BattleRoyaleCountReached: Activating with time to start: %1 seconds", i_TimeToStart));
         super.Activate();
 
+    	BattleRoyaleConfig m_Config = BattleRoyaleConfig.GetConfig();
+        BattleRoyaleServerData m_ServerData = m_Config.GetServerData();
+		if ( m_ServerData.enable_vigrid_api )
+		{
+			// Lock the server via webhook
+			LockServerWebhook serverWebhook = new LockServerWebhook( m_ServerData.webhook_jwt_token );
+			serverWebhook.LockServer();
+		}
+
         string second = "seconds";
         if ( i_TimeToStart == 1 )
             second = "second";

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
@@ -44,12 +44,6 @@ class BattleRoyalePrepare: BattleRoyaleState
     {
         super.Activate();
 
-		if ( m_ServerData.enable_vigrid_api )
-		{
-			LockServerWebhook serverWebhook = new LockServerWebhook( m_ServerData.webhook_jwt_token );
-			serverWebhook.LockServer();
-		}
-
         StartMatchWebhook matchWebhook = new StartMatchWebhook( m_ServerData.webhook_jwt_token );
         BattleRoyaleServer br_instance = BattleRoyaleServer.GetInstance();
         matchWebhook.startMatch( br_instance.match_uuid );


### PR DESCRIPTION
The server locking logic via webhook has been moved from the BattleRoyalePrepare state to the BattleRoyaleCountReached state. This ensures the server is locked at the correct phase of the Battle Royale flow, improving match preparation and access control.