### PR TITLE
Add config option to disable prevent weapon raise

### DIFF
--- a/Extra/PreventWeaponRaise/README.md
+++ b/Extra/PreventWeaponRaise/README.md
@@ -2,12 +2,12 @@
 
 Stops the weapon from being forced upward when the muzzle is close to a wall or doorway. Vanilla's
 lift-weapon behaviour is a realism touch that reads as unresponsive in close-quarters fights, so it is
-removed here.
+removed here — unless the server admin asks for it back, see *Configuration*.
 
 |                 |                                                        |
 |-----------------|--------------------------------------------------------|
 | **PBO**         | `extra_preventweaponraise.pbo`                          |
-| **Side**        | client (`#ifndef SERVER`)                               |
+| **Side**        | both (unguarded, with `#ifdef SERVER` halves inside)    |
 | **Stages**      | `4_World`                                               |
 | **`defines[]`** | none                                                    |
 | **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
@@ -20,6 +20,13 @@ vanilla's obstruction raycast entirely. All that is left is the un-lift path:
 ```c
 override void CheckLiftWeapon()
 {
+    //--- Admin opted out: hand the whole thing back to vanilla.
+    if (m_VigridPreventWeaponRaiseDisabled)
+    {
+        super.CheckLiftWeapon();
+        return;
+    }
+
     if (GetInstanceType() == DayZPlayerInstanceType.INSTANCETYPE_CLIENT)
     {
         // Never lift weapon and sync it to false if already lifted
@@ -34,6 +41,42 @@ So the lift state is never set, and if something else already set it, it is sync
 Despite the addon's name, this affects **only** the obstruction lift. Raising the weapon normally,
 aiming down sights and melee are all untouched.
 
+## Configuration
+
+One key, read only by this addon:
+
+| Where | Key | Effect |
+|---|---|---|
+| `serverDZ.cfg` | `BRDisablePreventWeaponRaise = 1;` | turns the addon off — vanilla's obstruction lift comes back |
+
+An absent key reads as `0`, which is indistinguishable from an explicit `0` — both leave the addon
+active, so a server that has never heard of the key keeps the behaviour it has today.
+
+## Design notes
+
+**The switch is server-owned but the behaviour is client-side, and bridging that is the whole of the
+implementation.** `ServerConfigGetInt` is a server-only API — vanilla documents it as *"Server config
+parsing. Returns 0 if not found"*, and a client has no `serverDZ.cfg` to find anything in, so it
+answers `0` for every key. Reading the switch directly from the client-side hook therefore cannot
+work, and fails **silently**: the key appears to be ignored with no error anywhere.
+
+So the server reads it and mirrors the answer onto each player as the netsync bool
+`m_VigridPreventWeaponRaiseDisabled`, exactly the way [SafeZone](../SafeZone/README.md) carries its
+truce flag. Three consequences:
+
+- **`PlayerBase.c` is deliberately unguarded** so both sides compile it. `RegisterNetSyncVariableBool`
+  sits in the shared `Init()` override precisely so registration order is byte-identical on both
+  sides — mandatory for netsync. Compiling the override server side costs nothing: vanilla's whole
+  `CheckLiftWeapon` body is inside an `INSTANCETYPE_CLIENT` branch, so both paths are no-ops there.
+- **Netsync rather than an RPC broadcast**, so a player connecting later is covered for free;
+  `OnConnect` / `OnReconnect` re-assert it unconditionally.
+- **The key is read once per process**, in `VigridPreventWeaponRaiseState`. `CheckLiftWeapon` runs
+  every frame from `HandleWeapons` inside the command handler, so nothing but a field read belongs in
+  it — the netsync flag costs nothing there, a string-keyed config lookup would not.
+
+The flag defaults to `false` (suppression active), so a client that has not received its first sync
+yet behaves exactly as this addon always has.
+
 ## Caveats
 
 - Vanilla's `CheckLiftWeapon` also computes and syncs a separate weapon-obstruction value. This
@@ -44,4 +87,6 @@ aiming down sights and melee are all untouched.
 
 ## Disabling
 
-Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely.
+`BRDisablePreventWeaponRaise = 1;` in `serverDZ.cfg` is the runtime switch and needs no rebuild — use
+that one on a server running the published mod. To drop the addon from the build entirely, rename
+`config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped.

