### PR TITLE
Remove redundant chat log in CreateScriptedMenu

### DIFF
--- a/Scripts/Client/5_Mission/Mission/MissionBase.c
+++ b/Scripts/Client/5_Mission/Mission/MissionBase.c
@@ -4,7 +4,6 @@ modded class MissionBase
 	override UIScriptedMenu CreateScriptedMenu(int id)
 	{
 #ifndef NO_GUI
-		GetGame().Chat("CreateScriptedMenu: " + id.ToString(), "colorFriendly");
 		if (id == MENU_SPAWN_SELECTION)
 		{
 			GetGame().Chat("CreateScriptedMenu: MENU_SPAWN_SELECTION", "colorFriendly");


### PR DESCRIPTION
Eliminated an unnecessary chat message that logged the menu ID in CreateScriptedMenu. This reduces chat clutter and keeps only relevant messages.