### PR TITLE
Authorize server RPCs from the sender, not the client-chosen target

### DIFF
--- a/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleClient.c
+++ b/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleClient.c
@@ -306,16 +306,17 @@ class BattleRoyaleClient: BattleRoyaleBase
 
         b_IsReady = true; //this only runs once
 
-        PlayerBase player = PlayerBase.Cast( GetGame().GetPlayer() );
         ref Param1<bool> ready_state = new Param1<bool>( true );  //perhaps this can be made togglable?
-        GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "PlayerReadyUp", ready_state, false , NULL, player);
+        //--- No target: the server resolves the subject from the RPC sender identity. Sending one
+        //--- would be ignored, and inviting it back is how the ready-up-anyone exploit worked.
+        GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "PlayerReadyUp", ready_state, false );
 
     }
 
     void Unstuck()
     {
-        PlayerBase player = PlayerBase.Cast( GetGame().GetPlayer() );
-        GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "PlayerUnstuck", NULL, true , NULL, player);
+        //--- No target - see ReadyUp above.
+        GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "PlayerUnstuck", NULL, true );
 
     }
 

--- a/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
+++ b/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
@@ -397,8 +397,10 @@ class SpawnSelectionMenu extends UIScriptedMenu
 
 		BattleRoyaleUtils.Trace(string.Format("SpawnSelectionMenu::SelectSpawnPoint: %1", tempPosition));
 
-		PlayerBase player = PlayerBase.Cast( GetGame().GetPlayer() );
-		GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "OnPlayerSpawnSelected", new Param1<vector>( tempPosition ), true, NULL, player );
+		//--- No target: the server resolves the subject from the RPC sender identity and re-runs the
+		//--- checks above. Sending one would be ignored - it was how a client could set another
+		//--- player's spawn point.
+		GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "OnPlayerSpawnSelected", new Param1<vector>( tempPosition ), true );
 	}
 
 	void WorldRenderOval(CanvasWidget canvas, MapWidget world_map, float world_x, float world_z, float radius_x, float radius_z, int color = -1)

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
@@ -435,16 +435,50 @@ class BattleRoyaleServer: BattleRoyaleBase
         return -1;
     }
 
