### PR TITLE
Wrap debug key handling with DIAG preprocessor

### DIFF
--- a/Scripts/Client/5_Mission/Mission/MissionGameplay.c
+++ b/Scripts/Client/5_Mission/Mission/MissionGameplay.c
@@ -295,6 +295,7 @@ modded class MissionGameplay
 			if (GetUApi().GetInputByID(UADayZBRUnstuck).LocalPress()) {
 				BattleRoyaleClient.Cast( m_BattleRoyale ).Unstuck();
 			}
+#ifdef DIAG
 			// Debug key
 			if (GetUApi().GetInputByID(UADayZBRDebug).LocalPress()) {
 				SpawnSelectionMenu m = SpawnSelectionMenu.Cast(GetUIManager().EnterScriptedMenu(MENU_SPAWN_SELECTION, GetUIManager().GetMenu()));
@@ -302,6 +303,7 @@ modded class MissionGameplay
 				m.SetSpawnSize(50);
 				m.SetFirstZone(Vector(6000, 0, 7777), 1500);
 			}
+#endif
 #ifdef BR_MINIMAP
 			if (GetUApi().GetInputByID(UADayZBRToggleMiniMap).LocalPress()) {
 				b_MiniMapShow = !b_MiniMapShow;


### PR DESCRIPTION
Added DIAG preprocessor guards around the debug key input handling in MissionGameplay to ensure debug functionality is only included in diagnostic builds.