### PR TITLE
Gate the no-UUID warning, snap invalid spawn clicks, name the dependency sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A DayZ Standalone mod (Bohemia Interactive Enfusion engine) implementing battle-royale gameplay, written in **EnfusionScript** (`.c` files). Originally by Kegan, maintained by Myst. Version `0.1.0-Vigrid`, defined in `Scripts/Client/2_GameLib/BattleRoyaleConstants.c` and mirrored in `mod.cpp`.
 
-Hard dependencies (mod load order set in `Workbench/project.cfg`): CF, Dabs Framework, Community-Online-Tools, DayZ-Expansion. `Scripts/Client/config.cpp` requires `DayZExpansion_Scripts`.
+Hard dependencies (mod load order set in `Workbench/project.cfg`): [CF](https://github.com/Arkensor/DayZ-CommunityFramework), [Dabs Framework](https://github.com/InclementDab/DayZ-Dabs-Framework), [Community-Online-Tools](https://github.com/Jacob-Mango/DayZ-CommunityOnlineTools), [DayZ-Expansion](https://github.com/salutesh/DayZ-Expansion-Scripts). `Scripts/Client/config.cpp` requires `DayZExpansion_Scripts`. Each link is the mod's source repository — consult it for a dependency's API rather than guessing.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Original work by Kegan: https://gitlab.desolationredux.com/DayZ/DayZBR-Mod/BattleRoyale
 
+## Dependencies
+
+This mod requires the following mods. Their source code is available on GitHub — useful when
+checking a dependency's API:
+
+| Mod                      | Source                                                    |
+|--------------------------|-----------------------------------------------------------|
+| CF (Community Framework) | https://github.com/Arkensor/DayZ-CommunityFramework        |
+| Dabs Framework           | https://github.com/InclementDab/DayZ-Dabs-Framework        |
+| Community Online Tools   | https://github.com/Jacob-Mango/DayZ-CommunityOnlineTools   |
+| DayZ Expansion           | https://github.com/salutesh/DayZ-Expansion-Scripts         |
+
 ## LICENSE
 
 This work is licensed under the [DAYZ STANDALONE PUBLIC LICENSE SHARE ALIKE (DSPL-SA)](LICENSE).  

--- a/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
+++ b/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
@@ -93,6 +93,20 @@ static const int HEATMAP_REPAINT_WATCHDOG_MS = 500;
 static const int BR_OVAL_MIN_SEGMENTS = 16;
 static const int BR_OVAL_MAX_SEGMENTS = 180;
 
+//--- spawn selection snapping
+//a click on water or outside the first zone is snapped to the nearest valid point
+//by walking from the click towards the zone centre. Distance, in metres, between
+//two samples along that line: fine enough not to step over a beach, coarse enough
+//that a 1500 m radius costs ~60 iterations of two native surface calls -- all
+//inside a single mouse-up.
+static const float BR_SPAWN_SNAP_STEP = 25.0;
+//runaway guard on that walk. At the step above this covers 12.8 km, more than any
+//zone radius, so it should never be the reason a search stops.
+static const int BR_SPAWN_SNAP_MAX_STEPS = 512;
+//how far inside the circle a click from outside it lands, in metres. Keeps the
+//snapped point clear of the boundary rather than sitting exactly on it.
+static const float BR_SPAWN_SNAP_INSET = 25.0;
+
 
 //--- zoning subsystem
 static const float DAYZBR_ZS_MIN_DISTANCE_PERCENT = 0.25; //min next zone distance as a percent of maximum distance (1 => 100%)

--- a/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
+++ b/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
@@ -594,6 +594,133 @@ class SpawnSelectionMenu extends UIScriptedMenu
 		}
 	}
 
