### PR TITLE
Add server config for weapon spawn ammo and magazine

### DIFF
--- a/Extra/SpawnWithAmmoAndMagazine/Scripts/4_World/Entities/ItemBase.c
+++ b/Extra/SpawnWithAmmoAndMagazine/Scripts/4_World/Entities/ItemBase.c
@@ -6,24 +6,78 @@ modded class ItemBase
 	{
 		super.EEOnCECreate();
 
-		if( IsWeapon() )
+		bool config_disable_spawn_with_ammo = GetGame().ServerConfigGetInt( "BRDisableSpawnWithAmmo" ) == 1;
+		if( IsWeapon() && !config_disable_spawn_with_ammo )
 		{
 //			if( Flaregun.Cast(this) ) return;  // Skip flaregun
 
+			int min_spawn = 1;
+			int max_spawn = 2;
+			int config_min_spawn = GetGame().ServerConfigGetInt( "BRMinSpawnAmmo" );
+			int config_max_spawn = GetGame().ServerConfigGetInt( "BRMaxSpawnAmmo" );
+
+			// Override min/max spawn if set in server config
+			// If min is set below 0, set it to 0
+			// If max is set below min, set it to min
+			// If max is set to 0 or below, ignore it and use default
+			if( config_min_spawn > 0 )
+			{
+				min_spawn = config_min_spawn;
+			}
+			if( config_min_spawn < 0 )
+			{
+				min_spawn = 0;
+			}
+
+			if( config_max_spawn > 0 )
+			{
+				max_spawn = config_max_spawn;
+			}
+
+			// Ensure max is not lower than min
+			if( max_spawn < min_spawn )
+			{
+				max_spawn = min_spawn;
+			}
+
 			Weapon weapon = Weapon.Cast(this);
 			string magazineType = weapon.GetRandomMagazineTypeName(0);
+			// Try to spawn a magazine of the weapon's compatible magazines
 			if( magazineType != string.Empty )
 			{
-				for( int i = 0; i < Math.RandomIntInclusive(1, 2); i++ )
+				int spawnCount = Math.RandomIntInclusive(min_spawn, max_spawn);
+				int validMagazinesSpawned = 0;
+				int maxAttempts = spawnCount * 10; // Set a reasonable limit to prevent infinite loops
+				int attempts = 0;
+
+				// Keep trying until we've spawned enough valid magazines or hit the attempt limit
+				while (validMagazinesSpawned < spawnCount && attempts < maxAttempts)
 				{
+					attempts++;
 					magazineType = weapon.GetRandomMagazineTypeName(0);
+
+					// Skip high capacity magazines (check if > 100 rounds)
+					int maxMagCapacity = GetGame().ConfigGetInt("CfgMagazines " + magazineType + " count");
+					if(maxMagCapacity > 100)
+					{
+						Print("[SpawnWithAmmo] Skipping high capacity magazine: " + magazineType + " (" + maxMagCapacity + " rounds)");
+						continue; // Try another magazine type without counting it as spawned
+					}
+
+					// Valid magazine found, spawn it
 					Print("Magazine type: " + magazineType);
-					Print(GetGame().CreateObjectEx( magazineType, GetPosition(), ECE_CREATEPHYSICS|ECE_UPDATEPATHGRAPH ));
+					Print(GetGame().CreateObjectEx(magazineType, GetPosition(), ECE_CREATEPHYSICS|ECE_UPDATEPATHGRAPH));
+					validMagazinesSpawned++;
+				}
+
+				if (validMagazinesSpawned < spawnCount)
+				{
+					Print("[SpawnWithAmmo] Could only spawn " + validMagazinesSpawned + " valid magazines after " + attempts + " attempts");
 				}
 			}
-			else
+			else  // No compatible magazines, try to spawn chamberable ammo piles instead
 			{
-				for( int j = 0; j < Math.RandomIntInclusive(1, 2); j++ )
+				for( int j = 0; j < Math.RandomIntInclusive(min_spawn, max_spawn); j++ )
 				{
 					array<string> ammoTypes = new array<string>;
 					ConfigGetTextArray("chamberableFrom", ammoTypes);


### PR DESCRIPTION
Introduces server configuration options to control weapon spawn behavior: disables spawning with ammo, sets min/max ammo spawn, and skips high capacity magazines. Ensures min/max values are validated and applies these settings when spawning magazines or ammo piles for weapons.