### PR TITLE
Set starting item health to maximum on spawn

### DIFF
--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
@@ -108,7 +108,7 @@ class BattleRoyalePrepare: BattleRoyaleState
     {
         DeleteAllItems(process_player);
 
-		array<int> player_lobby_items_shortcut = m_GameSettings.player_starting_items_shortcut;
+		array<int> player_starting_items_shortcut = m_GameSettings.player_starting_items_shortcut;
 
         int cCount = a_StartingClothes.Count();
         bool item_spawned = false;
@@ -124,8 +124,11 @@ class BattleRoyalePrepare: BattleRoyaleState
                     new_item = clothes.GetInventory().CreateEntityInCargo(a_StartingItems[j]);
                     if( new_item )
 					{
+						// set health to the maximum
+						new_item.SetHealthMax();
+
 						// If item is in the shortcut list, set it to the hotbar
-						int shortcut_index = player_lobby_items_shortcut.Find(j);
+						int shortcut_index = player_starting_items_shortcut.Find(j);
 						if(shortcut_index != -1)
 						{
 							process_player.SetQuickBarEntityShortcut(new_item, shortcut_index);

--- a/Scripts/Server/5_Mission/Mission/MissionServer.c
+++ b/Scripts/Server/5_Mission/Mission/MissionServer.c
@@ -79,9 +79,12 @@ modded class MissionServer
 		for(int i = 0; i < player_lobby_items.Count(); i++)
 		{
 			string item_name = player_lobby_items.Get(i);
-			EntityAI item = m_player.GetInventory().CreateInInventory( item_name );
+			EntityAI item = m_player.GetInventory().CreateInInventory(item_name);
 			if(item)
 			{
+				// set health to the maximum
+				item.SetHealth(item.GetMaxHealth());
+
 				//see if this item has a shortcut
 				int shortcut_index = player_lobby_items_shortcut.Find(i);
 				if(shortcut_index != -1)


### PR DESCRIPTION
Ensures that items given to players at the start of Battle Royale and in the lobby have their health set to maximum. Also refactors a variable name for clarity in BattleRoyalePrepare.