### PR TITLE
Enable trace logging for server builds

### DIFF
--- a/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
+++ b/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
@@ -12,6 +12,11 @@ static const string BATTLEROYALE_VERSION = "0.1.0-Vigrid";
 #define CF_TRACE_ENABLED
 #endif
 
+#ifdef SERVER
+#define BR_TRACE_ENABLED
+#define CF_TRACE_ENABLED
+#endif
+
 //--- debug settings
 #ifdef BR_TRACE_ENABLED
 	static const int BATTLEROYALE_LOG_LEVEL = 4; // Trace


### PR DESCRIPTION
Added conditional defines to enable BR_TRACE_ENABLED and CF_TRACE_ENABLED when compiling for the server. This ensures trace logging is active during server builds for improved debugging.