### PR TITLE
Add CLAUDE.md, and require a worktree for feature work

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,165 +1,27 @@
 # Copilot Instructions for Vigrid Battle Royale
 
-## Repository Overview
+Full guidance lives in **[`CLAUDE.md`](../CLAUDE.md)** at the repository root — read it
+before making changes. It is the single source of truth for build commands,
+architecture, and conventions. Do not duplicate it here.
 
-This is a **DayZ Battle Royale mod** that adds battle royale gameplay mechanics to the DayZ survival game. It's a community mod originally created by Kegan and modified by Myst, licensed under DSPL-SA (DayZ Standalone Public License Share Alike).
+The constraints below are repeated because ignoring them produces code that will not
+compile or will silently run on the wrong side.
 
-### High-Level Repository Information
-- **Project Type**: DayZ mod (Bohemia Interactive engine)
-- **Languages**: EnfusionScript (.c files - C-like syntax specific to DayZ)
-- **Size**: ~240 files total, 94 script files (~11,600 lines of code), medium-sized mod
-- **Version**: 0.1.0-Vigrid (defined in `Scripts/Client/2_GameLib/BattleRoyaleConstants.c`)
-- **Target Runtime**: DayZ Standalone game client/server
-- **Dependencies**: DayZ Expansion framework, CF framework, Community Online Tools, Dabs Framework
-- **Platform**: Windows-only development (requires DayZ Tools)
+## EnfusionScript
 
-## Build Instructions
+- No ternary operator (`a ? b : c`). Use `if`/`else`.
+- No multi-line `if` conditions — the whole condition must be on one line.
+- One declaration per variable name per method scope, even across disjoint branches.
 
-**CRITICAL**: This mod requires Windows with DayZ Tools installed. Linux/macOS development is not supported.
+## Client/Server
 
-### Prerequisites
-1. **DayZ Tools** installed via Steam (under Tools in Steam Library)
-2. **P:\ drive mount** - This is MANDATORY. The entire DayZ modding toolchain requires P:\ to be mounted to your DayZ working directory
-3. **Project configuration files**:
-   - `Workbench/project.cfg` (provided)
-   - `Workbench/user.cfg` (copy from `user_sample.cfg` and modify paths)
+`Scripts/Client/` and `Scripts/Server/` are not a runtime split — both PBOs load on
+both sides. Execution is gated by the preprocessor guard on line 1 of each file:
+`#ifdef SERVER` for server-only, `#ifndef SERVER` for client-only, no guard for shared.
+Always add the correct guard.
 
