### PR TITLE
Simplify round completion checks in BattleRoyale states

### DIFF
--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -242,22 +242,38 @@ class BattleRoyaleRound: BattleRoyaleState
         super.Deactivate();
     }
 
-    override bool IsComplete() //return true when this state is complete & ready to transfer to the next state
-    {
-		if(IsActive())
-		{
+	override bool IsComplete() //return true when this state is complete & ready to transfer to the next state
+	{
+		if(!IsActive())
+			return super.IsComplete();
+
 #ifdef Carim
-			if(GetPlayers().Count() <= 1 || GetGroupsCount() <= 1)
+		bool playersLessThanTwo = GetPlayers().Count() <= 1;
+		bool groupsLessThanTwo = GetGroupsCount() <= 1;
+
+		if(playersLessThanTwo || groupsLessThanTwo)
+		{
+			string reason;
+			if(playersLessThanTwo && groupsLessThanTwo)
+				reason = "(Players/Groups)";
+			else if(playersLessThanTwo)
+				reason = "(Players)";
+			else
+				reason = "(Groups)";
+
+			BattleRoyaleUtils.Trace(GetName() + " IsComplete " + reason + "!");
+			Deactivate();
+		}
 #else
-			if(GetPlayers().Count() <= 1)
+		if(GetPlayers().Count() <= 1)
+		{
+			BattleRoyaleUtils.Trace(GetName() + " IsComplete (Players)!");
+			Deactivate();
+		}
 #endif
-			{
-				BattleRoyaleUtils.Trace(GetName() + " IsComplete (Players)!");
-				Deactivate();
-			}
-        }
-        return super.IsComplete();
-    }
+
+		return super.IsComplete();
+	}
 
     override bool SkipState(BattleRoyaleState _previousState)
     {

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -244,26 +244,17 @@ class BattleRoyaleRound: BattleRoyaleState
 
     override bool IsComplete() //return true when this state is complete & ready to transfer to the next state
     {
-		int nb_players = GetPlayers().Count();
-
 		if(IsActive())
 		{
 #ifdef Carim
-			if(i_MaxPartySize < 1 || nb_players <= i_MaxPartySize)
-			{
-				if( nb_players <= 1 || GetGroupsCount() <= 1 )
-				{
-					BattleRoyaleUtils.Trace(GetName() + " IsComplete (Groups)!");
-					Deactivate();
-				}
-			}
+			if(GetPlayers().Count() <= 1 || GetGroupsCount() <= 1)
 #else
-			if( nb_players <= 1 )
+			if(GetPlayers().Count() <= 1)
+#endif
 			{
 				BattleRoyaleUtils.Trace(GetName() + " IsComplete (Players)!");
 				Deactivate();
 			}
-#endif
         }
         return super.IsComplete();
     }

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
@@ -119,30 +119,30 @@ class BattleRoyaleLastRound: BattleRoyaleState
         return true;
     }
 
-    override string GetName()
-    {
-        return "Last Gameplay State";
-    }
+	override string GetName()
+	{
+		return "Last Gameplay State";
+	}
 
-    override bool IsComplete() //return true when this state is complete & ready to transfer to the next state
-    {
-        if(IsActive())
-        {
+	override bool IsComplete() //return true when this state is complete & ready to transfer to the next state
+	{
+		if(IsActive())
+		{
 #ifdef Carim
-            if(GetPlayers().Count() <= 1 || GetGroupsCount() <= 1)
+			if(GetPlayers().Count() <= 1 || GetGroupsCount() <= 1)
 #else
 			if(GetPlayers().Count() <= 1)
 #endif
-                Deactivate();
-        }
+				Deactivate();
+		}
 
-        return super.IsComplete();
-    }
+		return super.IsComplete();
+	}
 
-    override void OnPlayerKilled(PlayerBase player, Object source)
-    {
-        super.OnPlayerKilled( player, source );
-    }
+	override void OnPlayerKilled(PlayerBase player, Object source)
+	{
+		super.OnPlayerKilled( player, source );
+	}
 
     override void OnPlayerTick(PlayerBase player, float timeslice)
     {

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
@@ -128,13 +128,12 @@ class BattleRoyaleLastRound: BattleRoyaleState
     {
         if(IsActive())
         {
-            if(GetPlayers().Count() < 2)
-                Deactivate();
-
 #ifdef Carim
-            if(GetGroupsCount() < 2)
-                Deactivate();
+            if(GetPlayers().Count() <= 1 || GetGroupsCount() <= 1)
+#else
+			if(GetPlayers().Count() <= 1)
 #endif
+                Deactivate();
         }
 
         return super.IsComplete();


### PR DESCRIPTION
Refactored IsComplete logic in BattleRoyaleRound and BattleRoyaleLastRound to use unified player and group count checks. This reduces redundant conditions and improves code clarity for determining when a round should end.