### PR TITLE
Add Vehicle3PP default fix mod with CarScript override

### DIFF
--- a/Extra/Vehicle3PPDefaultFix/Scripts/4_World/Vehicle3PP/Entities/Vehicles/CarScript.c
+++ b/Extra/Vehicle3PPDefaultFix/Scripts/4_World/Vehicle3PP/Entities/Vehicles/CarScript.c
@@ -1,0 +1,54 @@
+#ifdef Vehicle3PP
+modded class CarScript
+{
+	protected bool m_Allow3PPCamera;
+	protected bool m_DriverOnly;
+
+	override void EEInit()
+	{
+		if (GetGame().IsDedicatedServer())
+		{
+			array<string> ForcedWhitelist = {
+				"OffroadHatchback",
+				"CivilianSedan",
+				"Hatchback_02",
+				"Sedan_02",
+				"Truck_01_Covered",
+				"Offroad_02"
+			};
+
+			array<string> vehicles = GetVehicle3PPConfig().GetWhitelist();
+
+			// Ensure forced vehicles are always in the whitelist
+			foreach (string forced_vehicle : ForcedWhitelist)
+			{
+				if (vehicles.Find(forced_vehicle) == -1)
+					vehicles.Insert(forced_vehicle);
+			}
+
+			m_DriverOnly = GetVehicle3PPConfig().IsDriverOnly();
+
+			// if no vehicles are specified, 3PP for all
+			if (!vehicles || vehicles.Count() < 1)
+			{
+				m_Allow3PPCamera = true;
+			}
+			else
+			{
+				foreach (string vehicle : vehicles)
+				{
+					if (IsInherited(vehicle.ToType()) || vehicle == GetType() || KindOf(vehicle))
+					{
+						m_Allow3PPCamera = true;
+						break;
+					}
+				}
+			}
+
+			SetSynchDirty();
+		}
+
+		super.EEInit();
+	}
+}
+#endif

--- a/Extra/Vehicle3PPDefaultFix/config.cpp
+++ b/Extra/Vehicle3PPDefaultFix/config.cpp
@@ -1,0 +1,35 @@
+class CfgPatches
+{
+    class vigrid_vehicle3pp_default_fix
+    {
+        requiredAddons[]=
+        {
+            "DZ_Scripts"
+        };
+    };
+};
+
+class CfgMods
+{
+    class vigrid_vehicle3pp_default_fix
+    {
+        name = "Vigrid Vehicle3PP Default Fix";
+        type = "mod";
+        dependencies[]=
+        {
+            "World"
+        };
+
+        class defs
+        {
+            class worldScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/Vehicle3PPDefaultFix/Scripts/4_World"
+                };
+            };
+        };
+    };
+};


### PR DESCRIPTION
Introduces a new mod 'Vigrid Vehicle3PP Default Fix' with configuration and a CarScript override. The CarScript modification enforces a whitelist for vehicles allowed to use the 3rd person camera and ensures certain vehicles are always included, with support for driver-only restrictions.