--- a/Extra/PreventWeaponRaise/Scripts/4_World/Entities/ManBase/PlayerBase.c
+++ b/Extra/PreventWeaponRaise/Scripts/4_World/Entities/ManBase/PlayerBase.c
@@ -3,14 +3,23 @@ modded class PlayerBase
 {
 	override void CheckLiftWeapon()
 	{
-		// lift weapon check
-		if (GetInstanceType() == DayZPlayerInstanceType.INSTANCETYPE_CLIENT)
+		bool config_disable_prevent_weapon_raise = GetGame().ServerConfigGetInt( "BRDisablePreventWeaponRaise" );
+
+		if (!config_disable_prevent_weapon_raise)
 		{
-			// Never lift weapon and sync it to false if already lifted
-			if (m_LiftWeapon_player)
+			// lift weapon check
+			if (GetInstanceType() == DayZPlayerInstanceType.INSTANCETYPE_CLIENT)
 			{
-				SendLiftWeaponSync(false);
+				// Never lift weapon and sync it to false if already lifted
+				if (m_LiftWeapon_player)
+				{
+					SendLiftWeaponSync(false);
+				}
 			}
+		}
+		else
+		{
+			super.CheckLiftWeapon();
 		}
 	}
 }

--- a/Extra/PreventWeaponRaise/Scripts/4_World/Entities/ManBase/PlayerBase.c
+++ b/Extra/PreventWeaponRaise/Scripts/4_World/Entities/ManBase/PlayerBase.c
@@ -1,25 +1,85 @@
-#ifndef SERVER
+/**
+ *  PreventWeaponRaise - the client-side lift suppression, plus the flag that gates it.
+ *
+ *  No guard: this file compiles on both sides on purpose. The client is the only side that ever
+ *  lifts a weapon, but the admin switch lives in serverDZ.cfg and only the server can read that -
+ *  so the server owns the flag and mirrors it down as a netsync bool. Compiling the override
+ *  server side too costs nothing: vanilla's whole CheckLiftWeapon body is inside an
+ *  INSTANCETYPE_CLIENT branch, so both paths below are no-ops there.
+ */
 modded class PlayerBase
 {
-	override void CheckLiftWeapon()
-	{
-		bool config_disable_prevent_weapon_raise = GetGame().ServerConfigGetInt( "BRDisablePreventWeaponRaise" );
+    //--- Netsynced. Registered in Init() below, so the registration order is identical on both
+    //--- sides - which it must be, since both sides compile this same file.
+    //--- Defaults to false = suppression active, so a client that has not received its first sync
+    //--- yet behaves exactly as this addon always has.
+    protected bool m_VigridPreventWeaponRaiseDisabled;
 
-		if (!config_disable_prevent_weapon_raise)
-		{
-			// lift weapon check
-			if (GetInstanceType() == DayZPlayerInstanceType.INSTANCETYPE_CLIENT)
-			{
-				// Never lift weapon and sync it to false if already lifted
-				if (m_LiftWeapon_player)
-				{
-					SendLiftWeaponSync(false);
-				}
-			}
-		}
-		else
-		{
-			super.CheckLiftWeapon();
-		}
-	}
+    override void Init()
+    {
+        super.Init();
+
+        RegisterNetSyncVariableBool("m_VigridPreventWeaponRaiseDisabled");
+    }
+
+#ifdef SERVER
+    override void OnConnect()
+    {
+        super.OnConnect();
+
+        VigridPreventWeaponRaise_Refresh();
+    }
+
+    override void OnReconnect()
+    {
+        super.OnReconnect();
+
+        //--- A reconnect reuses the existing entity, so the flag is already right server side and
+        //--- this would no-op. Push it anyway: it costs one bool and it means a rejoining player
+        //--- can never end up on the wrong behaviour because a sync was missed.
+        VigridPreventWeaponRaise_Refresh();
+    }
+
+    /**
+     *  Server side only. Re-assert the admin's choice on this player, syncing unconditionally.
+     */
+    void VigridPreventWeaponRaise_Refresh()
+    {
+        m_VigridPreventWeaponRaiseDisabled = VigridPreventWeaponRaiseState.IsDisabled();
+        SetSynchDirty();
+    }
+#endif
+
+    bool VigridPreventWeaponRaise_IsDisabled()
+    {
+        return m_VigridPreventWeaponRaiseDisabled;
+    }
+
+    /**
+     *  Vanilla raycasts ahead of the muzzle every frame and lifts the weapon when it would clip
+     *  geometry. That reads as unresponsive in the close-quarters fights this mod is made of, so the
+     *  raycast is discarded and only the un-lift path is kept.
+     *
+     *  Called every frame from HandleWeapons, inside the command handler - so nothing expensive
+     *  belongs here. Reading the netsynced flag is a field access; reading serverDZ.cfg would not be.
+     */
+    override void CheckLiftWeapon()
+    {
+        //--- Admin opted out: hand the whole thing back to vanilla.
+        if (m_VigridPreventWeaponRaiseDisabled)
+        {
+            super.CheckLiftWeapon();
+            return;
+        }
+
+        // lift weapon check
+        if (GetInstanceType() == DayZPlayerInstanceType.INSTANCETYPE_CLIENT)
+        {
+            // Never lift weapon and sync it to false if already lifted
+            if (m_LiftWeapon_player)
+            {
+                SendLiftWeaponSync(false);
+            }
+        }
+    }
 }

