### PR TITLE
Add TODOs for auto-connect via CLI in MainMenu

### DIFF
--- a/Scripts/Client/5_Mission/Mission/MainMenu.c
+++ b/Scripts/Client/5_Mission/Mission/MainMenu.c
@@ -158,6 +158,8 @@ modded class MainMenu
 		}
 		else
 		{
+			//TODO: If there's parameters from the CLI, use them to connect to the server automatically
+			//TODO: Must test if it's the first time the main menu is loaded, to avoid an infinite loop
 			m_PlayButtonLabel.SetText("#main_menu_play");
 		}
 


### PR DESCRIPTION
Added comments indicating plans to use CLI parameters for automatic server connection and to ensure this only occurs on the first main menu load to prevent infinite loops.