### PR TITLE
Disable activation of disease modifiers

### DIFF
--- a/Extra/PreventPlayerModifiers/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Diseases/CommonCold.c
+++ b/Extra/PreventPlayerModifiers/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Diseases/CommonCold.c
@@ -1,0 +1,7 @@
+modded class CommonColdMdfr
+{
+	override protected bool ActivateCondition(PlayerBase player)
+	{
+		return false;
+	}
+}

--- a/Extra/PreventPlayerModifiers/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Diseases/Influenza.c
+++ b/Extra/PreventPlayerModifiers/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Diseases/Influenza.c
@@ -1,0 +1,7 @@
+modded class InfluenzaMdfr
+{
+	override protected bool ActivateCondition(PlayerBase player)
+	{
+		return false;
+	}
+}

--- a/Extra/PreventPlayerModifiers/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Diseases/Pneumonia.c
+++ b/Extra/PreventPlayerModifiers/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Diseases/Pneumonia.c
@@ -1,0 +1,7 @@
+modded class PneumoniaMdfr
+{
+	override protected bool ActivateCondition(PlayerBase player)
+	{
+		return false;
+	}
+}


### PR DESCRIPTION
Added overrides for CommonColdMdfr, InfluenzaMdfr, and PneumoniaMdfr classes to always return false in ActivateCondition, preventing these disease modifiers from activating for players.