### PR TITLE
Refactor CLI param checks to use IsCLIParam

### DIFF
--- a/Extra/LimitUnconsciousTime/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Unconsciousness.c
+++ b/Extra/LimitUnconsciousTime/Scripts/4_World/Classes/PlayerModifiers/Modifiers/Unconsciousness.c
@@ -14,7 +14,8 @@ modded class UnconsciousnessMdfr
 	override bool ActivateCondition(PlayerBase player)
 	{
 		bool config_disable_unconsciousness = GetGame().ServerConfigGetInt("BRDisableUnconsciousness") == 1;
-		if(!config_disable_unconsciousness)
+		bool cli_disable_unconsciousness = IsCLIParam("br-disable-unconsciousness");
+		if(!config_disable_unconsciousness && !cli_disable_unconsciousness)
 		{
 			if(super.ActivateCondition(player))
 			{

--- a/Scripts/Client/3_Game/BattleRoyaleUtils.c
+++ b/Scripts/Client/3_Game/BattleRoyaleUtils.c
@@ -89,12 +89,11 @@ class BattleRoyaleUtils: Managed
 	static bool CheckLogLevel(int level)
 	{
 		// Check command line params
-		string param;
-		if (GetCLIParam("br-trace", param)) return (TRACE >= level);
-		if (GetCLIParam("br-debug", param)) return (DEBUG >= level);
-		if (GetCLIParam("br-info", param)) return (INFO >= level);
-		if (GetCLIParam("br-warn", param)) return (WARN >= level);
-		if (GetCLIParam("br-none", param)) return false;  // Disable all logging
+		if (IsCLIParam("br-trace")) return (TRACE >= level);
+		if (IsCLIParam("br-debug")) return (DEBUG >= level);
+		if (IsCLIParam("br-info")) return (INFO >= level);
+		if (IsCLIParam("br-warn")) return (WARN >= level);
+		if (IsCLIParam("br-none")) return false;  // Disable all logging
 
 		// Check server config
 		int config_br_log_level = GetGame().ServerConfigGetInt("BRLogLevel");


### PR DESCRIPTION
Replaced GetCLIParam with IsCLIParam for checking command line parameters in BattleRoyaleUtils and UnconsciousnessMdfr. This simplifies the code by removing unnecessary string parameter handling and ensures consistent CLI param checking.