+	// Client mirror of 3_BattleRoyaleSpawnSelection.IsValidSpawnSelection(). Keep the two in step:
+	// the server is the authority and silently drops anything it disagrees with, so a point this
+	// accepts but the server does not costs the player their pick with no feedback at all.
+	bool IsSpawnPositionValid(vector p)
+	{
+		float half_spawn = GetSpawnSize() / 2;
+		int worldSize = GetGame().GetWorld().GetWorldSize();
+
+		if (p[0] < half_spawn || p[2] < half_spawn || p[0] > (worldSize - half_spawn) || p[2] > (worldSize - half_spawn))
+			return false;
+
+		if (GetGame().SurfaceIsSea(p[0], p[2]))
+			return false;
+
+		// The server rejects ponds as well. Without this the walk below happily stops on a lake and
+		// the selection is thrown away server-side.
+		if (GetGame().SurfaceIsPond(p[0], p[2]))
+			return false;
+
+		if (v_FirstZoneCenter != "0 0 0" && f_FirstZoneRadius > 0)
+		{
+			// 2D, like the server. vector.Distance would fold in the y that ScreenToMap returns and
+			// make the client stricter than the authority for no reason.
+			float dx = p[0] - v_FirstZoneCenter[0];
+			float dz = p[2] - v_FirstZoneCenter[2];
+			// Add a small tolerance (25 meters) to account for precision errors
+			if (Math.Sqrt((dx * dx) + (dz * dz)) > (f_FirstZoneRadius + 25))
+				return false;
+		}
+
+		return true;
+	}
+
+	// One extra step inland from a point that just passed validation. A snapped point sitting right
+	// on a shoreline leaves the server's GetRandomSafePosition(pos, spawn_selection_radius) ball
+	// mostly water, and when that search gives up the player is teleported somewhere random instead
+	// of anywhere near what they clicked.
+	vector NudgeInland(vector pos, vector step_dir, float remaining)
+	{
+		if (remaining <= 0)
+			return pos;
+
+		float travel = BR_SPAWN_SNAP_STEP;
+		if (travel > remaining)
+			travel = remaining;
+
+		vector nudged = pos + (step_dir * travel);
+		nudged[1] = 0;
+
+		if (IsSpawnPositionValid(nudged))
+			return nudged;
+
+		return pos;
+	}
+
+	// Resolve a clicked point to something the player can actually spawn on, by walking from the
+	// click towards the zone centre and taking the first valid sample. Searching that one direction
+	// is enough: for a click outside the circle the nearest in-circle point IS on the line to the
+	// centre, and for a click on water that same line heads inland on any sensibly placed zone.
+	// Returns vector.Zero only when the whole line is unusable - a zone centred on open water.
+	vector FindNearestValidSpawn(vector pos)
+	{
+		int worldSize = GetGame().GetWorld().GetWorldSize();
+		float half_spawn = GetSpawnSize() / 2;
+
+		vector candidate = pos;
+		candidate[1] = 0;
+		candidate[0] = Math.Clamp(candidate[0], half_spawn, worldSize - half_spawn);
+		candidate[2] = Math.Clamp(candidate[2], half_spawn, worldSize - half_spawn);
+
+		// Where to walk towards. Without a usable zone the menu still needs a direction, and the
+		// middle of the map is the only landmark it has.
+		vector target = Vector(worldSize / 2, 0, worldSize / 2);
+		if (v_FirstZoneCenter != "0 0 0" && f_FirstZoneRadius > 0)
+		{
+			target = Vector(v_FirstZoneCenter[0], 0, v_FirstZoneCenter[2]);
+
+			// A click outside the circle is resolved by this projection alone: drop it onto the
+			// boundary, a little inside it, and let the walk below deal with water from there.
+			vector from_center = candidate - target;
+			float center_distance = from_center.Length();
+			if (center_distance > f_FirstZoneRadius)
+			{
+				float inset_radius = f_FirstZoneRadius - BR_SPAWN_SNAP_INSET;
+				if (inset_radius < 0)
+					inset_radius = 0;
+
+				candidate = target + (from_center.Normalized() * inset_radius);
+				candidate[1] = 0;
+				candidate[0] = Math.Clamp(candidate[0], half_spawn, worldSize - half_spawn);
+				candidate[2] = Math.Clamp(candidate[2], half_spawn, worldSize - half_spawn);
+			}
+		}
+
+		// The common case - a click on open ground inside the circle - costs one validity test and
+		// no walking.
+		if (IsSpawnPositionValid(candidate))
+			return candidate;
+
+		vector to_target = target - candidate;
+		float remaining = to_target.Length();
+		if (remaining <= 0)
+			return vector.Zero;
+
+		vector step_dir = to_target.Normalized();
+
+		int steps = Math.Ceil(remaining / BR_SPAWN_SNAP_STEP);
+		if (steps > BR_SPAWN_SNAP_MAX_STEPS)
+			steps = BR_SPAWN_SNAP_MAX_STEPS;
+
+		for (int i = 1; i <= steps; i++)
+		{
+			float travelled = i * BR_SPAWN_SNAP_STEP;
+			// The last sample is the target itself rather than a point beyond it.
+			if (travelled > remaining)
+				travelled = remaining;
+
+			vector probe = candidate + (step_dir * travelled);
+			probe[1] = 0;
+
+			if (IsSpawnPositionValid(probe))
+				return NudgeInland(probe, step_dir, remaining - travelled);
+		}
+
+		return vector.Zero;
+	}
+
 	void SelectSpawnPoint(vector pos)
 	{
 		BattleRoyaleUtils.Trace("SpawnSelectionMenu::SelectSpawnPoint");
@@ -607,40 +734,23 @@ class SpawnSelectionMenu extends UIScriptedMenu
 
 		vector tempPosition = m_MapWidget.ScreenToMap(pos);
 
-		// Check if the position is valid, e.g. within the world bounds
-		int worldSize = GetGame().GetWorld().GetWorldSize();  // Get the world size
-		if (tempPosition[0] < (GetSpawnSize()/2) || tempPosition[2] < (GetSpawnSize()/2) || tempPosition[0] > (worldSize-(GetSpawnSize()/2)) || tempPosition[2] > (worldSize-(GetSpawnSize()/2)))
+		// Water, out of bounds and outside the first zone are no longer rejected outright - the click
+		// is snapped to the nearest point the server will accept. Zero comes back only when no such
+		// point exists along the line to the zone centre.
+		vector spawnPosition = FindNearestValidSpawn(tempPosition);
+
+		if (spawnPosition == vector.Zero)
 		{
-			BattleRoyaleUtils.Trace("SpawnSelectionMenu::SelectSpawnPoint Invalid Position (out of world bounds)");
-			BattleRoyaleUtils.Trace(string.Format("X: %1 Y: %2", (GetSpawnSize()/2), worldSize-(GetSpawnSize()/2)));
+			BattleRoyaleUtils.Trace(string.Format("SpawnSelectionMenu::SelectSpawnPoint No valid spawn near %1", tempPosition));
 			return;
 		}
 
-		// Check if the position is valid, e.g. not in sea
-		if(GetGame().SurfaceIsSea(tempPosition[0], tempPosition[2]))
-		{
-			BattleRoyaleUtils.Trace("SpawnSelectionMenu::SelectSpawnPoint Invalid Position (in sea)");
-			return;
-		}
-
-		// Check if the position is valid, e.g. within the first zone
-		if (v_FirstZoneCenter != "0 0 0" && f_FirstZoneRadius > 0)
-		{
-			float distance = vector.Distance(tempPosition, v_FirstZoneCenter);
-			// Add a small tolerance (25 meters) to account for precision errors
-			if (distance > (f_FirstZoneRadius + 25))
-			{
-				BattleRoyaleUtils.Trace("SpawnSelectionMenu::SelectSpawnPoint Invalid Position (out of first zone)");
-				return;
-			}
-		}
-
-		BattleRoyaleUtils.Trace(string.Format("SpawnSelectionMenu::SelectSpawnPoint: %1", tempPosition));
+		BattleRoyaleUtils.Trace(string.Format("SpawnSelectionMenu::SelectSpawnPoint: click %1 -> spawn %2", tempPosition, spawnPosition));
 
 		//--- No target: the server resolves the subject from the RPC sender identity and re-runs the
 		//--- checks above. Sending one would be ignored - it was how a client could set another
 		//--- player's spawn point.
-		GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "OnPlayerSpawnSelected", new Param1<vector>( tempPosition ), true );
+		GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "OnPlayerSpawnSelected", new Param1<vector>( spawnPosition ), true );
 	}
 
 	void WorldRenderOval(CanvasWidget canvas, MapWidget world_map, float world_x, float world_z, float radius_x, float radius_z, int color = -1)

