### PR TITLE
Add hot zones feature to Battle Royale mode

### DIFF
--- a/GUI/layouts/widgets/text_widget.layout
+++ b/GUI/layouts/widgets/text_widget.layout
@@ -1,0 +1,30 @@
+FrameWidgetClass FrameTextWidget {
+ size 100 20
+ halign center_ref
+ valign center_ref
+ hexactpos 1
+ vexactpos 1
+ hexactsize 1
+ vexactsize 1
+ {
+  TextWidgetClass TextWidget1 {
+   visible 1
+   inheritalpha 1
+   size 1 1
+   halign center_ref
+   valign center_ref
+   hexactpos 0
+   vexactpos 0
+   hexactsize 0
+   vexactsize 0
+   text "Text"
+   font "gui/fonts/sdf_MetronBook24"
+   "exact text" 1
+   "size to text h" 1
+   "size to text v" 1
+   "text halign" center
+   "text valign" center
+   priority 2000
+  }
+ }
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Files are saved in the `Vigrid-BattleRoyale` folder inside the profile directory
 |-------------------------|----------------------------------------------------------------------------|
 | `pois_settings.json`    | Overriding spawn points                                                    |
 | `spawns_settings.json`  | Lobby spawn point, player spawn points, city avoidance settings            |
-| `zone_settings.json`    | Number of zones, zone size and duration, end zone configuration            |
+| `zone_settings.json`    | Number of zones, zone size and duration, end zone configuration, hot zones |
 | `lobby_settings.json`   | Lobby configuration                                                        |
 | `general_settings.json` | Notification, zone damage, airdrop settings, etc.                          |
 | `server_settings.json`  | Vigrid API configuration (optional, cannot be overridden by mission files) |

--- a/Scripts/Client/3_Game/BattleRoyale/RPC/BattleRoyaleRPC.c
+++ b/Scripts/Client/3_Game/BattleRoyale/RPC/BattleRoyaleRPC.c
@@ -16,8 +16,8 @@ class BattleRoyaleRPC
 		GetRPCManager().AddRPC( RPC_DAYZBR_NAMESPACE, "SetTopPosition", this );
 		GetRPCManager().AddRPC( RPC_DAYZBR_NAMESPACE, "ShowWinScreen", this );
 		GetRPCManager().AddRPC( RPC_DAYZBR_NAMESPACE, "ChatLog", this );
-
 		GetRPCManager().AddRPC( RPC_DAYZBR_NAMESPACE, "NotificationMessage", this );
+		GetRPCManager().AddRPC( RPC_DAYZBR_NAMESPACE, "UpdateHotZones", this );
 
 		BattleRoyaleUtils.Trace("BattleRoyaleClient::Init - Done");
 	}
@@ -53,6 +53,8 @@ class BattleRoyaleRPC
 		future_play_area_radius = 0.0;
 		top_position = 0;
 		winner_screen = false;
+		hot_zone_centers = new array<vector>();
+		hot_zone_radii = new array<float>();
 	}
 
 	// Set the number of players and groups
@@ -290,6 +292,46 @@ class BattleRoyaleRPC
 			}
 
 			ExpansionNotification(DAYZBR_MSG_TITLE, translated_message, DAYZBR_MSG_IMAGE, COLOR_EXPANSION_NOTIFICATION_INFO, data.param2).Create();
+		}
+	}
+
+	// Hot Zones
+
+	ref array<vector> hot_zone_centers = new array<vector>();
+	ref array<float> hot_zone_radii = new array<float>();
+	bool hot_zones_received = false;
+
+	void UpdateHotZones(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
+	{
+		Param2<ref array<string>, ref array<float>> data;
+		if( !ctx.Read( data ) )
+		{
+			Error("FAILED TO READ UPDATEHOTZONES RPC");
+			return;
+		}
+		if ( type == CallType.Client )
+		{
+			if (hot_zones_received)
+			{
+				BattleRoyaleUtils.Trace("UpdateHotZones: Already received, ignoring");
+				return;
+			}
+
+			BattleRoyaleUtils.Trace(string.Format("UpdateHotZones: Received %1 hot zones", data.param1.Count()));
+			hot_zone_centers.Clear();
+			hot_zone_radii.Clear();
+
+			int i;
+			for (i = 0; i < data.param1.Count(); i++)
+			{
+				vector center = data.param1.Get(i).ToVector();
+				float radius = data.param2.Get(i);
+				hot_zone_centers.Insert(center);
+				hot_zone_radii.Insert(radius);
+				BattleRoyaleUtils.Trace(string.Format("Hot Zone %1: Center=%2 Radius=%3", i, center, radius));
+			}
+
+			hot_zones_received = true;
 		}
 	}
 }

