### PR TITLE
Remove unused remaining_parties variable

### DIFF
--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -18,7 +18,6 @@ class BattleRoyaleRound: BattleRoyaleState
 
 #ifdef Carim
     int i_MaxPartySize;
-    autoptr set<string> remaining_parties
 #endif
 
     protected ref array<ref Timer> m_MessageTimers;


### PR DESCRIPTION
Deleted the unused 'remaining_parties' set variable from the BattleRoyaleRound class under the Carim preprocessor directive to clean up the code.