--- a/Scripts/Server/3_Game/Config/BattleRoyaleServerData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleServerData.c
@@ -1,7 +1,7 @@
 #ifdef SERVER
 class BattleRoyaleServerData: BattleRoyaleDataBase
 {
-	int version = 1;  // Config version
+	int version = 2;  // Config version
 
 	// Enable Vigrid API support
 	bool enable_vigrid_api = false;
@@ -17,7 +17,8 @@ class BattleRoyaleServerData: BattleRoyaleDataBase
     bool force_match_uuid = false;
 
     // If the server should warn the players if no UUID is received
-    bool warning_no_uuid = false;
+    // Only has an effect when enable_vigrid_api is true
+    bool warning_no_uuid = true;
 
 	// Autolock the server when a match starts
 	// Gonna make a POST request to the autolock URL at the start of the match
@@ -57,5 +58,18 @@ class BattleRoyaleServerData: BattleRoyaleDataBase
 		string errorMessage;
 		if (!JsonFileLoader<BattleRoyaleServerData>.SaveFile(GetProfilePath(), this, errorMessage))
 			ErrorEx(errorMessage);
+	}
+
+	override void Upgrade()
+	{
+		if (version < 2)
+		{
+			// warning_no_uuid was never read before v2, the warning was always shown.
+			// Enable it so the behaviour is unchanged for existing servers.
+			warning_no_uuid = true;
+
+			version = 2;
+			Save();  // Save the upgraded config
+		}
 	}
 };

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
@@ -74,7 +74,7 @@ class BattleRoyaleServer: BattleRoyaleBase
 			}
 			BattleRoyaleUtils.Trace("Match UUID: " + match_uuid);
         } else {
-        	match_uuid = "disabled";  // Set a string to disable the ingame error message if no uuid is set
+        	match_uuid = "";  // No API, no match to register
         }
 
         m_Timer = new Timer;