--- a/Scripts/Client/3_Game/Loading/LoadingScreen.c
+++ b/Scripts/Client/3_Game/Loading/LoadingScreen.c
@@ -53,26 +53,29 @@ modded class LoadingScreen
 		LoadingScreenBackground backgrounds = null;
 		LoadingScreenBackground defaultBackgrounds = null;
 
-		string worldNameLower = GetGame().GetWorldName();
-		worldNameLower.ToLower();
-
-		// Find background for current map or default
-		for (int i = 0; i < m_Backgrounds.Count(); i++)
+		if (GetGame())
 		{
-			LoadingScreenBackground current = m_Backgrounds[i];
-			if (current)
-			{
-				string mapNameLower = current.MapName;
-				mapNameLower.ToLower();
-				if (mapNameLower == worldNameLower)
-				{
-					backgrounds = current;
-					break;
-				}
+			string worldNameLower = GetGame().GetWorldName();
+			worldNameLower.ToLower();
 
-				if (mapNameLower == "default")
+			// Find background for current map or default
+			for (int i = 0; i < m_Backgrounds.Count(); i++)
+			{
+				LoadingScreenBackground current = m_Backgrounds[i];
+				if (current)
 				{
-					defaultBackgrounds = current;
+					string mapNameLower = current.MapName;
+					mapNameLower.ToLower();
+					if (mapNameLower == worldNameLower)
+					{
+						backgrounds = current;
+						break;
+					}
+
+					if (mapNameLower == "default")
+					{
+						defaultBackgrounds = current;
+					}
 				}
 			}
 		}

--- a/Scripts/Client/5_Mission/GUI/Map/ExpansionMapMenu.c
+++ b/Scripts/Client/5_Mission/GUI/Map/ExpansionMapMenu.c
@@ -4,6 +4,7 @@ modded class ExpansionMapMenu
     protected ref BattleRoyaleClient m_BattleRoyaleClient;
     protected ref BattleRoyaleMapMarkerZone m_CurrentZone;
     protected ref BattleRoyaleMapMarkerZone m_NextZone;
+    protected ref array<ref BattleRoyaleMapMarkerZone> m_HotZones;
 
     protected ref map<string, ref BattleRoyaleMapMarkerPlayerArrow> m_NetworkPlayerMarkers;
 
@@ -16,6 +17,8 @@ modded class ExpansionMapMenu
         }
 
         super.Init();
+
+        m_HotZones = new array<ref BattleRoyaleMapMarkerZone>();
 
         BattleRoyaleUtils.Trace("Map Init! Updating Zones...");
         UpdateZones();
@@ -62,6 +65,40 @@ modded class ExpansionMapMenu
             m_NextZone.SetPosition(center);
             m_NextZone.SetSize_A(radius);
             m_NextZone.SetSize_B(radius);
+        }
+
+        // Update Hot Zones
+        BattleRoyaleRPC br_rpc = BattleRoyaleRPC.GetInstance();
+        if (br_rpc && br_rpc.hot_zone_centers && br_rpc.hot_zone_centers.Count() > 0)
+        {
+            int needed_hot_zones = br_rpc.hot_zone_centers.Count();
+
+            if (m_HotZones.Count() < needed_hot_zones)
+            {
+                int zones_to_create = needed_hot_zones - m_HotZones.Count();
+                int hz_idx;
+                for (hz_idx = 0; hz_idx < zones_to_create; hz_idx++)
+                {
+                    BattleRoyaleMapMarkerZone hot_zone_marker = new BattleRoyaleMapMarkerZone( layoutRoot, m_MapWidget );
+                    hot_zone_marker.SetColor(ARGB(255, 255, 0, 0));
+                    hot_zone_marker.SetThickness(2);
+                    m_HotZones.Insert(hot_zone_marker);
+                    m_Markers.Insert(hot_zone_marker);
+                    BattleRoyaleUtils.Trace("Creating Hot Zone Map Marker!");
+                }
+            }
+
+            int hz_index;
+            for (hz_index = 0; hz_index < br_rpc.hot_zone_centers.Count(); hz_index++)
+            {
+                center = br_rpc.hot_zone_centers.Get(hz_index);
+                radius = br_rpc.hot_zone_radii.Get(hz_index);
+
+                BattleRoyaleMapMarkerZone hot_zone = m_HotZones.Get(hz_index);
+                hot_zone.SetPosition(center);
+                hot_zone.SetSize_A(radius);
+                hot_zone.SetSize_B(radius);
+            }
         }
     }
 