+    //--- Null-safe identity description for rejection logs. `sender` may legitimately be NULL,
+    //--- so it must never be dereferenced directly inside a log string.
+    static string GetIdentityLogName(PlayerIdentity identity)
+    {
+        if(!identity)
+            return "<null identity>";
+
+        return identity.GetName() + " (" + identity.GetPlainId() + ")";
+    }
+
+    //--- Authorization gate for admin-only RPCs.
+    //--- `sender` is supplied by the engine and cannot be forged by the client, unlike the
+    //--- `Object target` these handlers used to trust. Uses the same admins_steamid64 list that
+    //--- OnPlayerConnected() already consults to let admins join outside the lobby state.
+    //--- Static so the COT module (BRMasterControlsModule) can share it.
+    static bool IsAdminIdentity(PlayerIdentity identity)
+    {
+        if(!identity)
+            return false;
+
+        string steamid = identity.GetPlainId();
+        if(steamid == "")
+            return false;
+
+        BattleRoyaleConfig config_data = BattleRoyaleConfig.GetConfig();
+        if(!config_data)
+            return false;
+
+        BattleRoyaleGameData game_settings = config_data.GetGameData();
+        if(!game_settings)
+            return false;
+
+        if(!game_settings.admins_steamid64)
+            return false;
+
+        return (game_settings.admins_steamid64.Find(steamid) != -1);
+    }
+
+    //--- NOTE: `target` is deliberately ignored here - it is client-chosen and could name any
+    //--- other player. The subject is always resolved from `sender` instead.
     void PlayerReadyUp(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
     {
         Param1< bool > data;
         if( !ctx.Read( data ) ) return;
-
-        if(!target) return;
-
-        PlayerBase targetBase = PlayerBase.Cast(target);
-
-        if(!targetBase) return;
 
         if(type == CallType.Server)
         {
@@ -452,7 +486,8 @@ class BattleRoyaleServer: BattleRoyaleBase
             if(!Class.CastTo(m_DebugStateObj, GetCurrentState())) //this ensures we can only ready up during the debug state
                 return;
 
-            if(!m_DebugStateObj.ContainsPlayer(targetBase))
+            PlayerBase senderBase = m_DebugStateObj.GetPlayerFromIdentity(sender);
+            if(!senderBase)
             {
                 Error("Debug state does not contain player requesting ready up!");
                 return;
@@ -460,7 +495,7 @@ class BattleRoyaleServer: BattleRoyaleBase
 
             if(data.param1)
             {
-                m_DebugStateObj.ReadyUp(targetBase);
+                m_DebugStateObj.ReadyUp(senderBase);
             }
             else
             {
@@ -470,28 +505,24 @@ class BattleRoyaleServer: BattleRoyaleBase
         }
     }
 
+    //--- NOTE: `target` is deliberately ignored here - see PlayerReadyUp above.
     void PlayerUnstuck(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
     {
-		if(!target) return;
-
-		PlayerBase targetBase = PlayerBase.Cast(target);
-
-		if(!targetBase) return;
-
 		if(type == CallType.Server)
 		{
 			BattleRoyaleStartMatch m_StartMatchStateObj;
 			if(!Class.CastTo(m_StartMatchStateObj, GetCurrentState()))
 				return;
 
-            if(!m_StartMatchStateObj.ContainsPlayer(targetBase))
+            PlayerBase senderBase = m_StartMatchStateObj.GetPlayerFromIdentity(sender);
+            if(!senderBase)
             {
                 Error("StartMatch state does not contain player requesting unstuck!");
                 return;
             }
 
-			m_StartMatchStateObj.DeferredUnstuck( targetBase );
-			targetBase.SetSynchDirty();
+			m_StartMatchStateObj.DeferredUnstuck( senderBase );
+			senderBase.SetSynchDirty();
 		}
     }
 
@@ -537,6 +568,17 @@ class BattleRoyaleServer: BattleRoyaleBase
     {
         BattleRoyaleUtils.Trace("BattleRoyaleManager NextState");
 #ifdef SERVER
+        if(type != CallType.Server)
+            return;
+
+        //--- Skipping a match phase is an admin action. The VPP "MenuBattleRoyaleManager" permission
+        //--- only decides whether the client renders the button, so it is no protection at all here.
+        if(!IsAdminIdentity(sender))
+        {
+            BattleRoyaleUtils.Warn("Rejected unauthorized NextState request from " + GetIdentityLogName(sender));
+            return;
+        }
+
         BattleRoyaleServer m_BrServer;
         if(Class.CastTo( m_BrServer, GetBR()))
         {

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
@@ -130,6 +130,37 @@ class BattleRoyaleState: Timeable
         return (m_Players.Find(player) >= 0);
     }
 
+    //--- Resolve the engine-supplied RPC `sender` to a player tracked by THIS state.
+    //--- Server RPC handlers must use this instead of the `Object target` they receive:
+    //--- `target` is chosen by the client and can name any other player, `sender` cannot be spoofed.
+    //--- Returns NULL when the identity is unusable or the sender is not part of this state,
+    //--- so the membership test that ContainsPlayer used to provide is inherent here.
+    PlayerBase GetPlayerFromIdentity(PlayerIdentity identity)
+    {
+        if(!identity)
+            return NULL;
+
+        string sender_id = identity.GetId();
+        if(sender_id == "")
+            return NULL;
+
+        for(int i = 0; i < m_Players.Count(); ++i)
+        {
+            PlayerBase candidate = m_Players.Get(i);
+            if(!candidate)
+                continue;
+
+            PlayerIdentity candidate_identity = candidate.GetIdentity();
+            if(!candidate_identity)
+                continue;
+
+            if(candidate_identity.GetId() == sender_id)
+                return candidate;
+        }
+
+        return NULL;
+    }
+
 	void OnPlayerTick(PlayerBase player, float timeslice)
 	{
 	}

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
@@ -14,6 +14,12 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 
 	ref map<string, vector> spawnpoints;
 
+	//--- Zone number Activate() advertised to the clients. Cached so the server validates incoming
+	//--- selections against exactly the circle it told players about - GetDynamicStartingZone() is
+	//--- called with m_Players.Count() here but with i_NumStartingPlayers elsewhere, and the two
+	//--- can disagree.
+	private int i_SpawnZoneNumber;
+
     void BattleRoyaleSpawnSelection()
     {
     	m_Config = BattleRoyaleConfig.GetConfig();
@@ -54,7 +60,8 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
         super.Activate();
 
         // Send RPC to all players to show spawn selection UI
-        ref BattleRoyalePlayArea spawn_area = BattleRoyaleZone.GetZone(GetDynamicStartingZone(m_Players.Count())).GetArea();
+        i_SpawnZoneNumber = GetDynamicStartingZone(m_Players.Count());
+        ref BattleRoyalePlayArea spawn_area = BattleRoyaleZone.GetZone(i_SpawnZoneNumber).GetArea();
         vector v_FirstZoneCenter = spawn_area.GetCenter();
         float f_FirstZoneRadius = spawn_area.GetRadius();
         float f_SpawnSelectionRadius = m_GameSettings.spawn_selection_radius;
@@ -159,6 +166,52 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 		Deactivate();
 	}
 
+	//--- Server-side validation of a client-submitted spawn point.
+	//--- Mirrors the checks in SpawnSelectionMenu.SelectSpawnPoint() - those run on the client only,
+	//--- so a modified client can otherwise submit any coordinate on the map.
+	//--- Deliberately does NOT call IsSafeForTeleport(): that runs a sphere cast plus a geometry box
+	//--- test and is far too heavy for a per-click RPC. 4_BattleRoyalePrepare already runs
+	//--- GetRandomSafePosition() around the chosen point to handle actual placement safety.
+	private bool IsValidSpawnSelection(vector position)
+	{
+		int world_size = GetGame().GetWorld().GetWorldSize();
+
+		if(position[0] < 0 || position[2] < 0 || position[0] > world_size || position[2] > world_size)
+			return false;
+
+		if(GetGame().SurfaceIsSea(position[0], position[2]))
+			return false;
+
+		if(GetGame().SurfaceIsPond(position[0], position[2]))
+			return false;
+
+		BattleRoyaleZone spawn_zone = BattleRoyaleZone.GetZone(i_SpawnZoneNumber);
+		if(!spawn_zone)
+			return true;
+
+		BattleRoyalePlayArea spawn_area = spawn_zone.GetArea();
+		if(!spawn_area)
+			return true;
+
+		// The client only applies its zone test when it received a usable circle. Match that, so a
+		// degenerate zone makes the server permissive rather than rejecting every selection.
+		float radius = spawn_area.GetRadius();
+		if(radius <= 0)
+			return true;
+
+		// 2D distance, and the same 25 m tolerance the client applies, so that no selection the
+		// client considered legitimate is rejected here.
+		vector center = spawn_area.GetCenter();
+		float dx = position[0] - center[0];
+		float dz = position[2] - center[2];
+		if(Math.Sqrt((dx * dx) + (dz * dz)) > (radius + 25))
+			return false;
+
+		return true;
+	}
+
+	//--- NOTE: `target` is deliberately ignored - it is client-chosen and could name any other
+	//--- player. The subject is resolved from the engine-supplied `sender` instead.
 	void OnPlayerSpawnSelected(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
 	{
 		Param1<vector> data;
@@ -170,15 +223,24 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 		if ( type == CallType.Server )
 		{
 			BattleRoyaleUtils.Trace("Player selected spawn point: " + data.param1.ToString());
-			PlayerBase pbTarget = PlayerBase.Cast(target);
+			PlayerBase pbTarget = GetPlayerFromIdentity(sender);
 			if(pbTarget)
 			{
-				BattleRoyaleUtils.Trace("Player " + pbTarget.GetIdentity().GetName() + " selected spawn point: " + data.param1.ToString());
+				BattleRoyaleUtils.Trace("Player " + sender.GetName() + " selected spawn point: " + data.param1.ToString());
+
+				// Reject out-of-bounds / sea / out-of-zone selections. Returning without calling
+				// SetSpawnPos leaves spawn_pos at the vector.Zero sentinel, so Deactivate() assigns
+				// a fallback spawn exactly as it does for a player who never picked one.
+				if(!IsValidSpawnSelection(data.param1))
+				{
+					BattleRoyaleUtils.Warn("Rejected invalid spawn selection " + data.param1.ToString() + " from " + sender.GetName() + " (" + sender.GetPlainId() + ")");
+					return;
+				}
 
 				if (b_ShowHeatMap)
 				{
 					// Add the spawn point to the player's spawnpoints map
-					spawnpoints.Set(pbTarget.GetIdentity().GetId(), data.param1);
+					spawnpoints.Set(sender.GetId(), data.param1);
 
 					// Update the heatmap for the players
 					array<vector> heatmap_points = new array<vector>;
@@ -192,19 +254,19 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 				pbTarget.SetSpawnPos(data.param1); // Set the spawn position for the player
 
 #ifdef Carim
-				int own_color = GetSpawnColor(pbTarget.GetIdentity().GetId());
+				int own_color = GetSpawnColor(sender.GetId());
 #else
 				int own_color = spawn_colors.Get(Math.RandomInt(0, spawn_colors.Count()));
 #endif
 
 				// Set the spawn position and color for the player
-				GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ShowSpawnPoint", new Param3<PlayerBase, vector, int>(pbTarget, data.param1, own_color), true, pbTarget.GetIdentity(), pbTarget);
+				GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ShowSpawnPoint", new Param3<PlayerBase, vector, int>(pbTarget, data.param1, own_color), true, sender, pbTarget);
 
 #ifdef Carim
 				BattleRoyaleUtils.Trace("Test if player is in a group");
 				if(GetGroup(pbTarget))
 				{
-					BattleRoyaleUtils.Trace("Player " + pbTarget.GetIdentity().GetName() + " is in a group, sharing spawn point with group");
+					BattleRoyaleUtils.Trace("Player " + sender.GetName() + " is in a group, sharing spawn point with group");
 
 					set<PlayerBase> groupMembers = GetGroup(pbTarget);
 					foreach (PlayerBase member : groupMembers)
@@ -212,19 +274,19 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 						BattleRoyaleUtils.Trace("Sharing spawn point with " + member.GetIdentity().GetName());
 						if (member != pbTarget)
 						{
-							GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ShowSpawnPoint", new Param3<PlayerBase, vector, int>(pbTarget, data.param1, GetSpawnColor(pbTarget.GetIdentity().GetId())), true, member.GetIdentity(), member);
+							GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ShowSpawnPoint", new Param3<PlayerBase, vector, int>(pbTarget, data.param1, GetSpawnColor(sender.GetId())), true, member.GetIdentity(), member);
 						}
 					}
 				}
 				else
 				{
-					BattleRoyaleUtils.Trace("Player " + pbTarget.GetIdentity().GetName() + " is not in a group, not sharing spawn point");
+					BattleRoyaleUtils.Trace("Player " + sender.GetName() + " is not in a group, not sharing spawn point");
 				}
 #endif
 			}
 			else
 			{
-				BattleRoyaleUtils.Trace("Player is NULL in OnPlayerSpawnSelected");
+				BattleRoyaleUtils.Warn("Rejected spawn selection from an identity not tracked by the spawn selection state: " + BattleRoyaleServer.GetIdentityLogName(sender));
 			}
 		}
 	}

--- a/Scripts/Server/5_Mission/COT/GUI/BRMasterControlsModule.c
+++ b/Scripts/Server/5_Mission/COT/GUI/BRMasterControlsModule.c
@@ -25,23 +25,51 @@ modded class BRMasterControlsModule
         }
     }
 
+    //--- These RPCs drive the match state machine and are reachable by ANY connected client that
+    //--- sends the right ScriptRPC id - the COT "BattleRoyale.StateMachine.View" permission only
+    //--- gates whether the client renders the module, so it is no protection server-side.
+    //--- Authorize against the same admin list BattleRoyaleServer uses.
     private void RPC_Next( ParamsReadContext ctx, PlayerIdentity senderRPC, Object target )
     {
+        if(!BattleRoyaleServer.IsAdminIdentity(senderRPC))
+        {
+            BattleRoyaleUtils.Warn("[DayZBR COT] Rejected unauthorized Next request from " + BattleRoyaleServer.GetIdentityLogName(senderRPC));
+            return;
+        }
+
         Server_Next(); //Server received next command
     }
 
     private void RPC_Pause( ParamsReadContext ctx, PlayerIdentity senderRPC, Object target )
     {
+        if(!BattleRoyaleServer.IsAdminIdentity(senderRPC))
+        {
+            BattleRoyaleUtils.Warn("[DayZBR COT] Rejected unauthorized Pause request from " + BattleRoyaleServer.GetIdentityLogName(senderRPC));
+            return;
+        }
+
         Server_Pause(); //Server received next command
     }
 
     private void RPC_Resume( ParamsReadContext ctx, PlayerIdentity senderRPC, Object target )
     {
+        if(!BattleRoyaleServer.IsAdminIdentity(senderRPC))
+        {
+            BattleRoyaleUtils.Warn("[DayZBR COT] Rejected unauthorized Resume request from " + BattleRoyaleServer.GetIdentityLogName(senderRPC));
+            return;
+        }
+
         Server_Resume(); //Server received next command
     }
 
     private void RPC_SpawnAirdrop( ParamsReadContext ctx, PlayerIdentity senderRPC, Object target )
     {
+        if(!BattleRoyaleServer.IsAdminIdentity(senderRPC))
+        {
+            BattleRoyaleUtils.Warn("[DayZBR COT] Rejected unauthorized SpawnAirdrop request from " + BattleRoyaleServer.GetIdentityLogName(senderRPC));
+            return;
+        }
+
 #ifdef EXPANSIONMODMISSIONS
 		ExpansionNotification(new StringLocaliser( DAYZBR_MSG_TITLE ), new StringLocaliser( "Airdrop sent." ), DAYZBR_MSG_IMAGE, COLOR_EXPANSION_NOTIFICATION_INFO, DAYZBR_MSG_TIME).Create();
 		ExpansionMissionModule.s_Instance.CallAirdrop(senderRPC.GetPlayer().GetPosition());


### PR DESCRIPTION
Server-side RPC handlers took the acting player from the target object the
client supplied - which the client chooses. They now resolve the actor from the
engine-supplied sender identity instead.

Squashed from 1 commit:
  5a2e7b3  Merge branch 'worktree-fix-rpc-sender-auth'

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 3 of 31 replaying the local history onto `main`.