@@ -240,6 +240,7 @@ class BattleRoyaleServer: BattleRoyaleBase
 
         //Dirty way to sync server settings with the client | this should be converted into a generic "sync settings" function
         BattleRoyaleConfig config_data = BattleRoyaleConfig.GetConfig();
+        BattleRoyaleServerData m_ServerData = config_data.GetServerData();
 
         BattleRoyaleDebug m_Debug = BattleRoyaleDebug.Cast( GetState(0) );
         vector debug_pos = m_Debug.GetCenter();
@@ -286,7 +287,7 @@ class BattleRoyaleServer: BattleRoyaleBase
 
         GetCurrentState().AddPlayer(player);
 
-        if( match_uuid == "" )
+        if( m_ServerData.enable_vigrid_api && m_ServerData.warning_no_uuid && match_uuid == "" )
         	GetCurrentState().MessagePlayerUntranslated( player, "STR_BR_MM_ERROR_REGISTERING_MATCH");
     }
 

--- a/Workbench/Batchfiles/LaunchLocalMP.bat
+++ b/Workbench/Batchfiles/LaunchLocalMP.bat
@@ -16,7 +16,10 @@ if errorlevel 1 exit /b 1
 call "%~dp0_LaunchServer.bat" %PlayerSteamID%
 
 REM Give the server a head start before the first client connects.
-timeout /t 5 /nobreak >nul
+REM PING, not TIMEOUT: timeout reads the console to allow a keypress to cancel it, so it
+REM aborts with "input redirection is not supported" and skips the wait entirely whenever
+REM stdin is not a real console (piped, redirected, or launched from a tool or scheduler).
+ping -n 6 127.0.0.1 >nul
 
 for /L %%i in (1,1,%clientCount%) do call :client %%i
 
@@ -27,5 +30,6 @@ if "%~1"=="1" set "slot=A"
 if "%~1"=="2" set "slot=B"
 if "%~1"=="3" set "slot=C"
 call "%~dp0_LaunchClient.bat" %slot%
-timeout /t 2 /nobreak >nul
+REM See the note above on PING vs TIMEOUT.
+ping -n 3 127.0.0.1 >nul
 exit /b 0


### PR DESCRIPTION
Four unrelated fixes from the same stretch of history:

- warning_no_uuid now gates the match registration warning. It was a dead
  setting: the warning fired regardless.
- A spawn selection click on an invalid point snaps to the nearest valid point
  instead of being silently ignored.
- LaunchLocalMP uses PING rather than TIMEOUT for its delays, which does not
  fail when stdin is redirected.
- README.md and CLAUDE.md name the source repository of each dependency mod, so
  an API question is answered from the source rather than guessed.

Squashed from 4 commits:
  9e9c15f  Merge branch 'worktree-warning-no-uuid-gate'
  3730544  Merge branch 'worktree-fix-launchlocalmp-timeout'
  5b5026a  Merge branch 'worktree-spawn-snap-nearest-valid'
  d540f05  Merge branch 'worktree-docs-dependency-sources'

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 5 of 31 replaying the local history onto `main`.