--- a/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
+++ b/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
@@ -26,6 +26,8 @@ class SpawnSelectionMenu extends UIScriptedMenu
 	protected CanvasWidget m_HeatMapCanvas;
 	protected ref array<vector> m_HeatMapSpawnPoints = new array<vector>();
 
+	protected ref array<TextWidget> m_HotZoneTextWidgets = new array<TextWidget>();
+
 	void SpawnSelectionMenu()
 	{
 		BattleRoyaleUtils.Trace("SpawnSelectionMenu::SpawnSelectionMenu");
@@ -35,6 +37,13 @@ class SpawnSelectionMenu extends UIScriptedMenu
 	void ~SpawnSelectionMenu()
 	{
 		g_Game.SetKeyboardHandle(NULL);
+
+		// Clean up text widgets
+		foreach (TextWidget widget : m_HotZoneTextWidgets)
+		{
+			widget.Unlink();
+		}
+		m_HotZoneTextWidgets.Clear();
 
 		if (m_Hud)
 		{
@@ -176,7 +185,70 @@ class SpawnSelectionMenu extends UIScriptedMenu
 				distance_A = vector.Distance(mapPos_center,mapPos_edge_A);
 				distance_B = vector.Distance(mapPos_center,mapPos_edge_B);
 
-				WorldRenderOval(m_SpawnCanvas, m_MapWidget, v_FirstZoneCenter[0], v_FirstZoneCenter[2], f_FirstZoneRadius, f_FirstZoneRadius, ARGB(255, 255, 255, 255));
+				WorldRenderOval(m_SpawnCanvas, m_MapWidget, v_FirstZoneCenter[0], v_FirstZoneCenter[2], f_FirstZoneRadius, f_FirstZoneRadius, ARGB(128, 255, 255, 255));
+			}
+
+			// Show hot zones (red circles)
+			BattleRoyaleRPC br_rpc = BattleRoyaleRPC.GetInstance();
+			if (br_rpc && br_rpc.hot_zone_centers && br_rpc.hot_zone_centers.Count() > 0)
+			{
+				int hz_index;
+				for (hz_index = 0; hz_index < br_rpc.hot_zone_centers.Count(); hz_index++)
+				{
+					vector hot_zone_center = br_rpc.hot_zone_centers.Get(hz_index);
+					float hot_zone_radius = br_rpc.hot_zone_radii.Get(hz_index);
+
+					m_edgePos_A = hot_zone_center;
+					m_edgePos_A[0] = m_edgePos_A[0] + hot_zone_radius;
+
+					m_edgePos_B = hot_zone_center;
+					m_edgePos_B[2] = m_edgePos_B[2] + hot_zone_radius;
+
+					mapPos_edge_A = m_MapWidget.MapToScreen(m_edgePos_A);
+					mapPos_edge_B = m_MapWidget.MapToScreen(m_edgePos_B);
+					mapPos_center = m_MapWidget.MapToScreen(hot_zone_center);
+
+					distance_A = vector.Distance(mapPos_center, mapPos_edge_A);
+					distance_B = vector.Distance(mapPos_center, mapPos_edge_B);
+
+					WorldRenderFilledOval(m_SpawnCanvas, m_MapWidget, hot_zone_center[0], hot_zone_center[2], hot_zone_radius, hot_zone_radius, ARGB(50, 255, 215, 0), ARGB(100, 255, 215, 0));
+
+//					// Add text over the hot zone
+//					Widget frameTextWidget = GetGame().GetWorkspace().CreateWidgets("Vigrid-BattleRoyale/GUI/layouts/widgets/text_widget.layout", m_MapWidget);
+//					if (frameTextWidget)
+//					{
+//						BattleRoyaleUtils.Trace("Creating hot zone text widget frame for hot zone " + (hz_index + 1));
+//						TextWidget hotZoneText = TextWidget.Cast(frameTextWidget.FindAnyWidget("TextWidget1"));
+//						if (hotZoneText)
+//						{
+//							BattleRoyaleUtils.Trace("Creating hot zone text widget for hot zone " + (hz_index + 1));
+//
+//							// Get map widget's position
+//							float map_x, map_y;
+//							m_MapWidget.GetScreenPos(map_x, map_y);
+//
+//							// Position the text at the center of the hot zone
+//							// Adjust the position to be relative to the MapWidget
+//							float x_pos = mapPos_center[0] - map_x;
+//							float y_pos = mapPos_center[1] - map_y - 10; // Adjust 10 pixels up for better positioning
+//
+//							hotZoneText.SetPos(x_pos, y_pos);
+//							hotZoneText.SetText(string.Format("HOT ZONE %1", hz_index + 1));
+//							hotZoneText.SetColor(ARGB(255, 255, 0, 0)); // Make it red for better visibility
+//							hotZoneText.SetShadow(1);
+//
+//							// Ensure the text size is appropriate
+//							hotZoneText.SetSize(100, 20);
+//
+//							m_HotZoneTextWidgets.Insert(hotZoneText);
+//							BattleRoyaleUtils.Trace("Hot zone text widget created and positioned at " + x_pos + "," + y_pos);
+//						} else {
+//							BattleRoyaleUtils.Trace("Failed to find TextWidget1 in hot zone text widget");
+//						}
+//					} else {
+//						BattleRoyaleUtils.Trace("Failed to create hot zone text widget");
+//					}
+				}
 			}
 
 			// Define constants for heat map
@@ -401,6 +473,17 @@ class SpawnSelectionMenu extends UIScriptedMenu
 		GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "OnPlayerSpawnSelected", new Param1<vector>( tempPosition ), true, NULL, player );
 	}
 