-### Required Setup Steps
-1. **Always** ensure P:\ drive is mounted before any build operation
-2. **Always** configure `user.cfg` with correct paths:
-   - `WorkDrive=P:\`
-   - `ModBuildDirectory=P:\Mods\`
-   - `KeyDirectory=P:\Keys\`
-   - `GameDirectory=` (path to DayZ installation)
-   - `ServerDirectory=` (path to DayZ Server installation)
-   - `WorkbenchDirectory=` (path to DayZ Tools/Workbench)
+## Build
 
-### Build Commands (Execute from `Workbench/Batchfiles/` directory)
-
-#### Main Build Process
-```batch
-Deploy.bat
-```
-- This is the primary build command
-- Calls `CI.bat` which orchestrates the entire build
-- Creates PBO files (Packed Bohemia Object archives - DayZ mod format)
-- **Timing**: Can take 2-5 minutes depending on system
-- **Validates**: P:\ drive mount, configuration files, tool availability
-
-#### Build Validation Steps
-1. Check for P:\ drive: `if not exist "P:\" ( echo Mount P: drive first & exit /b 1 )`
-2. Verify configuration: Build will fail if `project.cfg` or `user.cfg` missing
-3. Monitor build logs in `Workbench/Logs/` directory
-4. Success indicator: `Workbench/Logs/Build.success` file created
-5. Failure indicator: `Workbench/Logs/Build.failure` file created
-
-#### Testing/Launch Commands
-```batch
-LaunchOffline.bat     # Test mod in single-player
-LaunchLocalMP.bat     # Test mod in local multiplayer
-LaunchServer.bat      # Start dedicated server with mod
-```
-
-#### Utility Commands
-```batch
-KillGame.bat         # Kill all DayZ processes
-ClearLogs.bat        # Clear build logs
-SetupLaunch.bat      # Validate configuration (run before launch)
-```
-
-### Common Build Issues & Workarounds
-- **"P: drive not mounted"**: Ensure P:\ is properly mapped to your DayZ working directory
-- **"Failed to find project.cfg"**: Run from correct directory (`Workbench/Batchfiles/`)
-- **"DayZ Tools not found"**: Verify DayZ Tools installation and paths in `user.cfg`
-- **Permission errors**: Run as Administrator if needed
-- **Build timeout**: Normal for large mods; wait for completion
-
-## Project Layout & Architecture
-
-### Core Structure
-```
-/
-├── Scripts/              # Main mod code
-│   ├── Client/          # Client-side scripts
-│   │   ├── 2_GameLib/   # Game library extensions
-│   │   ├── 3_Game/      # Core game modifications
-│   │   ├── 4_World/     # World/environment scripts  
-│   │   └── 5_Mission/   # Mission/gamemode scripts
-│   └── Server/          # Server-side scripts
-│       ├── 3_Game/      # Server game logic
-│       ├── 4_World/     # Server world management
-│       └── 5_Mission/   # Server mission control
-├── Data/                # Resource files and configurations
-├── GUI/                 # User interface assets
-├── Models/              # 3D models and shapes
-├── Workbench/           # Build system and tools
-│   ├── Batchfiles/      # Build automation scripts
-│   ├── project.cfg      # Project configuration
-│   └── user_sample.cfg  # User configuration template
-└── Extra/               # Optional mod components
-```
-
-### Key Configuration Files
-- **`mod.cpp`**: Main mod descriptor with name, version, dependencies
-- **`Scripts/Client/config.cpp`**: Client-side mod configuration and patches
-- **`Scripts/Server/config.cpp`**: Server-side mod configuration
-- **`Scripts/Client/2_GameLib/BattleRoyaleConstants.c`**: Version and debug constants
-- **`Workbench/project.cfg`**: Build project settings (ModName, dependencies, launch params)
-- **`Workbench/user.cfg`**: User-specific paths and settings (copy from user_sample.cfg)
-
-### Main Code Entry Points
-- **`Scripts/Client/3_Game/DayZGame.c`**: Main client game modifications
-- **`Scripts/Client/5_Mission/BattleRoyale/Client/`**: Battle royale client logic
-- **`Scripts/Server/5_Mission/BattleRoyale/Server/`**: Battle royale server logic
-
-### Architecture Components
-- **Battle Royale System**: Zone management, player tracking, match logic
-- **Client UI**: HUD elements, notifications, match information
-- **Server Management**: Player spawning, zone calculations, match state
-- **Webhook Integration**: Vigrid network integration for matchmaking
-- **Configuration System**: JSON-based settings in profile directory
-
-### Validation Pipeline
-**No automated CI/CD** - This is a Windows-only toolchain that requires manual building.
-
-To validate changes:
-1. Build the mod successfully (`Deploy.bat`)
-2. Test in single-player (`LaunchOffline.bat`) 
-3. Test core functionality (zone system, spawning, UI)
-4. Check for script errors in game logs
-5. Test in multiplayer environment if possible
-
-### Dependencies Not Obvious from Structure
-- **DayZ Expansion**: Major framework dependency (licensed version required)
-- **Community Framework (CF)**: Base modding framework
-- **Community Online Tools**: Admin and debugging tools
-- **Dabs Framework**: Additional scripting utilities
-
-### Critical Files for Code Changes
-- Battle royale logic: `Scripts/*/5_Mission/BattleRoyale/`
-- UI modifications: `Scripts/Client/5_Mission/` and `GUI/`
-- Game mechanics: `Scripts/*/3_Game/`
-
-## Important Notes for Coding Agents
-
-1. **Always validate P:\ drive mount** before attempting builds
-2. **EnfusionScript syntax** is C-like but has DayZ-specific conventions:
-   - **Does NOT support ternary operators** (`condition ? trueValue : falseValue`)
-   - **Does NOT support multi-line if conditions** - all conditions must be on a single line
-   - **Variables must be declared once per method scope** - even if in different code blocks/conditions
-   - Use if-else statements instead of ternary operators
-3. **Never modify working batch files** without understanding the build pipeline
-4. **Client/Server separation** is critical - changes must go in correct directories
-5. **Dependencies are strict** - respect the mod loading order in configs
-6. **Test incrementally** - build and test small changes before major modifications
-7. **UI changes** require both script and GUI asset modifications
-
-### Debug Configuration
-The mod supports multiple debug levels via launch parameters:
-- `-br-warn`: Warning messages only  
-- `-br-info`: Information and warnings
-- `-br-debug`: Debug, information, and warnings
-- `-br-trace`: All messages (trace, debug, info, warnings)
-
-### Trust These Instructions
-Only search for additional information if these instructions are incomplete or found to be incorrect. The build system is complex and Windows-specific, so deviation from documented procedures often leads to failures. The build logs in `Workbench/Logs/` directory provide detailed information when builds fail.
+Windows only, requires DayZ Tools and a mounted `P:\` drive.
+Run `Deploy.bat` from `Workbench/Batchfiles/` (cwd matters). There is no CI and there
+are no tests; validate by launching with `DayZDiag_x64.exe` and reading the `.rpt` log.

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ user.cfg
 /Workbench/*.cfg.bat
 /Workbench/*.cfg.*.bat
 /Workbench/Logs/
+/.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,185 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A DayZ Standalone mod (Bohemia Interactive Enfusion engine) implementing battle-royale gameplay, written in **EnfusionScript** (`.c` files). Originally by Kegan, maintained by Myst. Version `0.1.0-Vigrid`, defined in `Scripts/Client/2_GameLib/BattleRoyaleConstants.c` and mirrored in `mod.cpp`.
+
+Hard dependencies (mod load order set in `Workbench/project.cfg`): CF, Dabs Framework, Community-Online-Tools, DayZ-Expansion. `Scripts/Client/config.cpp` requires `DayZExpansion_Scripts`.
+
+## Workflow
+
+**Always work in a git worktree.** Before the first edit for any new feature or fix, call the `EnterWorktree` tool — it creates a branch plus a worktree under `.claude/worktrees/` and switches the session into it. Never commit directly to `main`.
+
+- Skip it for read-only work: answering questions, searching, reading logs.
+- Skip it if the session is already inside `.claude/worktrees/` — worktrees do not nest.
+- **Building from a worktree needs an extra step.** `Deploy.bat` builds whatever `P:\Vigrid-BattleRoyale\` points at, which is the primary checkout (see `SetupMod.bat` below). To build worktree code, re-point that junction at the worktree, or merge back to the primary checkout first — otherwise the build silently packs the old sources.
+- Finish the work with a commit on the worktree branch; push and open a draft PR when the change should go to the remote.
+
+## Build & run
+
+Windows-only. Requires DayZ Tools (Steam) and a mounted `P:\` work drive.
+
+**One-time setup:**
+1. Copy `Workbench/user_sample.cfg` → `Workbench/user.cfg` and fill in `WorkDrive`, `ModBuildDirectory`, `KeyDirectory`, `KeyName`, `GameDirectory`, `ServerDirectory`, `SPMission`, `MPMission`, profile dirs, SteamIDs. `user.cfg` is gitignored and its values override `project.cfg`.
+2. `Workbench/Batchfiles/SetupMod.bat` — creates the `P:\Vigrid-BattleRoyale\` junction into this checkout. The checkout folder name must equal `PrefixLinkRoot` (`Vigrid-BattleRoyale`).
+
+**All batch files must be run with cwd = `Workbench/Batchfiles`** — several `call` siblings by relative path.
+
+| Command | Purpose |
+|---|---|
+| `Deploy.bat` | Build. Thin wrapper over `CI.bat` → `CI_Build.bat` → `CI1.bat`. Binarize + rapify + pack + sign into `%ModBuildDirectory%@Vigrid-BattleRoyale\`. 2-5 min. |
+| `Deploy.bat rebuildAll` | Wipe the output mod folder and rebuild everything. |
+| `LaunchOffline.bat` | Single-player with `SPMission`. |
+| `LaunchServer.bat` | Dedicated server (clears logs + `storage_*` first). |
+| `LaunchLocalMP.bat` / `MP2` / `MP3` | Server + 1/2/3 local clients. |
+| `KillGame.bat` | Kill all DayZ/Diag processes. |
+| `ClearLogs.bat` | Clear **game** logs (`.rpt`, `.ADM`, `.mdmp`) from profile dirs — not build logs. |
+| `ClearStorage.bat` | Delete `storage_*` under `MPMission`. |
+
+Build result: `Workbench/Logs/Build.log`, plus marker files `Build.success` / `Build.failure` / `Build.deploy`. `CI.bat` hard-fails if `P:\` is not mounted.
+
+Each `config.cpp` with no ancestor `config.cpp` becomes one PBO — currently 7 mod PBOs (`Data`, `GUI`, `LanguageCore`, `Models_Shapes`, `Sounds`, `Scripts_Client`, `Scripts_Server`) plus 10 `Extra_*`. Renaming a top-level folder renames its PBO.
+
+## Testing
+
+**There are no tests, no linter, and no CI.** `.github/` contains only `copilot-instructions.md`.
+
+Validation loop: `Deploy.bat` → launch (`ClientEXE` defaults to `DayZDiag_x64.exe`) → read the `.rpt` in the profile directory for script errors.
+
+Runtime log verbosity (one at a time): `-br-warn`, `-br-info`, `-br-debug`, `-br-trace`, `-br-none`. On a server, `serverDZ.cfg` key `BRLogLevel` (1-4, negative disables) does the same. Diag builds default to trace via `#ifdef DIAG` → `BR_TRACE_ENABLED` in `BattleRoyaleConstants.c:10-20`.
+
+Log with `BattleRoyaleUtils.Error/Warn/Info/Debug/Trace(string)` (`Scripts/Client/3_Game/BattleRoyaleUtils.c`) — not `Print`. On server+DIAG these mirror into in-game chat via the `ChatLog` RPC.
+
+## EnfusionScript constraints
+
+- **No ternary operator.** Use `if`/`else`.
+- **No multi-line `if` conditions** — the whole condition must be on one line.
+- **One declaration per variable name per method scope**, even across disjoint branches.
+- `modded class X` extends an existing class; `override` is required to replace a method.
+
+## Architecture
+
+### Script modules and the Client/Server split
+
+The engine compiles in fixed stages: `1_Core → 2_GameLib → 3_Game → 4_World → 5_Mission`. `config.cpp` maps a folder to a stage via `class defs { class <stage>ScriptModule { files[] = {...} } }`. Files are registered **by directory**, so adding a new `.c` file needs no config change; adding a new stage folder does.
+
+**`Scripts/Client` vs `Scripts/Server` is not a runtime split.** Both PBOs ship in the same mod and load on both sides. What actually gates execution is the preprocessor guard on line 1 of each file:
+
+- `Scripts/Server/**` — every file opens with `#ifdef SERVER`.
+- `Scripts/Client/**` — `#ifndef SERVER` for client-only, **or no guard at all** for shared code that compiles on both sides (e.g. `BattleRoyaleConstants.c`, `BattleRoyaleUtils.c`, `BattleRoyaleBase.c`, `MissionBaseWorld.c`, `BattleRoyalePlayArea.c`).
+
+When adding a file, pick the folder for organisation and **always add the right guard.** An unguarded file under `Scripts/Client/` runs on the server too.
+
+`BattleRoyale_Scripts_Server` lists `BattleRoyale_Scripts_Client` in `requiredAddons`, so server files compile *after* client files in every stage — that ordering is what lets server code `modded class` over client-declared classes.
+
+Compile-time feature flags live in `Scripts/Client/config.cpp:36-43` (`defines[]`). Only `DAYZ_BATTLEROYALE` is active; `BLUE_ZONE`, `BR_MINIMAP`, `MOVING_ZONE`, `BR_TRACE_ENABLED` are commented out but gate real code. Other `#ifdef`s in use: `SERVER`, `DIAG`, `Carim` (party mod), `JM_COT`, `VPPADMINTOOLS`, `EXPANSIONMODMISSIONS`.
+
+### Entry points
+
+`MissionBaseWorld` (`Scripts/Client/4_World/MissionBaseWorld.c`) holds `ref BattleRoyaleBase m_BattleRoyale`, and the free function **`GetBR()`** in the same file is how any code reaches it on either side.
+
+- Server: `BattleRoyaleServer` (`Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c`), constructed in `MissionServer.OnInit()`, ticked from `MissionServer.OnUpdate`. Also `BattleRoyaleServer.GetInstance()`.
+- Client: `BattleRoyaleClient` (`Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleClient.c`), constructed in `MissionGameplay.OnInit()`, ticked from `MissionGameplay.OnUpdate`.
+
+### Match state machine (server)
+
+States are an **ordered `array<ref BattleRoyaleState>`** built in `BattleRoyaleServer.Init()` (`BattleRoyaleServer.c:88-133`). There is no state enum — the numeric filename prefix in `Scripts/Server/5_Mission/BattleRoyale/Server/States/` encodes the order:
+
+`1_BattleRoyaleDebug` (lobby / ready-up) → `2_BattleRoyaleCountReached` (countdown, lock server) → `3_BattleRoyaleSpawnSelection` (only if `enable_spawn_selection_menu`) → `4_BattleRoyalePrepare` (loadout + teleport) → `5_BattleRoyaleStartMatch` (warmup) → `6_BattleRoyaleRound` × `num_zones` → `7_BattleRoyaleLastRound` → `8_BattleRoyaleWin` → `9_BattleRoyaleRestart` (`RequestExit`). A match is one-shot; the server process restarts between matches.
+
+**The completion protocol is inverted.** `BattleRoyaleState.IsComplete()` returns `!IsActive()` (`0_BattleRoyaleState.c:85-92`), so a state signals "done" by calling **`Deactivate()`** on itself — typically from a timer callback, or from an overridden `IsComplete()` that tests its condition, calls `Deactivate()`, then `return super.IsComplete()`.
+
+`BattleRoyaleServer.Update()` is the only driver: it `Update()`s every state each frame and checks `IsComplete()` at 10 Hz, then deactivates → migrates the player list → activates the next non-skipped state (`SkipState()` lets a state opt out entirely; rounds use it for the dynamic starting zone).
+
+`BattleRoyaleState` extends `Timeable` (`Scripts/Server/3_Game/Logic/Timeable.c`) — use `AddTimer(duration, this, "MethodName", params, looping)`; looping timers are stopped automatically by `Deactivate()`.
+
+Long-running work uses script coroutines — `GetGame().GameScript.Call(this, "MethodName", NULL)` plus `Sleep()` (see `4_BattleRoyalePrepare.ProcessPlayers`), not the call queue.
+
+### Zones
+
+`BattleRoyaleZone` (server, `BattleRoyaleZone.c`) is a static registry; all play areas are generated **once per process** into `static ref array<ref BattleRoyalePlayArea> m_PlayAreas`, largest first. **Zone 1 is the largest** and the last zone is the smallest — `BattleRoyaleZone.c:71` indexes with `i_NumRounds - GetZoneNumber()`. Radii come from `zone_settings.json` `static_sizes`; the other `shrink_type` values are declared but marked unused.
+
+Within a round, the new circle only becomes the damaging boundary at 80% of the round timer (`LockNewZone`); before that `GetActiveZone()` returns the previous zone. Damage is applied per player from `PlayerBase.OnScheduledTick` → `BattleRoyaleServer.OnPlayerTick` → `GetCurrentState().OnPlayerTick`, scaled by zone index.
+
+`BattleRoyaleZone.OnActivate(array<PlayerBase>)` is an intentionally empty hook for player-count-driven zone sizing.
+
+### Networking
+
+Primary channel is **CF's `GetRPCManager()`** with string-named RPCs in two namespaces (`BattleRoyaleConstants.c:37-38`):
+
+- `RPC_DAYZBR_NAMESPACE` (`"RPC-DayZBR"`) — server → client
+- `RPC_DAYZBRSERVER_NAMESPACE` (`"RPC-DayZBR-Server"`) — client → server
+
+```c
+// register (ctor)
+GetRPCManager().AddRPC( RPC_DAYZBR_NAMESPACE, "UpdateCurrentPlayArea", this );
+
+// handler signature is always this
+void UpdateCurrentPlayArea(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
+
+// send: (namespace, name, params, guaranteed, [identity], [target])
+GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ShowWinScreen", NULL, true, player.GetIdentity() );
+```
+
+**Match state is never sent as a state id.** The server pushes discrete facts (`StartMatch`, `SetPlayerCount`, `SetCountdownSeconds`, `UpdateCurrentPlayArea`, `UpdateFuturePlayArea`, `SetFade`, `SetInput`, `SetTopPosition`, …). Each lands as a plain field on the client singleton **`BattleRoyaleRPC`** (`Scripts/Client/3_Game/BattleRoyale/RPC/BattleRoyaleRPC.c`), and `BattleRoyaleClient.Update()` polls those fields every frame, diffing against `br_previous_*` locals to detect edges.
+
+Two secondary channels: `ScriptRPC` with the `BattleRoyaleCOTStateMachineRPC` enum (`Scripts/Client/2_GameLib/BattleRoyaleEnums.c`) for the COT admin module, and sync juncture id `88` for teleports (`Scripts/Server/4_World/Entities/ManBase/PlayerBase.c`).
+
+### Settings (JSON)
+
+Server-side only (`Scripts/Server/3_Game/Config/`, all `#ifdef SERVER`). `BattleRoyaleConfig` is a singleton holding `map<string, ref BattleRoyaleDataBase>`; reach it with `BattleRoyaleConfig.GetConfig().GetGameData()` etc.
+
+| File in `$profile:Vigrid-BattleRoyale\` | Class | Registry key |
+|---|---|---|
+| `general_settings.json` | `BattleRoyaleGameData` | `GameData` |
+| `lobby_settings.json` | `BattleRoyaleLobbyData` | `DebugData` |
+| `spawns_settings.json` | `BattleRoyaleSpawnsData` | `SpawnsData` |
+| `zone_settings.json` | `BattleRoyaleZoneData` | `ZoneData` |
+| `pois_settings.json` | `BattleRoyalePOIsData` | `POIsData` |
+| `server_settings.json` | `BattleRoyaleServerData` | `ServerData` — **no mission override** |
+
+The mission override (`$mission:Vigrid-BattleRoyale\`) is **not a merge** — `JsonFileLoader<T>.LoadFile()` is called twice into the same instance (`Load()` then `LoadMission()`), so only keys present in the mission JSON get overwritten. `Upgrade()` runs inside `Load()`, before the mission pass, and `Save()` only ever writes the profile path.
+
+Each class carries `int version` plus an `Upgrade()` migration. `Load()` re-saves after reading, so new fields appear in existing profile JSONs on next boot.
+
+### Localization
+
+Single source: `LanguageCore/stringtable.csv`, keys prefixed `STR_BR_`. Three reference styles:
+- Layouts: `text "#STR_BR_..."`
+- Client script: `SetText("#STR_BR_...")`
+- **Server script: the bare key with no `#`.** `MessagePlayerUntranslated()` / `MessagePlayersUntranslated()` (`0_BattleRoyaleState.c:200-242`) ship the key over the `NotificationMessage` RPC and the client localizes it in `BattleRoyaleRPC.NotificationMessage()`, which also substitutes the `READY_KEY` / `UNSTUCK_KEY` placeholders with live keybinds.
+
+### UI
+
+Layouts live in `GUI/layouts/`. The dominant pattern is imperative — `GetGame().GetWorkspace().CreateWidgets("Vigrid-BattleRoyale/GUI/layouts/....layout")` then `FindAnyWidget("Name")`; most layouts have no `scriptclass`. `SpawnSelectionMenu` is a `UIScriptedMenu` (`MENU_SPAWN_SELECTION = 75` in `Scripts/Client/3_Game/Constants.c`, instantiated in `MissionBase.CreateScriptedMenu`). The only declarative `scriptclass` binding is the COT `master_controls.layout` → `BRMasterControlsForm`.
+
+Keybinds are declared in `Data/Inputs.xml` (`UADayZBRReadyUp` = F1, `UADayZBRUnstuck` = F2, `UADayZBRDebug` = F3), registered via `inputs = "Vigrid-BattleRoyale/Data/Inputs.xml"` in `Scripts/Client/config.cpp`.
+
+### Vigrid API / webhooks
+
+`Scripts/Server/3_Game/BattleRoyale/Webhook/` — REST via `GetRestApi().GetRestContext(BATTLEROYALE_API_ENDPOINT)`. Every call site is gated on `BattleRoyaleConfig.GetConfig().GetServerData().enable_vigrid_api`; `use_autolock` is a separate, independent gate that is *not* covered by it. Each webhook pairs with a `RestCallback` subclass that retries from `i_TryLeft`.
+
+Client-side matchmaking is `MatchMakingWebhook` (`Scripts/Client/3_Game/BattleRoyale/Webhook/`), used by the modded `MainMenu`.
+
+## Asset paths
+
+Script and JSON references use the PBO-relative form with forward slashes: `Vigrid-BattleRoyale/GUI/layouts/...`. `config.cpp` `samples[]` uses backslashes with a leading slash. Profile/mission paths use `$profile:` / `$mission:` with **escaped** backslashes (`"$profile:Vigrid-BattleRoyale\\"`). The prefix comes from `PrefixLinkRoot` in `Workbench/project.cfg`.
+
+Note the imageset's internal name is `battleroyale_gui`, not the filename `dayzbr_gui` — hence `"set:battleroyale_gui image:..."`.
+
+## Adding things
+
+- **A gameplay phase** — subclass `BattleRoyaleState` in `States/` with the next numeric prefix, override `GetName`/`Activate`/`Deactivate`/`IsComplete`/`OnPlayerTick`, and insert it at the right index in `BattleRoyaleServer.Init()`.
+- **A field in an existing settings file** — add the member to the data class, bump `version`, add an `Upgrade()` branch if migration is needed. Nothing else.
+- **A whole new settings file** — new `BattleRoyaleDataBase` subclass + one `m_Configs.Insert()` in `BattleRoyaleConfig.Init()` (marked `//--- adding a new config? copy below`) + a typed accessor.
+- **A server → client value** — field + handler + `AddRPC` in the `BattleRoyaleRPC` ctor + a line in its `Reset()`, then read it from `BattleRoyaleClient.Update()`.
+- **A client → server command** — `AddRPC` in the `BattleRoyaleServer` ctor, or in a state's `Activate()` paired with `RemoveRPC` in `Deactivate()`.
+- **A standalone tweak** — new folder under `Extra/` with its own `config.cpp` and `Scripts/<stage>/`; it becomes its own PBO. Rename `config.cpp` → `config.cpp.disabled` to exclude it from the build (see `Extra/DisableFogChernarusPlus/`).
+
+## Notes
+
+- `Extra/` holds 11 independent single-purpose sub-addons, each its own PBO, all built unconditionally.
+- Spectating is not implemented — `GUI/layouts/hud/spectator/player.layout` exists but nothing references it. Death shows a screen, then forces disconnect.
+- `Workbench/version` (`0.8.100368`) is a DayZ build number read by nothing. The mod version is `BATTLEROYALE_VERSION`.


### PR DESCRIPTION
CLAUDE.md becomes the single guide for working in this repo: what the mod is,
its hard dependencies and their load order, the Workbench build and launch
workflow, the EnfusionScript constraints that bite, and the architecture - the
script stages and the client/server split, the match state machine, zones,
networking, settings and localization. The copilot instructions are rewritten
to point at it rather than duplicate it.

Also adds the workflow rule that feature and fix work happens in a git worktree
and never directly on main, with the caveat that Deploy.bat builds whatever the
P: junction points at, so worktree code needs the junction re-pointed or a merge
back before it is packed.

Squashed from 2 commits:
  dedfdaf  Refactor copilot instructions and add CLAUDE.md for build guidance
  9ba5f11  Require a git worktree for new feature/fix work

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 1 of 31 replaying the local history onto `main`.