--- a/Extra/PreventWeaponRaise/Scripts/4_World/Server/VigridPreventWeaponRaiseState.c
+++ b/Extra/PreventWeaponRaise/Scripts/4_World/Server/VigridPreventWeaponRaiseState.c
@@ -1,0 +1,39 @@
+#ifdef SERVER
+/**
+ *  PreventWeaponRaise - the authoritative switch, server side.
+ *
+ *  The suppression itself is a client-side concern: vanilla's whole CheckLiftWeapon body sits inside
+ *  an INSTANCETYPE_CLIENT branch, so the client is the only side that ever decides to lift. But the
+ *  switch that turns the suppression off is a serverDZ.cfg key, and ServerConfigGetInt is a
+ *  server-only API - on a client there is no server config to parse and it answers 0 for every key.
+ *  So the server reads it and mirrors the answer down to each player as a netsync bool; see
+ *  PlayerBase.c.
+ *
+ *  Read once per process rather than per connect. The file is parsed at boot and never changes
+ *  under a running server, so re-asking is pure waste - and the original version of this feature
+ *  asked once per frame, from inside the command handler.
+ */
+class VigridPreventWeaponRaiseState
+{
+    private static bool s_Resolved;
+    private static bool s_Disabled;
+
+    /**
+     *  Is the addon switched off by the admin?
+     *
+     *  An absent key reads as 0, which is indistinguishable from an explicit 0 - both mean "leave the
+     *  addon active". That is the safe default: every server that has never heard of this key keeps
+     *  the behaviour it has today.
+     */
+    static bool IsDisabled()
+    {
+        if (!s_Resolved)
+        {
+            s_Disabled = GetGame().ServerConfigGetInt("BRDisablePreventWeaponRaise") == 1;
+            s_Resolved = true;
+        }
+
+        return s_Disabled;
+    }
+}
+#endif

--- a/Extra/README.md
+++ b/Extra/README.md
@@ -35,7 +35,7 @@ own PBO automatically. See the root `CLAUDE.md` for the script-module and stage 
 | [Map](Map/README.md) | `extra_map.pbo` | both | Fullscreen map, HUD minimap, HUD compass, party-shared markers and zone circles |
 | [MapSatellite](MapSatellite/README.md) | `extra_mapsatellite.pbo` | both | Config only — switches the map to satellite imagery, retunes its overlay layers and makes place names legible over it |
 | [PreventPlayerModifiers](PreventPlayerModifiers/README.md) | `extra_preventplayermodifiers.pbo` | both | Disables hunger, thirst, broken legs and four diseases |
-| [PreventWeaponRaise](PreventWeaponRaise/README.md) | `extra_preventweaponraise.pbo` | client | Stops the weapon being forced up against walls |
+| [PreventWeaponRaise](PreventWeaponRaise/README.md) | `extra_preventweaponraise.pbo` | both | Stops the weapon being forced up against walls |
 | [RandomMenuGear](RandomMenuGear/README.md) | `extra_randommenugear.pbo` | client | Re-dresses the main-menu character randomly on every menu show |
 | [SafeZone](SafeZone/README.md) | `extra_safezone.pbo` | both | Lobby truce — no firing, no player-inflicted damage |
 | [SpawnCarFull](SpawnCarFull/README.md) | `extra_spawncarfull.pbo` | server | Vehicles spawn with 30–100 % fuel, plus full coolant and oil |
@@ -55,6 +55,7 @@ Most of these have no settings at all. The ones that do:
 | MapSatellite | none, and it cannot have any — `MapWidget` exposes no satellite API, so the `config.cpp` rename is the whole control surface |
 | SpawnWithAmmoAndMagazine | `serverDZ.cfg`: `BRDisableSpawnWithAmmo`, `BRMinSpawnAmmo`, `BRMaxSpawnAmmo` |
 | LimitUnconsciousTime | `serverDZ.cfg`: `BRDisableUnconsciousness`, or `-br-disable-unconsciousness` on the command line |
+| PreventWeaponRaise | `serverDZ.cfg`: `BRDisablePreventWeaponRaise` — server-read, mirrored to each client as a netsync bool |
 | SafeZone | none — controlled entirely through its API |
 
 ## Compile-time defines


### PR DESCRIPTION
Introduces a server config 'BRDisablePreventWeaponRaise' to conditionally bypass the custom weapon raise prevention logic. If the config is enabled, the default behavior is restored by calling the base class implementation.