+	/**
+	 * Renders the outline of an oval on the given canvas, using world coordinates for positioning.
+	 *
+	 * @param canvas      The CanvasWidget instance used for rendering.
+	 * @param world_map   The MapWidget instance used to convert world coordinates to screen coordinates.
+	 * @param world_x     The X-coordinate of the oval's center in world space.
+	 * @param world_z     The Z-coordinate of the oval's center in world space.
+	 * @param radius_x    The radius of the oval along the X-axis in world units.
+	 * @param radius_z    The radius of the oval along the Z-axis in world units.
+	 * @param color       The color of the oval outline, specified as an ARGB integer. Defaults to -1 (white).
+	 */
 	void WorldRenderOval(CanvasWidget canvas, MapWidget world_map, float world_x, float world_z, float radius_x, float radius_z, int color = -1)
 	{
 		if (!world_map || radius_x <= 0 || radius_z <= 0 || !canvas)
@@ -448,6 +531,106 @@ class SpawnSelectionMenu extends UIScriptedMenu
 			float y2 = cy + (screenHeight * Math.Sin(angle2 * Math.DEG2RAD));
 
 			canvas.DrawLine(x1, y1, x2, y2, 2, color);
+		}
+	}
+
+	/**
+	 * Renders a filled oval on the given canvas, using world coordinates for positioning.
+	 *
+	 * @param canvas      The CanvasWidget instance used for rendering.
+	 * @param world_map   The MapWidget instance used to convert world coordinates to screen coordinates.
+	 * @param world_x     The X-coordinate of the oval's center in world space.
+	 * @param world_z     The Z-coordinate of the oval's center in world space.
+	 * @param radius_x    The radius of the oval along the X-axis in world units.
+	 * @param radius_z    The radius of the oval along the Z-axis in world units.
+	 * @param fillColor   The color to fill the oval with, specified as an ARGB integer. Defaults to -1 (white).
+	 * @param outlineColor The color of the oval outline, specified as an ARGB integer. If -1, no outline is drawn.
+	 */
+	void WorldRenderFilledOval(CanvasWidget canvas, MapWidget world_map, float world_x, float world_z, float radius_x, float radius_z, int fillColor = -1, int outlineColor = -1)
+	{
+		if (!world_map || radius_x <= 0 || radius_z <= 0 || !canvas)
+		{
+			BattleRoyaleUtils.Trace("WorldRenderFilledOval: Invalid parameters");
+			return;
+		}
+
+		float screen_x, screen_y;
+		world_map.GetScreenPos(screen_x, screen_y);
+
+		// Create the center point in world coordinates
+		vector worldCenter = Vector(world_x, 0, world_z);
+		vector screenCenter = world_map.MapToScreen(worldCenter);
+
+		// Create edge points in world coordinates for accurate size calculation
+		vector worldEdgeX = Vector(world_x + radius_x, 0, world_z);
+		vector worldEdgeZ = Vector(world_x, 0, world_z + radius_z);
+
+		// Convert edges to screen coordinates
+		vector screenEdgeX = world_map.MapToScreen(worldEdgeX);
+		vector screenEdgeZ = world_map.MapToScreen(worldEdgeZ);
+
+		// Calculate width and height in screen pixels
+		float screenWidth = vector.Distance(screenCenter, screenEdgeX);
+		float screenHeight = vector.Distance(screenCenter, screenEdgeZ);
+
+		// Calculate the center of the oval in screen space
+		float cx = screenCenter[0] - screen_x;
+		float cy = screenCenter[1] - screen_y;
+
+		// Draw the filled part of the oval using horizontal lines
+		float a = screenWidth;  // Semi-major axis
+		float b = screenHeight; // Semi-minor axis
+
+		float a_squared = a * a;
+		float b_squared = b * b;
+
+		// Calculate the bounding rectangle for the oval
+		float top = cy - b;
+		float bottom = cy + b;
+
+		float x1, x2, y1, y2;
+
+		// For each scanline (horizontal line)
+		for (float y = top; y <= bottom; y += 1)
+		{
+			// Calculate how far we are from the center vertically
+			float dy = y - cy;
+			float dy_squared = dy * dy;
+
+			// If we're inside the vertical bounds of the ellipse
+			if (b_squared - dy_squared >= 0)
+			{
+				// Calculate the half-width of the ellipse at this y position
+				float half_width = a * Math.Sqrt(1 - (dy_squared / b_squared));
+
+				// Calculate the start and end points of the horizontal line
+				x1 = cx - half_width;
+				x2 = cx + half_width;
+
+				// Draw the horizontal line
+				canvas.DrawLine(x1, y, x2, y, 1, fillColor);
+			}
+		}
+
+		// Draw the outline of the oval if an outline color is specified
+		if (outlineColor != -1)
+		{
+			int segments = Math.Max(360, Math.Round(Math.Max(screenWidth, screenHeight) / 2));
+			float angleIncrement = 360.0 / segments;
+
+			for(int i = 0; i < segments; i++)
+			{
+				float angle1 = i * angleIncrement;
+				float angle2 = (i + 1) * angleIncrement;
+
+				x1 = cx + (screenWidth * Math.Cos(angle1 * Math.DEG2RAD));
+				y1 = cy + (screenHeight * Math.Sin(angle1 * Math.DEG2RAD));
+
+				x2 = cx + (screenWidth * Math.Cos(angle2 * Math.DEG2RAD));
+				y2 = cy + (screenHeight * Math.Sin(angle2 * Math.DEG2RAD));
+
+				canvas.DrawLine(x1, y1, x2, y2, 2, outlineColor);
+			}
 		}
 	}
 
@@ -538,3 +721,4 @@ class SpawnSelectionMenu extends UIScriptedMenu
 		}
 	}
 }
+

--- a/Scripts/Server/3_Game/Config/BattleRoyaleZoneData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleZoneData.c
@@ -31,6 +31,10 @@ class BattleRoyaleZoneData: BattleRoyaleDataBase
     // Constant (NOT USED ANYMORE)
     float constant_scale = 0.65;
 
+    // Hot Zones - Static red circles shown on map throughout the game
+    ref array<string> hot_zone_centers = {};  // Array of vectors as strings (e.g., "6000 0 7000")
+    ref array<float> hot_zone_radii = {};  // Array of radii corresponding to each hot zone center
+
     override string GetProfilePath()
     {
         return BATTLEROYALE_SETTINGS_FOLDER + "zone_settings.json";

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
@@ -660,6 +660,22 @@ class BattleRoyaleState: Timeable
 			}
 		}
 	}
+
+    void SendHotZones()
+    {
+        BattleRoyaleConfig m_Config = BattleRoyaleConfig.GetConfig();
+        BattleRoyaleZoneData m_ZoneSettings = m_Config.GetZoneData();
+
+        if (m_ZoneSettings.hot_zone_centers && m_ZoneSettings.hot_zone_centers.Count() > 0)
+        {
+            BattleRoyaleUtils.Trace(string.Format("[BattleRoyaleStartMatch] Sending %1 hot zones", m_ZoneSettings.hot_zone_centers.Count()));
+            GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "UpdateHotZones", new Param2<ref array<string>, ref array<float>>(m_ZoneSettings.hot_zone_centers, m_ZoneSettings.hot_zone_radii), true);
+        }
+        else
+        {
+            BattleRoyaleUtils.Trace("[BattleRoyaleStartMatch] No hot zones configured");
+        }
+    }
 }
 
 // Base state for the Debug Zone.

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
@@ -61,6 +61,9 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 
         GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ShowSpawnSelection", new Param4<int, float, vector, float>(i_SpawnSelectionDuration, f_SpawnSelectionRadius, v_FirstZoneCenter, f_FirstZoneRadius), true);
 
+        // Send hot zones configuration to all clients
+        SendHotZones();
+
         // Add timer to deactivate this state after a certain time
         m_SpawnSelectionTimer = AddTimer(i_SpawnSelectionDuration + i_ExtraScreenTime, this, "OnSpawnSelectionTimeout", NULL, false);
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
@@ -51,6 +51,9 @@ class BattleRoyaleStartMatch: BattleRoyaleState
         //send start match RPC (this will enable UI such as kill count)
         GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "StartMatch", new Param1<bool>(true), true); //don't need a param, but id rather keep it just so i know nothing wierd occurs (eventually find out if we can remove it)
 
+        // Send hot zones configuration to all clients
+        SendHotZones();
+
         int max_time = i_TimeToUnlock - 1;
         for(int i = max_time; i > 0; i--)
         {
@@ -220,3 +223,4 @@ class BattleRoyaleStartMatch: BattleRoyaleState
         super.OnPlayerKilled( player, source );
     }
 }
+#endif


### PR DESCRIPTION
This pull request introduces the "Hot Zones" feature to the Battle Royale game mode. Hot Zones are static, visually distinct areas (red circles) shown on the map and spawn selection screens to indicate special regions of interest. The implementation includes server configuration, network synchronization, and client-side rendering of hot zones in both the map and spawn selection UI. Additionally, there are minor improvements and cleanups in the codebase.

**Hot Zones Feature Implementation**

* Server-side configuration:
  - Added `hot_zone_centers` and `hot_zone_radii` arrays to `BattleRoyaleZoneData` for configuring hot zones in `zone_settings.json`.
  - Implemented `SendHotZones()` in `BattleRoyaleState` to broadcast hot zone data to all clients at match start and spawn selection. [[1]](diffhunk://#diff-b147d0ed38ff34e7f26d12d0a730e6c8d457c4abdaaadeb5820641539a47b7deR663-R678) [[2]](diffhunk://#diff-4dd755fbd0676a32d42bcef95c341781fd0d9bd8d2ee89f0d3aabb17b6decf4bR64-R66) [[3]](diffhunk://#diff-00ba839b732dbf1a852598c92303135fd7701cc774b55c955146b4d297bd2a6dR54-R56)

* Network synchronization and client state:
  - Registered a new RPC `"UpdateHotZones"` in `BattleRoyaleRPC`, with logic to receive, store, and prevent duplicate hot zone updates on the client. [[1]](diffhunk://#diff-7c7ebcfe2333e71de4c4e7fea5bb2df86b7257f81a47fd7c4961f3c8e116f31cL19-R20) [[2]](diffhunk://#diff-7c7ebcfe2333e71de4c4e7fea5bb2df86b7257f81a47fd7c4961f3c8e116f31cR56-R57) [[3]](diffhunk://#diff-7c7ebcfe2333e71de4c4e7fea5bb2df86b7257f81a47fd7c4961f3c8e116f31cR297-R336)

* Client-side rendering:
  - Map screen (`ExpansionMapMenu`): Dynamically creates and updates map markers for each hot zone, drawing red circles at the configured positions and radii. [[1]](diffhunk://#diff-7321de4cabfac0c68d0b8495665fb8190abc4bced5ff7cdb4eaf2bcefaf292b3R7) [[2]](diffhunk://#diff-7321de4cabfac0c68d0b8495665fb8190abc4bced5ff7cdb4eaf2bcefaf292b3R21-R22) [[3]](diffhunk://#diff-7321de4cabfac0c68d0b8495665fb8190abc4bced5ff7cdb4eaf2bcefaf292b3R69-R102)
  - Spawn selection screen (`SpawnSelectionMenu`): Renders filled yellow ovals for each hot zone, with groundwork for future text labels. Includes cleanup of dynamically created widgets. [[1]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR29-R30) [[2]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR41-R47) [[3]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cL179-R251)
  - Added new utility function `WorldRenderFilledOval` for drawing filled ovals on the map/spawn canvas. [[1]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR476-R486) [[2]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR537-R636)

**Supporting and Minor Changes**

* Added a reusable text widget layout for potential hot zone labeling.
* Updated documentation to mention hot zones in `zone_settings.json`.
* Minor fix for loading screen background logic. [[1]](diffhunk://#diff-f9fd83f426f57c89b1284de26c07b5861882467b74896a385ad8c4a5086b4c0bR56-R57) [[2]](diffhunk://#diff-f9fd83f426f57c89b1284de26c07b5861882467b74896a385ad8c4a5086b4c0bR81)

**References:**  
[[1]](diffhunk://#diff-3082e07677fb475391a2b1684d8f437ed7c8d0e4e1327cfd982688410881182cR34-R37) [[2]](diffhunk://#diff-b147d0ed38ff34e7f26d12d0a730e6c8d457c4abdaaadeb5820641539a47b7deR663-R678) [[3]](diffhunk://#diff-4dd755fbd0676a32d42bcef95c341781fd0d9bd8d2ee89f0d3aabb17b6decf4bR64-R66) [[4]](diffhunk://#diff-00ba839b732dbf1a852598c92303135fd7701cc774b55c955146b4d297bd2a6dR54-R56) [[5]](diffhunk://#diff-7c7ebcfe2333e71de4c4e7fea5bb2df86b7257f81a47fd7c4961f3c8e116f31cL19-R20) [[6]](diffhunk://#diff-7c7ebcfe2333e71de4c4e7fea5bb2df86b7257f81a47fd7c4961f3c8e116f31cR56-R57) [[7]](diffhunk://#diff-7c7ebcfe2333e71de4c4e7fea5bb2df86b7257f81a47fd7c4961f3c8e116f31cR297-R336) [[8]](diffhunk://#diff-7321de4cabfac0c68d0b8495665fb8190abc4bced5ff7cdb4eaf2bcefaf292b3R7) [[9]](diffhunk://#diff-7321de4cabfac0c68d0b8495665fb8190abc4bced5ff7cdb4eaf2bcefaf292b3R21-R22) [[10]](diffhunk://#diff-7321de4cabfac0c68d0b8495665fb8190abc4bced5ff7cdb4eaf2bcefaf292b3R69-R102) [[11]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR29-R30) [[12]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR41-R47) [[13]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cL179-R251) [[14]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR476-R486) [[15]](diffhunk://#diff-7c4ae8010f1249b989d0fa846cedee101bd5666fa036ae16f7bab0bb44f6d17cR537-R636) [[16]](diffhunk://#diff-cdb538889d17cdf45bc03744ecbd3f43a19b269160320b5a49e5993df07db1a1R1-R30) [[17]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R43) [[18]](diffhunk://#diff-f9fd83f426f57c89b1284de26c07b5861882467b74896a385ad8c4a5086b4c0bR56-R57) [[19]](diffhunk://#diff-f9fd83f426f57c89b1284de26c07b5861882467b74896a385ad8c4a5086b4c0bR81)Introduces support for static 'hot zones' (red circles) on the map, configurable via zone_settings.json. Adds server-to-client RPC for hot zone data, client-side rendering on both the map and spawn selection screens, and updates documentation. Hot zones are now sent to clients at match start and during spawn selection.