### PR TITLE
Add the KillFeed and RandomMenuGear addons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Build result: `Workbench/Logs/Build.log`, plus marker files `Build.success` / `B
 | `_LaunchServer.bat <SteamID>` | Clear logs + storage, then start the dedicated server. |
 | `SetupLaunch.bat <MP\|SP>` | Preamble for every `Launch*.bat`: config, validation, mod list, kill running game. Deliberately no `setlocal` — it exports into the caller. |
 
-Each `config.cpp` with no ancestor `config.cpp` becomes one PBO — currently 8 mod PBOs (`Data`, `GUI`, `LanguageCore`, `Models_Shapes`, `Sounds`, `Scripts_Client`, `Scripts_Server`, `Party`) plus 10 `Extra_*`. Renaming a top-level folder renames its PBO.
+Each `config.cpp` with no ancestor `config.cpp` becomes one PBO — currently 8 mod PBOs (`Data`, `GUI`, `LanguageCore`, `Models_Shapes`, `Sounds`, `Scripts_Client`, `Scripts_Server`, `Party`) plus 12 `Extra_*`. Renaming a top-level folder renames its PBO.
 
 ## Testing
 
@@ -191,6 +191,27 @@ Layouts live in `GUI/layouts/`. The dominant pattern is imperative — `GetGame(
 
 Keybinds are declared in `Data/Inputs.xml` (`UADayZBRReadyUp` = F1, `UADayZBRUnstuck` = F2, `UADayZBRDebug` = F3), registered via `inputs = "Vigrid-BattleRoyale/Data/Inputs.xml"` in `Scripts/Client/config.cpp`.
 
+### Kill feed (`Extra/KillFeed/`)
+
+A standalone addon replacing the third-party `nulledkillfeed.pbo`. It builds into `extra_killfeed.pbo` and defines `KILLFEED`. It hooks vanilla `PlayerBase.EEKilled` itself, so it works on any DayZ server — Battle Royale is not required.
+
+**Same discipline rule as `Party/`: nothing under `Extra/KillFeed/` may reference a `BattleRoyale*` symbol.** It carries its own logger (`KillFeedLog`), settings (`$profile:KillFeed\killfeed_settings.json`), `stringtable.csv` (`STR_KF_*`), layouts and RPC namespace (`RPC-KillFeed`). `KILLFEED_PREFIX` in `KillFeedConstants.c` is the single place the asset path appears.
+
+The Battle Royale mod talks to it **only** through `KillFeedAPI` (`Extra/KillFeed/Scripts/4_World/KillFeedAPI.c`), five call sites, each wrapped in `#ifdef KILLFEED`:
+
+```c
+#ifdef KILLFEED
+    KillFeedAPI.NoteEnvironmentalDamage( player, KillFeedCause.ZONE );
+#endif
+```
+
+- `SetActive(bool)` — the feed is off in the lobby (`1_BattleRoyaleDebug`), on from `5_BattleRoyaleStartMatch`, off again at `8_BattleRoyaleWin`.
+- `NoteEnvironmentalDamage(player, cause)` — called at both `DecreaseHealthCoef` zone-damage sites (`6_BattleRoyaleRound`, `7_BattleRoyaleLastRound`). Scripted damage reaches `EEKilled` with the victim as their own killer, so without this hint a zone death is indistinguishable from starvation. Hints expire after `KILLFEED_HINT_TTL_MS` and are consumed by the death that uses them.
+
+A row renders the killer's weapon **with its attachments** by spawning a client-local `ECE_LOCAL` copy, re-attaching the accessory classnames the server sent, and handing it to an `ItemPreviewWidget` — the same mechanism as the vanilla quickbar. At most `KILLFEED_MAX_ROWS` preview entities exist at once; each is `Delete()`d when its row expires.
+
+Note `$profile:KillFeed\` is also used by NulledKillfeed (`Settings.json`). The filenames differ, so they coexist, but deleting the folder to remove one wipes the other.
+
 ### Vigrid API / webhooks
 
 `Scripts/Server/3_Game/BattleRoyale/Webhook/` — REST via `GetRestApi().GetRestContext(BATTLEROYALE_API_ENDPOINT)`. Every call site is gated on `BattleRoyaleConfig.GetConfig().GetServerData().enable_vigrid_api`; `use_autolock` is a separate, independent gate that is *not* covered by it. Each webhook pairs with a `RestCallback` subclass that retries from `i_TryLeft`.
@@ -214,6 +235,7 @@ Note the imageset's internal name is `battleroyale_gui`, not the filename `dayzb
 
 ## Notes
 
-- `Extra/` holds 11 independent single-purpose sub-addons, each its own PBO, all built unconditionally.
+- `Extra/` holds 13 independent single-purpose sub-addons, each its own PBO, all built unconditionally. All are small script tweaks except `Extra/KillFeed/`, a self-contained addon documented under *Architecture → Kill feed*.
+- `Extra/RandomMenuGear/` re-dresses the main-menu intro character in a random outfit plus a slung rifle and a melee weapon, re-rolled on every menu show. It hooks vanilla `IntroSceneCharacter.CreateNewCharacterById` (creation, prev/next arrows) and `MainMenu.OnShow` (returning from a submenu — that path calls `OnChangeCharacter(false)` and never recreates the character). It is **not** a fix for the broken character save that makes the menu character render naked; it only decorates the spawned object. Gear is applied with `GameInventory.CreateAttachmentEx` and deliberately never written into `MenuDefaultCharacterData` — that map is serialized to the server on connect and saved locally, so writing to it would leak menu gear into the real spawn loadout. Same discipline rule as `Party/` and `Extra/KillFeed/`: no `BattleRoyale*` symbol may be referenced.
 - Spectating is not implemented — `GUI/layouts/hud/spectator/player.layout` exists but nothing references it. Death shows a screen, then forces disconnect.
 - `Workbench/version` (`0.8.100368`) is a DayZ build number read by nothing. The mod version is `BATTLEROYALE_VERSION`.

--- a/Extra/KillFeed/GUI/layouts/killfeed.layout
+++ b/Extra/KillFeed/GUI/layouts/killfeed.layout
@@ -1,0 +1,37 @@
+FrameWidgetClass KillFeedRoot {
+ ignorepointer 1
+ position 0 0
+ size 1 1
+ hexactpos 0
+ vexactpos 0
+ hexactsize 0
+ vexactsize 0
+ {
+  PanelWidgetClass KillFeedPanel {
+   ignorepointer 1
+   position 0 0
+   size 0.9 0.9
+   halign center_ref
+   valign center_ref
+   hexactpos 0
+   vexactpos 0
+   hexactsize 0
+   vexactsize 0
+   color 0 0 0 0
+   {
+    PanelWidgetClass KillFeedRows {
+     visible 1
+     ignorepointer 1
+     position 0 150
+     size 470 250
+     halign right_ref
+     hexactpos 0
+     vexactpos 1
+     hexactsize 1
+     vexactsize 1
+     color 0 0 0 0
+    }
+   }
+  }
+ }
+}

--- a/Extra/KillFeed/GUI/layouts/killfeed_row.layout
+++ b/Extra/KillFeed/GUI/layouts/killfeed_row.layout
@@ -1,0 +1,129 @@
+PanelWidgetClass RowRoot {
+ visible 1
+ ignorepointer 1
+ position 0 0
+ size 470 56
+ hexactpos 1
+ vexactpos 1
+ hexactsize 1
+ vexactsize 1
+ color 0 0 0 0.4
+ style DayZDefaultPanel
+ {
+  TextWidgetClass RowKiller {
+   inheritalpha 1
+   ignorepointer 1
+   position 8 0
+   size 140 56
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   style Bold
+   text "Killer"
+   font "gui/fonts/etelkatextpro"
+   "exact text" 0
+   "size to text h" 0
+   "size to text v" 0
+   "text halign" right
+   "text valign" center
+  }
+  PanelWidgetClass RowMiddle {
+   visible 1
+   ignorepointer 1
+   position 156 0
+   size 140 56
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   color 0 0 0 0
+   {
+    ItemPreviewWidgetClass RowWeapon {
+     visible 1
+     clipchildren 0
+     inheritalpha 1
+     ignorepointer 1
+     position 0 0
+     size 140 56
+     hexactpos 1
+     vexactpos 1
+     hexactsize 1
+     vexactsize 1
+     priority 151
+     draggable 0
+     "force flip enable" 1
+    }
+    ImageWidgetClass RowCauseIcon {
+     visible 0
+     inheritalpha 1
+     ignorepointer 1
+     position 0 12
+     size 32 32
+     hexactpos 1
+     vexactpos 1
+     hexactsize 1
+     vexactsize 1
+     image0 "set:dayz_gui image:iconSkull"
+     mode blend
+     "src alpha" 1
+     "no wrap" 1
+     stretch 1
+    }
+    TextWidgetClass RowCauseText {
+     visible 0
+     inheritalpha 1
+     ignorepointer 1
+     position 38 0
+     size 102 56
+     hexactpos 1
+     vexactpos 1
+     hexactsize 1
+     vexactsize 1
+     text ""
+     font "gui/fonts/etelkatextpro"
+     "exact text" 0
+     "size to text h" 0
+     "size to text v" 0
+     "text halign" left
+     "text valign" center
+    }
+   }
+  }
+  TextWidgetClass RowVictim {
+   inheritalpha 1
+   ignorepointer 1
+   position 304 0
+   size 106 56
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   style Bold
+   text "Victim"
+   font "gui/fonts/etelkatextpro"
+   "exact text" 0
+   "size to text h" 0
+   "size to text v" 0
+   "text halign" left
+   "text valign" center
+  }
+  TextWidgetClass RowDistance {
+   inheritalpha 1
+   ignorepointer 1
+   position 414 0
+   size 48 56
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   text ""
+   font "gui/fonts/etelkatextpro"
+   "exact text" 0
+   "size to text h" 0
+   "size to text v" 0
+   "text halign" right
+   "text valign" center
+  }
+ }
+}

--- a/Extra/KillFeed/Scripts/3_Game/Client/KillFeedRPC.c
+++ b/Extra/KillFeed/Scripts/3_Game/Client/KillFeedRPC.c
@@ -1,0 +1,59 @@
+#ifndef SERVER
+/**
+ *  KillFeed - client-side RPC receiver.
+ *
+ *  A queue of plain data, exactly like BattleRoyaleRPC: the handler stores, it never acts. The
+ *  5_Mission UI drains `pending` every frame. Keeping it that way is what allows this class to
+ *  live in 3_Game, which cannot reference anything above it - and MissionGameplay is 5_Mission.
+ */
+class KillFeedRPC
+{
+    private static ref KillFeedRPC m_Instance;
+
+    //--- Entries received but not yet handed to the UI. Drained, not polled: a feed is a stream of
+    //--- events, so nothing here is a "current value" the UI could diff against.
+    ref array<ref KillFeedEntry> pending = new array<ref KillFeedEntry>();
+
+    void KillFeedRPC()
+    {
+        GetRPCManager().AddRPC(RPC_KILLFEED_NAMESPACE, KF_RPC_ENTRY, this);
+        KillFeedLog.Debug("Client RPC registered");
+    }
+
+    static KillFeedRPC GetInstance()
+    {
+        if (!m_Instance)
+            m_Instance = new KillFeedRPC();
+
+        return m_Instance;
+    }
+
+    /**
+     *  Drop anything not yet shown. Called when the mission starts, because the singleton outlives
+     *  a server change and a stale kill would otherwise pop up on the next server's HUD.
+     */
+    void Reset()
+    {
+        pending.Clear();
+    }
+
+    //! Handler name must match KF_RPC_ENTRY exactly - CF's AddRPC dispatches by method name.
+    void KF_Entry(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
+    {
+        Param6<string, string, string, string, int, int> data;
+        if (!ctx.Read(data))
+        {
+            Error("FAILED TO READ KF_ENTRY RPC");
+            return;
+        }
+
+        if (type != CallType.Client)
+            return;
+
+        KillFeedLog.Trace(string.Format("KF_Entry: %1 -> %2 (%3) cause=%6 dist=%5 att=%4",
+            data.param1, data.param2, data.param3, data.param4, data.param5, data.param6));
+
+        pending.Insert(new KillFeedEntry(data.param1, data.param2, data.param3, data.param4, data.param5, data.param6));
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/3_Game/KillFeedCause.c
+++ b/Extra/KillFeed/Scripts/3_Game/KillFeedCause.c
@@ -1,0 +1,21 @@
+/**
+ *  KillFeed - why a player died. No guard: the server classifies, the client presents.
+ *
+ *  Travels as an int inside the entry RPC. WEAPON and MELEE are the only causes that carry a
+ *  weapon to render; everything else falls back to an icon and a phrase.
+ */
+enum KillFeedCause
+{
+    INVALID = -1, //Do not move this
+
+    WEAPON,      //!< shot by a player - renders the gun with its accessories, shows distance
+    MELEE,       //!< struck by a player holding a melee weapon - renders it, no distance
+    BAREHANDS,   //!< beaten to death by a player with nothing in hand
+    EXPLOSIVE,   //!< grenade or mine; the killer name is only known if something recorded it
+    ZONE,        //!< pushed in by the host game through KillFeedAPI.NoteEnvironmentalDamage
+    INFECTED,
+    ANIMAL,
+    ENVIRONMENT, //!< falls, starvation, drowning, and anything that could not be identified
+
+    COUNT //Do not move this
+}

--- a/Extra/KillFeed/Scripts/3_Game/KillFeedConstants.c
+++ b/Extra/KillFeed/Scripts/3_Game/KillFeedConstants.c
@@ -1,0 +1,65 @@
+/**
+ *  KillFeed - shared constants. No guard: this file compiles on both client and server.
+ *
+ *  Everything the addon needs to know about itself lives here. In particular KILLFEED_PREFIX is
+ *  the single place the asset path appears; every layout path is built from it, so extracting this
+ *  addon into a standalone mod is a one-line change here plus config.cpp.
+ */
+
+static const string KILLFEED_VERSION = "0.1.0";
+
+//--- Asset prefix. The ONLY hard-coded path in the addon - build every layout path from it.
+static const string KILLFEED_PREFIX = "Vigrid-BattleRoyale/Extra/KillFeed/";
+
+#ifdef DIAG
+#define KILLFEED_TRACE_ENABLED
+#endif
+
+//--- Log verbosity. Overridden at runtime by -killfeed-trace/-killfeed-debug/-killfeed-info/
+//--- -killfeed-warn/-killfeed-none on the command line, or by KillFeedLogLevel in serverDZ.cfg.
+#ifdef KILLFEED_TRACE_ENABLED
+    static const int KILLFEED_LOG_LEVEL = 4; // Trace
+#else
+    static const int KILLFEED_LOG_LEVEL = 0; // Error only
+#endif
+
+//--- Settings. The addon's own profile folder, deliberately not the host mod's, so that
+//--- extraction does not strand the file behind.
+static const string KILLFEED_SETTINGS_FOLDER = "$profile:KillFeed\\";
+static const string KILLFEED_SETTINGS_FILE = "$profile:KillFeed\\killfeed_settings.json";
+
+//--- RPC namespace (CF RPCManager, string-named). Server -> client only; the client never talks
+//--- back, so there is no second namespace to declare.
+static const string RPC_KILLFEED_NAMESPACE = "RPC-KillFeed";
+
+//--- Server -> client message name. CF's AddRPC dispatches by method name, so the handler on
+//--- KillFeedRPC must be named exactly this.
+static const string KF_RPC_ENTRY = "KF_Entry";
+
+//--- Attachment types travel as one string so the payload stays a flat Param. ';' cannot appear
+//--- in a DayZ classname, which makes it a safe separator.
+static const string KILLFEED_ATTACHMENT_SEPARATOR = ";";
+
+//--- Display. These are constants rather than settings because the settings file is #ifdef SERVER
+//--- and the client cannot read it; pushing them per-connect is a possible follow-up.
+static const int KILLFEED_MAX_ROWS = 4;         //!< rows on screen; also caps live preview entities
+static const int KILLFEED_ROW_SECONDS = 8;      //!< how long a row stays up
+static const int KILLFEED_ROW_HEIGHT = 60;      //!< px between row origins, must clear the row layout
+
+//--- Icon shown in place of the weapon preview when there is nothing to render. A vanilla imageset
+//--- on purpose: depending on another mod's texture would break the standalone promise.
+static const string KILLFEED_ICON_DEFAULT = "set:dayz_gui image:iconSkull";
+
+//--- Stringtable keys for the weaponless causes. The weapon causes render a model instead and so
+//--- need no phrase of their own.
+static const string STR_KILLFEED_ZONE = "#STR_KF_ZONE";
+static const string STR_KILLFEED_ENVIRONMENT = "#STR_KF_ENVIRONMENT";
+static const string STR_KILLFEED_INFECTED = "#STR_KF_INFECTED";
+static const string STR_KILLFEED_ANIMAL = "#STR_KF_ANIMAL";
+static const string STR_KILLFEED_BAREHANDS = "#STR_KF_BAREHANDS";
+static const string STR_KILLFEED_EXPLOSIVE = "#STR_KF_EXPLOSIVE";
+
+//--- How long a cause hint pushed through KillFeedAPI stays valid. A hint is a statement about why
+//--- a player is losing health right now, so it has to expire - otherwise a player who walked out
+//--- of the zone and starved to death an hour later would still be reported as a zone kill.
+static const int KILLFEED_HINT_TTL_MS = 10000;

--- a/Extra/KillFeed/Scripts/3_Game/KillFeedEntry.c
+++ b/Extra/KillFeed/Scripts/3_Game/KillFeedEntry.c
@@ -1,0 +1,45 @@
+/**
+ *  KillFeed - one row's worth of data. No guard: the server fills it in, the client renders it.
+ *
+ *  Pure data, deliberately: the client-side render state (the throwaway preview entity, the expiry
+ *  stamp) lives on KillFeedRowModel in 5_Mission, so this class stays safe to build on the server.
+ */
+class KillFeedEntry
+{
+    string killer_name;   //!< "" when nobody is credited - a zone death, a fall, an unattributed mine
+    string victim_name;
+    string weapon_type;   //!< classname to render, "" for the weaponless causes
+    string attachments;   //!< classnames joined by KILLFEED_ATTACHMENT_SEPARATOR, "" when bare
+    int distance;         //!< metres, -1 to hide the field
+    int cause;            //!< KillFeedCause
+
+    void KillFeedEntry(string killer, string victim, string weapon, string attachment_list, int metres, int death_cause)
+    {
+        killer_name = killer;
+        victim_name = victim;
+        weapon_type = weapon;
+        attachments = attachment_list;
+        distance = metres;
+        cause = death_cause;
+    }
+
+    //! True when the middle cell should render a model rather than an icon and a phrase.
+    bool HasWeapon()
+    {
+        return weapon_type != "";
+    }
+
+    /**
+     *  Attachment classnames, never null. Split here rather than at the call site so the join and
+     *  the split can never disagree about the separator.
+     */
+    array<string> GetAttachmentTypes()
+    {
+        array<string> types = new array<string>();
+        if (attachments == "")
+            return types;
+
+        attachments.Split(KILLFEED_ATTACHMENT_SEPARATOR, types);
+        return types;
+    }
+}

--- a/Extra/KillFeed/Scripts/3_Game/KillFeedLog.c
+++ b/Extra/KillFeed/Scripts/3_Game/KillFeedLog.c
@@ -1,0 +1,93 @@
+/**
+ *  KillFeed - logging. No guard: compiles on both client and server.
+ *
+ *  A deliberate near-duplicate of the host mod's logger. The discipline rule keeps this addon free
+ *  of BattleRoyale* symbols, so it carries its own. It also carries its own CLI flags and its own
+ *  serverDZ.cfg key, so the addons' verbosity can be tuned independently.
+ *
+ *  Runtime verbosity, highest priority first:
+ *    -killfeed-trace | -killfeed-debug | -killfeed-info | -killfeed-warn | -killfeed-none  (CLI)
+ *    KillFeedLogLevel = 1..4 in serverDZ.cfg, negative to silence               (server only)
+ *    KILLFEED_LOG_LEVEL                                                         (compile default)
+ */
+class KillFeedLog
+{
+    static const int NONE = 0;
+    static const int WARN = 1;
+    static const int INFO = 2;
+    static const int DEBUG = 3;
+    static const int TRACE = 4;
+
+    static void LogMessage(int level, string message)
+    {
+        if (!CheckLogLevel(level))
+            return;
+
+        int hour;
+        int minute;
+        int second;
+        GetHourMinuteSecond(hour, minute, second);
+
+        string stamp = hour.ToStringLen(2) + ":" + minute.ToStringLen(2) + ":" + second.ToStringLen(2);
+
+        if (level == NONE)
+        {
+            Error2("", stamp + " [KillFeed] " + message);
+            return;
+        }
+
+        PrintFormat("%1 [KillFeed][%2] %3", stamp, level, message);
+    }
+
+    static void Error(string message)
+    {
+        LogMessage(NONE, message);
+    }
+
+    static void Warn(string message)
+    {
+        LogMessage(WARN, message);
+    }
+
+    static void Info(string message)
+    {
+        LogMessage(INFO, message);
+    }
+
+    static void Debug(string message)
+    {
+        LogMessage(DEBUG, message);
+    }
+
+    static void Trace(string message)
+    {
+        LogMessage(TRACE, message);
+    }
+
+    static bool CheckLogLevel(int level)
+    {
+        //--- Command line wins.
+        if (IsCLIParam("killfeed-none"))
+            return false;
+        if (IsCLIParam("killfeed-trace"))
+            return TRACE >= level;
+        if (IsCLIParam("killfeed-debug"))
+            return DEBUG >= level;
+        if (IsCLIParam("killfeed-info"))
+            return INFO >= level;
+        if (IsCLIParam("killfeed-warn"))
+            return WARN >= level;
+
+#ifdef SERVER
+        //--- Then serverDZ.cfg. 0 is indistinguishable from "key absent", so it falls through to
+        //--- the compile-time default; a negative value silences the addon outright.
+        int config_level = GetGame().ServerConfigGetInt("KillFeedLogLevel");
+        if (config_level > 0)
+            return config_level >= level;
+        if (config_level < 0)
+            return false;
+#endif
+
+        return KILLFEED_LOG_LEVEL >= level;
+    }
+}

--- a/Extra/KillFeed/Scripts/3_Game/Server/KillFeedConfig.c
+++ b/Extra/KillFeed/Scripts/3_Game/Server/KillFeedConfig.c
@@ -1,0 +1,60 @@
+#ifdef SERVER
+/**
+ *  KillFeed - settings singleton. Creates the profile folder, loads killfeed_settings.json and
+ *  writes it straight back so a fresh server ends up with a file it can edit.
+ */
+class KillFeedConfig
+{
+    private static ref KillFeedConfig m_Instance;
+
+    private ref KillFeedData m_Settings;
+    private bool m_HasLoaded;
+
+    void KillFeedConfig()
+    {
+        m_Settings = new KillFeedData();
+        m_HasLoaded = false;
+    }
+
+    static KillFeedConfig GetConfig()
+    {
+        if (!m_Instance)
+        {
+            m_Instance = new KillFeedConfig();
+            m_Instance.Load();
+        }
+
+        return m_Instance;
+    }
+
+    void Load()
+    {
+        if (m_HasLoaded)
+            return;
+
+        m_HasLoaded = true;
+
+        if (!FileExist(KILLFEED_SETTINGS_FOLDER))
+        {
+            KillFeedLog.Info("Creating settings folder " + KILLFEED_SETTINGS_FOLDER);
+            MakeDirectory(KILLFEED_SETTINGS_FOLDER);
+        }
+
+        m_Settings.Load();
+
+        //--- Re-save unconditionally: creates the file on a fresh server, and on an existing one
+        //--- writes back any field added since it was last generated.
+        m_Settings.Save();
+
+        KillFeedLog.Info("Settings loaded (enabled=" + m_Settings.enabled + " show_distance=" + m_Settings.show_distance + ")");
+    }
+
+    KillFeedData GetSettings()
+    {
+        if (!m_HasLoaded)
+            Load();
+
+        return m_Settings;
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/3_Game/Server/KillFeedData.c
+++ b/Extra/KillFeed/Scripts/3_Game/Server/KillFeedData.c
@@ -1,0 +1,52 @@
+#ifdef SERVER
+/**
+ *  KillFeed - server settings, persisted at $profile:KillFeed\killfeed_settings.json.
+ *
+ *  Deliberately not built on the host mod's config base class: the discipline rule keeps this
+ *  addon free of BattleRoyale* symbols, so it carries its own tiny load/save/upgrade. The shape
+ *  mirrors the Battle Royale config classes on purpose, including the "load then immediately
+ *  re-save" trick that makes fields added in a later version materialise in an existing server's
+ *  JSON on next boot.
+ */
+class KillFeedData
+{
+    int version = 1;
+
+    bool enabled = true;                  //!< master switch; false stops the server broadcasting
+    bool show_distance = true;            //!< include the metre count on gunshot rows
+    bool show_environment_deaths = true;  //!< zone, falls, starvation, infected and animals
+
+    string GetPath()
+    {
+        return KILLFEED_SETTINGS_FILE;
+    }
+
+    void Load()
+    {
+        string error_message;
+
+        if (FileExist(GetPath()))
+        {
+            if (!JsonFileLoader<KillFeedData>.LoadFile(GetPath(), this, error_message))
+                ErrorEx(error_message);
+        }
+
+        Upgrade();
+    }
+
+    void Save()
+    {
+        string error_message;
+        if (!JsonFileLoader<KillFeedData>.SaveFile(GetPath(), this, error_message))
+            ErrorEx(error_message);
+    }
+
+    void Upgrade()
+    {
+        //--- No migrations yet. When one is needed: add an `if (version == N)` branch that fills
+        //--- the new fields, set version to N+1, then Save().
+        if (version < 1)
+            version = 1;
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/4_World/KillFeedAPI.c
+++ b/Extra/KillFeed/Scripts/4_World/KillFeedAPI.c
@@ -1,0 +1,57 @@
+#ifdef SERVER
+/**
+ *  KillFeed - the public API. THIS IS THE ENTIRE CONTRACT with the host game.
+ *
+ *  The addon needs none of it: it hooks vanilla PlayerBase.EEKilled and produces a feed on a bare
+ *  DayZ server. These two calls exist so a host game that knows more than the engine does can say
+ *  so - when a match is running, and why a player is losing health right now.
+ *
+ *  Every method is safe to call at any time, including before anything is initialised, so a host
+ *  game never has to null-check.
+ *
+ *  Usage from the host game (guard every call site, so removing the addon still builds):
+ *
+ *      #ifdef KILLFEED
+ *          KillFeedAPI.SetActive(true);
+ *      #endif
+ */
+class KillFeedAPI
+{
+    /**
+     *  Turn the feed on or off at runtime, on top of the `enabled` setting. A host game with a
+     *  lobby phase wants it off there: kills before the match are not part of the story, and a
+     *  feed running in the lobby just leaks who is fighting whom.
+     *
+     *  Not persisted - a fresh server starts with the feed on.
+     */
+    static void SetActive(bool active)
+    {
+        KillFeedDeath.SetActive(active);
+    }
+
+    static bool IsActive()
+    {
+        return KillFeedDeath.IsActive();
+    }
+
+    /**
+     *  Record why `victim` is currently taking damage, so that a death in the next few seconds is
+     *  labelled with `cause` instead of the generic environmental fallback.
+     *
+     *  Needed because scripted damage - DecreaseHealthCoef and friends - surfaces in EEKilled with
+     *  the victim as their own killer, which is indistinguishable from starving or falling. Call it
+     *  wherever the damage is applied; it is cheap enough to call on every tick.
+     *
+     *  The hint expires after KILLFEED_HINT_TTL_MS and is consumed by the death that uses it, so a
+     *  stale one can never mislabel a later, unrelated death.
+     */
+    static void NoteEnvironmentalDamage(PlayerBase victim, int cause)
+    {
+        if (!victim)
+            return;
+
+        victim.m_KillFeedHintCause = cause;
+        victim.m_KillFeedHintTime = GetGame().GetTime();
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/4_World/Server/KillFeedDeath.c
+++ b/Extra/KillFeed/Scripts/4_World/Server/KillFeedDeath.c
@@ -1,0 +1,252 @@
+#ifdef SERVER
+/**
+ *  KillFeed - death classification and broadcast. The whole server side of the addon.
+ *
+ *  Reached from the modded PlayerBase.EEKilled hook, so it works on a bare DayZ server; the host
+ *  game only ever contributes optional hints through KillFeedAPI.
+ *
+ *  Attribution follows vanilla PluginAdminLog.PlayerKilled: for a shot or a swing the `source` IS
+ *  the weapon, and the killer is its hierarchy parent. For fists the source is the player.
+ */
+class KillFeedDeath
+{
+    //--- Runtime gate on top of the `enabled` setting, driven by KillFeedAPI.SetActive. Defaults
+    //--- to on so a server that never calls the API still gets a feed.
+    private static bool m_Active = true;
+
+    static void SetActive(bool active)
+    {
+        if (m_Active == active)
+            return;
+
+        m_Active = active;
+        KillFeedLog.Info("Feed active = " + active);
+    }
+
+    static bool IsActive()
+    {
+        return m_Active;
+    }
+
+    static void OnPlayerKilled(PlayerBase victim, Object source)
+    {
+        if (!victim)
+            return;
+        if (!m_Active)
+            return;
+
+        KillFeedData settings = KillFeedConfig.GetConfig().GetSettings();
+        if (!settings.enabled)
+            return;
+
+        string victim_name = NameOf(victim);
+        if (victim_name == "")
+        {
+            KillFeedLog.Debug("Skipping a death with no resolvable victim name");
+            return;
+        }
+
+        //--- EnfusionScript allows one declaration per name per method scope, so everything the
+        //--- cascade below writes to is declared up front.
+        int cause = KillFeedCause.ENVIRONMENT;
+        string killer_name = "";
+        string weapon_type = "";
+        string attachments = "";
+        int distance = -1;
+
+        EntityAI source_entity = EntityAI.Cast(source);
+        PlayerBase killer_player = NULL;
+
+        if (!source || source == victim)
+        {
+            //--- Nothing hit them: zone damage, a fall, starvation, drowning. The host game may
+            //--- have told us which, in which case that wins.
+            cause = ConsumeHint(victim);
+        }
+        else if (source_entity && IsExplosive(source_entity))
+        {
+            cause = KillFeedCause.EXPLOSIVE;
+            killer_name = ResolveActivatorName(source_entity);
+        }
+        else if (source.IsWeapon() || source.IsMeleeWeapon())
+        {
+            if (source_entity)
+                killer_player = PlayerBase.Cast(source_entity.GetHierarchyParent());
+
+            if (killer_player)
+            {
+                killer_name = NameOf(killer_player);
+                weapon_type = source.GetType();
+                attachments = CollectAttachments(source_entity);
+
+                if (source.IsMeleeWeapon())
+                {
+                    cause = KillFeedCause.MELEE;
+                }
+                else
+                {
+                    cause = KillFeedCause.WEAPON;
+                    if (settings.show_distance)
+                        distance = Math.Round(vector.Distance(victim.GetPosition(), killer_player.GetPosition()));
+                }
+            }
+        }
+        else if (source.IsInherited(PlayerBase))
+        {
+            killer_player = PlayerBase.Cast(source);
+            killer_name = NameOf(killer_player);
+            cause = KillFeedCause.BAREHANDS;
+        }
+        else if (source.IsInherited(ZombieBase))
+        {
+            cause = KillFeedCause.INFECTED;
+        }
+        else if (source.IsInherited(AnimalBase))
+        {
+            cause = KillFeedCause.ANIMAL;
+        }
+
+        //--- A row with no name to credit is an environmental death however it was reached, which
+        //--- is exactly the set the setting gates.
+        if (killer_name == "" && !settings.show_environment_deaths)
+        {
+            KillFeedLog.Debug("Suppressing environmental death of " + victim_name);
+            return;
+        }
+
+        //--- A player cannot be their own killer on a feed row; it reads as a bug.
+        if (killer_name == victim_name)
+            killer_name = "";
+
+        Broadcast(killer_name, victim_name, weapon_type, attachments, distance, cause);
+    }
+
+    private static void Broadcast(string killer_name, string victim_name, string weapon_type, string attachments, int distance, int cause)
+    {
+        KillFeedLog.Info(string.Format("%1 killed %2 (cause=%3 weapon=%4 dist=%5)", killer_name, victim_name, cause, weapon_type, distance));
+
+        //--- No identity argument: that is what makes CF fan the message out to every client.
+        GetRPCManager().SendRPC(RPC_KILLFEED_NAMESPACE, KF_RPC_ENTRY,
+            new Param6<string, string, string, string, int, int>(
+                killer_name,
+                victim_name,
+                weapon_type,
+                attachments,
+                distance,
+                cause),
+            true);
+    }
+
+    /**
+     *  Everything attached to the weapon, as classnames. Iterated with AttachmentCount() rather
+     *  than GetAttachmentSlotsCount() - the former counts what is actually attached, the latter
+     *  counts declared slots and would mostly yield nulls.
+     *
+     *  Magazines are deliberately included: they are visible on the model, and rendering the gun
+     *  exactly as the killer carried it is the whole point of the feature.
+     */
+    private static string CollectAttachments(EntityAI weapon)
+    {
+        string result = "";
+        if (!weapon)
+            return result;
+
+        GameInventory inventory = weapon.GetInventory();
+        if (!inventory)
+            return result;
+
+        int count = inventory.AttachmentCount();
+        for (int i = 0; i < count; i++)
+        {
+            EntityAI attachment = inventory.GetAttachmentFromIndex(i);
+            if (!attachment)
+                continue;
+
+            if (result != "")
+                result = result + KILLFEED_ATTACHMENT_SEPARATOR;
+
+            result = result + attachment.GetType();
+        }
+
+        return result;
+    }
+
+    private static bool IsExplosive(EntityAI source)
+    {
+        if (source.IsInherited(Grenade_Base))
+            return true;
+
+        return source.IsInherited(LandMineTrap);
+    }
+
+    /**
+     *  Who armed the grenade or mine. Read defensively: the host mod records m_ActivatorId on its
+     *  own modded Grenade_Base, a bare DayZ server does not, and the row still renders without it.
+     */
+    private static string ResolveActivatorName(EntityAI source)
+    {
+        string uid = "";
+        EnScript.GetClassVar(source, "m_ActivatorId", -1, uid);
+        if (uid == "")
+            return "";
+
+        array<Man> players = new array<Man>();
+        GetGame().GetPlayers(players);
+
+        int count = players.Count();
+        for (int i = 0; i < count; i++)
+        {
+            Man candidate = players.Get(i);
+            if (!candidate)
+                continue;
+
+            PlayerIdentity identity = candidate.GetIdentity();
+            if (!identity)
+                continue;
+
+            if (identity.GetPlainId() == uid)
+                return identity.GetName();
+        }
+
+        return "";
+    }
+
+    /**
+     *  Take the cause the host game pushed in, if it is still fresh. Consumed rather than merely
+     *  read: a hint describes one death, and leaving it set would mislabel the next one.
+     */
+    private static int ConsumeHint(PlayerBase victim)
+    {
+        int cause = KillFeedCause.ENVIRONMENT;
+
+        if (victim.m_KillFeedHintCause != KillFeedCause.INVALID)
+        {
+            int age = GetGame().GetTime() - victim.m_KillFeedHintTime;
+            if (age >= 0 && age <= KILLFEED_HINT_TTL_MS)
+                cause = victim.m_KillFeedHintCause;
+        }
+
+        victim.m_KillFeedHintCause = KillFeedCause.INVALID;
+        victim.m_KillFeedHintTime = 0;
+
+        return cause;
+    }
+
+    //! Identity first, cached name as the fallback - a corpse can already have lost its identity.
+    private static string NameOf(Man player)
+    {
+        if (!player)
+            return "";
+
+        PlayerIdentity identity = player.GetIdentity();
+        if (identity)
+            return identity.GetName();
+
+        PlayerBase base_player = PlayerBase.Cast(player);
+        if (base_player)
+            return base_player.GetCachedName();
+
+        return "";
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/4_World/Server/KillFeedPlayerBase.c
+++ b/Extra/KillFeed/Scripts/4_World/Server/KillFeedPlayerBase.c
@@ -1,0 +1,24 @@
+#ifdef SERVER
+/**
+ *  KillFeed - the death hook, and the storage for a pushed cause hint.
+ *
+ *  A second `modded class PlayerBase` alongside the host mod's. Both chain through super, so
+ *  application order does not matter - but the override here must keep calling super, or it
+ *  silently cuts the other mod out of the chain.
+ */
+modded class PlayerBase
+{
+    //--- Set through KillFeedAPI.NoteEnvironmentalDamage. Scripted damage (a play-area tick, for
+    //--- instance) reaches EEKilled with the victim as their own killer, indistinguishable from
+    //--- starvation - this is how the host game says which it was. Consumed on death.
+    int m_KillFeedHintCause = KillFeedCause.INVALID;
+    int m_KillFeedHintTime = 0;
+
+    override void EEKilled(Object killer)
+    {
+        super.EEKilled(killer);
+
+        KillFeedDeath.OnPlayerKilled(this, killer);
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedMissionGameplay.c
+++ b/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedMissionGameplay.c
@@ -1,0 +1,54 @@
+#ifndef SERVER
+/**
+ *  KillFeed - client lifecycle.
+ *
+ *  A `modded class MissionGameplay` alongside the host mod's. Both chain through super, so
+ *  application order does not matter - but every override here must keep calling super, or it
+ *  silently cuts the other mod out of the chain.
+ */
+modded class MissionGameplay
+{
+    protected ref KillFeedUI m_KillFeed;
+
+    override void OnInit()
+    {
+        super.OnInit();
+
+        if (!m_KillFeed)
+            m_KillFeed = new KillFeedUI();
+
+        //--- The RPC singleton outlives a server change; anything still queued belongs to the
+        //--- previous session and would pop up on this one's HUD.
+        KillFeedRPC.GetInstance().Reset();
+
+        KillFeedLog.Debug("MissionGameplay::OnInit done");
+    }
+
+    override void OnMissionFinish()
+    {
+        //--- Free the preview entities before the world goes away, rather than leaving it to
+        //--- whenever the UI object happens to be collected.
+        if (m_KillFeed)
+            m_KillFeed.Clear();
+
+        m_KillFeed = NULL;
+
+        super.OnMissionFinish();
+    }
+
+    KillFeedUI GetKillFeed()
+    {
+        return m_KillFeed;
+    }
+
+    override void OnUpdate(float timeslice)
+    {
+        super.OnUpdate(timeslice);
+
+        if (!m_KillFeed)
+            return;
+
+        m_KillFeed.Update(timeslice);
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedRowModel.c
+++ b/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedRowModel.c
@@ -1,0 +1,88 @@
+#ifndef SERVER
+/**
+ *  KillFeed - one live row: the entry, when it expires, and the throwaway entity being rendered.
+ *
+ *  The preview entity hangs off the model rather than off the row widget, so that pushing a new
+ *  kill only re-points SetItem at an already-built entity instead of respawning every model on
+ *  screen. At most KILLFEED_MAX_ROWS of these exist at once.
+ */
+class KillFeedRowModel
+{
+    ref KillFeedEntry entry;
+    int expires_at;
+
+    //--- Not a ref: an engine-owned Object, released with Delete() rather than by refcount.
+    EntityAI preview;
+
+    void KillFeedRowModel(KillFeedEntry source_entry)
+    {
+        entry = source_entry;
+        expires_at = GetGame().GetTime() + (KILLFEED_ROW_SECONDS * 1000);
+        preview = SpawnPreview(source_entry);
+    }
+
+    void ~KillFeedRowModel()
+    {
+        Release();
+    }
+
+    //! Every removal path calls this explicitly; the destructor is only a safety net.
+    void Release()
+    {
+        if (!preview)
+            return;
+
+        preview.Delete();
+        preview = NULL;
+    }
+
+    /**
+     *  Build the thing the ItemPreviewWidget renders: a client-local weapon wearing the same
+     *  accessories the killer had. ECE_LOCAL keeps it off the network and out of the central
+     *  economy; simulation is switched off so it cannot tick, fall or take damage.
+     *
+     *  This is vanilla's own preview-spawn recipe, as used by the script console's item tab.
+     */
+    private EntityAI SpawnPreview(KillFeedEntry source_entry)
+    {
+        if (!source_entry)
+            return NULL;
+        if (!source_entry.HasWeapon())
+            return NULL;
+
+        //--- Vanilla brackets this call with DayZGame.m_IsPreviewSpawn, but that field and its only
+        //--- consumer both live behind #ifdef DEVELOPER, so it does nothing in a shipped build and
+        //--- referencing it fails to compile.
+        EntityAI weapon = EntityAI.Cast(GetGame().CreateObjectEx(source_entry.weapon_type, "0 0 0", ECE_LOCAL));
+
+        if (!weapon)
+        {
+            KillFeedLog.Warn("Could not create preview entity for " + source_entry.weapon_type);
+            return NULL;
+        }
+
+        //--- Attach before disabling simulation: the accessories are what make this feature worth
+        //--- having, so they go on while the entity is still fully alive.
+        GameInventory inventory = weapon.GetInventory();
+        if (inventory)
+        {
+            array<string> types = source_entry.GetAttachmentTypes();
+            int count = types.Count();
+            for (int i = 0; i < count; i++)
+            {
+                string type = types.Get(i);
+                if (type == "")
+                    continue;
+
+                if (!inventory.CreateAttachment(type))
+                    KillFeedLog.Debug("Could not attach " + type + " to " + source_entry.weapon_type);
+            }
+        }
+
+        weapon.DisableSimulation(true);
+        weapon.SetAllowDamage(false);
+
+        return weapon;
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedUI.c
+++ b/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedUI.c
@@ -1,0 +1,299 @@
+#ifndef SERVER
+/**
+ *  KillFeed - the feed itself.
+ *
+ *  Newest row on top. The widget pool is fixed at KILLFEED_MAX_ROWS and never grows or reorders;
+ *  a new kill shifts the model list and the rows are re-bound from it, so there is no widget churn
+ *  while people are dying in quick succession.
+ *
+ *  Rows are re-bound only when something actually changed. SetItem on an ItemPreviewWidget is not
+ *  free, and a feed spends most of its life idle.
+ */
+class KillFeedUI
+{
+    private Widget m_Root;
+    private Widget m_Rows;
+    private bool m_RootFailed;
+
+    //--- Newest first. Never longer than KILLFEED_MAX_ROWS.
+    private ref array<ref KillFeedRowModel> m_Model;
+
+    private ref array<Widget> m_RowWidgets;
+    private ref array<TextWidget> m_RowKillers;
+    private ref array<ItemPreviewWidget> m_RowWeapons;
+    private ref array<ImageWidget> m_RowCauseIcons;
+    private ref array<TextWidget> m_RowCauseTexts;
+    private ref array<TextWidget> m_RowVictims;
+    private ref array<TextWidget> m_RowDistances;
+
+    void KillFeedUI()
+    {
+        m_Model = new array<ref KillFeedRowModel>();
+
+        m_RowWidgets = new array<Widget>();
+        m_RowKillers = new array<TextWidget>();
+        m_RowWeapons = new array<ItemPreviewWidget>();
+        m_RowCauseIcons = new array<ImageWidget>();
+        m_RowCauseTexts = new array<TextWidget>();
+        m_RowVictims = new array<TextWidget>();
+        m_RowDistances = new array<TextWidget>();
+    }
+
+    void ~KillFeedUI()
+    {
+        Clear();
+
+        if (m_Root)
+            m_Root.Unlink();
+    }
+
+    void Update(float timeslice)
+    {
+        if (!EnsureRoot())
+            return;
+
+        bool dirty = Drain();
+
+        if (Expire())
+            dirty = true;
+
+        if (dirty)
+            Refresh();
+    }
+
+    //! Drop every live row and the entities behind them. Used on mission teardown.
+    void Clear()
+    {
+        int count = m_Model.Count();
+        for (int i = 0; i < count; i++)
+        {
+            KillFeedRowModel model = m_Model.Get(i);
+            if (model)
+                model.Release();
+        }
+
+        m_Model.Clear();
+    }
+
+    /**
+     *  Widgets are created on the first Update rather than in the constructor.
+     *
+     *  The constructor runs inside MissionGameplay.OnInit, and the only thing proven to work at
+     *  that point is what the host mod does - it builds its HUD after super.OnInit() has returned.
+     *  Deferring to the first frame means the mission is fully up before any layout is parsed, and
+     *  it costs one boolean test per call.
+     */
+    private bool EnsureRoot()
+    {
+        if (m_Root)
+            return true;
+        if (m_RootFailed)
+            return false;
+
+        KillFeedLog.Debug("Creating kill feed layout");
+        m_Root = GetGame().GetWorkspace().CreateWidgets(KILLFEED_PREFIX + "GUI/layouts/killfeed.layout");
+
+        if (!m_Root)
+        {
+            //--- Latch the failure: retrying every frame would spam the log for the whole session.
+            m_RootFailed = true;
+            KillFeedLog.Error("Could not create killfeed.layout - kill feed disabled");
+            return false;
+        }
+
+        m_Rows = m_Root.FindAnyWidget("KillFeedRows");
+        if (!m_Rows)
+        {
+            m_RootFailed = true;
+            m_Root.Unlink();
+            m_Root = NULL;
+            KillFeedLog.Error("killfeed.layout has no KillFeedRows widget - kill feed disabled");
+            return false;
+        }
+
+        BuildRows();
+        m_Root.Show(false);
+        KillFeedLog.Debug("Kill feed layout ready");
+        return true;
+    }
+
+    private void BuildRows()
+    {
+        for (int i = 0; i < KILLFEED_MAX_ROWS; i++)
+        {
+            Widget row = GetGame().GetWorkspace().CreateWidgets(KILLFEED_PREFIX + "GUI/layouts/killfeed_row.layout", m_Rows);
+            if (!row)
+            {
+                KillFeedLog.Error("Could not create killfeed_row.layout");
+                return;
+            }
+
+            row.SetPos(0, i * KILLFEED_ROW_HEIGHT);
+            row.Show(false);
+
+            m_RowWidgets.Insert(row);
+            m_RowKillers.Insert(TextWidget.Cast(row.FindAnyWidget("RowKiller")));
+            m_RowWeapons.Insert(ItemPreviewWidget.Cast(row.FindAnyWidget("RowWeapon")));
+            m_RowCauseIcons.Insert(ImageWidget.Cast(row.FindAnyWidget("RowCauseIcon")));
+            m_RowCauseTexts.Insert(TextWidget.Cast(row.FindAnyWidget("RowCauseText")));
+            m_RowVictims.Insert(TextWidget.Cast(row.FindAnyWidget("RowVictim")));
+            m_RowDistances.Insert(TextWidget.Cast(row.FindAnyWidget("RowDistance")));
+        }
+    }
+
+    //! Move everything the RPC layer has received into the model. Returns true if anything moved.
+    private bool Drain()
+    {
+        KillFeedRPC rpc = KillFeedRPC.GetInstance();
+        if (!rpc)
+            return false;
+
+        int count = rpc.pending.Count();
+        if (count == 0)
+            return false;
+
+        for (int i = 0; i < count; i++)
+            Push(rpc.pending.Get(i));
+
+        rpc.pending.Clear();
+        return true;
+    }
+
+    private void Push(KillFeedEntry entry)
+    {
+        if (!entry)
+            return;
+
+        m_Model.InsertAt(new KillFeedRowModel(entry), 0);
+
+        //--- Oldest rows fall off the bottom. Release before dropping the reference so the preview
+        //--- entity goes with them rather than lingering in the world.
+        while (m_Model.Count() > KILLFEED_MAX_ROWS)
+        {
+            int last = m_Model.Count() - 1;
+            m_Model.Get(last).Release();
+            m_Model.Remove(last);
+        }
+    }
+
+    //! Drop rows whose time is up. Returns true if anything was dropped.
+    private bool Expire()
+    {
+        bool changed = false;
+        int now = GetGame().GetTime();
+
+        for (int i = m_Model.Count() - 1; i >= 0; i--)
+        {
+            KillFeedRowModel model = m_Model.Get(i);
+            if (model && model.expires_at > now)
+                continue;
+
+            if (model)
+                model.Release();
+
+            m_Model.Remove(i);
+            changed = true;
+        }
+
+        return changed;
+    }
+
+    private void Refresh()
+    {
+        int model_count = m_Model.Count();
+        int row_count = m_RowWidgets.Count();
+
+        for (int i = 0; i < row_count; i++)
+        {
+            Widget row = m_RowWidgets.Get(i);
+            if (!row)
+                continue;
+
+            if (i >= model_count)
+            {
+                //--- Drop the reference as the row goes dark, so a hidden widget never keeps a
+                //--- deleted entity alive.
+                if (m_RowWeapons.Get(i))
+                    m_RowWeapons.Get(i).SetItem(NULL);
+
+                row.Show(false);
+                continue;
+            }
+
+            Bind(i, m_Model.Get(i));
+            row.Show(true);
+        }
+
+        m_Root.Show(model_count > 0);
+    }
+
+    private void Bind(int index, KillFeedRowModel model)
+    {
+        if (!model)
+            return;
+
+        KillFeedEntry entry = model.entry;
+        if (!entry)
+            return;
+
+        TextWidget killer = m_RowKillers.Get(index);
+        if (killer)
+            killer.SetText(entry.killer_name);
+
+        TextWidget victim = m_RowVictims.Get(index);
+        if (victim)
+            victim.SetText(entry.victim_name);
+
+        TextWidget distance = m_RowDistances.Get(index);
+        if (distance)
+        {
+            if (entry.distance >= 0)
+                distance.SetText(entry.distance.ToString() + " m");
+            else
+                distance.SetText("");
+        }
+
+        //--- The middle cell is exclusive: a model to look at, or an icon and a phrase. Never both.
+        bool has_model = model.preview != NULL;
+
+        ItemPreviewWidget weapon = m_RowWeapons.Get(index);
+        if (weapon)
+        {
+            weapon.SetItem(model.preview);
+            weapon.Show(has_model);
+        }
+
+        ImageWidget icon = m_RowCauseIcons.Get(index);
+        if (icon)
+            icon.Show(!has_model);
+
+        TextWidget cause = m_RowCauseTexts.Get(index);
+        if (cause)
+        {
+            cause.Show(!has_model);
+            if (!has_model)
+                cause.SetText(CausePhrase(entry.cause));
+        }
+    }
+
+    /**
+     *  The phrase shown when there is no weapon to render. Returned with its '#' so the widget
+     *  localises it; the weapon causes never reach here because they render a model instead.
+     */
+    private string CausePhrase(int cause)
+    {
+        if (cause == KillFeedCause.ZONE)
+            return STR_KILLFEED_ZONE;
+        if (cause == KillFeedCause.INFECTED)
+            return STR_KILLFEED_INFECTED;
+        if (cause == KillFeedCause.ANIMAL)
+            return STR_KILLFEED_ANIMAL;
+        if (cause == KillFeedCause.BAREHANDS)
+            return STR_KILLFEED_BAREHANDS;
+        if (cause == KillFeedCause.EXPLOSIVE)
+            return STR_KILLFEED_EXPLOSIVE;
+
+        return STR_KILLFEED_ENVIRONMENT;
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/5_Mission/Server/KillFeedMissionServer.c
+++ b/Extra/KillFeed/Scripts/5_Mission/Server/KillFeedMissionServer.c
@@ -1,0 +1,21 @@
+#ifdef SERVER
+/**
+ *  KillFeed - server boot.
+ *
+ *  Exists so the settings file materialises when the server starts rather than when the first
+ *  player dies. An admin looking for killfeed_settings.json should find it on a fresh server, not
+ *  have to get someone killed first.
+ */
+modded class MissionServer
+{
+    override void OnInit()
+    {
+        super.OnInit();
+
+        //--- Touching the singleton is what creates the profile folder and writes the file.
+        KillFeedConfig.GetConfig();
+
+        KillFeedLog.Info("KillFeed " + KILLFEED_VERSION + " ready");
+    }
+}
+#endif

--- a/Extra/KillFeed/config.cpp
+++ b/Extra/KillFeed/config.cpp
@@ -1,0 +1,87 @@
+/**
+ *  KillFeed - standalone kill feed with 3D weapon previews.
+ *
+ *  This folder is its own PBO because the build packs every folder holding a config.cpp with no
+ *  ancestor config.cpp. Keep exactly ONE config.cpp here and do not nest another one below it.
+ *
+ *  DISCIPLINE RULE: nothing under Extra/KillFeed/ may reference a BattleRoyale* symbol. The Battle
+ *  Royale mod consumes this addon through KillFeedAPI only, and every one of its call sites is
+ *  wrapped in #ifdef KILLFEED. The addon hooks vanilla PlayerBase.EEKilled directly, so it works
+ *  on any DayZ server with or without Battle Royale loaded. That keeps a later extraction into a
+ *  standalone @KillFeed mod a build-plumbing job rather than a rewrite - and it keeps
+ *  `config.cpp.disabled` working as a one-rename kill switch.
+ *
+ *  The only place the host mod's name survives is the asset path prefix: CI1.bat builds every
+ *  PBO's prefix as <PrefixLinkRoot>\<folder> and this build has no $PBOPREFIX$ override. That path
+ *  appears exactly once in the scripts, as KILLFEED_PREFIX in KillFeedConstants.c.
+ */
+class CfgPatches
+{
+    class KillFeed
+    {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+        requiredAddons[] =
+        {
+            "DZ_Data",
+            "DZ_Scripts",
+            "JM_CF_Scripts"
+        };
+    };
+};
+
+class CfgMods
+{
+    class KillFeed
+    {
+        dir = "Extra/KillFeed";
+        credits = "Myst";
+        type = "mod";
+        name = "Kill Feed";
+
+        dependencies[] =
+        {
+            "Game",
+            "World",
+            "Mission"
+        };
+
+        //--- Consumed by the Battle Royale mod to guard its call sites. defines[] are visible
+        //--- across CfgMods entries - the same mechanism that made #ifdef Carim work.
+        defines[] =
+        {
+            "KILLFEED"
+        };
+
+        //--- Only declare a script module once its folder actually exists: the engine registers
+        //--- files by directory, and pointing a module at a missing folder is a load-time error.
+        class defs
+        {
+            class gameScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/KillFeed/Scripts/3_Game"
+                };
+            };
+            class worldScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/KillFeed/Scripts/4_World"
+                };
+            };
+            class missionScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/KillFeed/Scripts/5_Mission"
+                };
+            };
+        };
+    };
+};

--- a/Extra/KillFeed/stringtable.csv
+++ b/Extra/KillFeed/stringtable.csv
@@ -1,0 +1,7 @@
+"Language","original","english","czech","german","russian","polish","hungarian","italian","spanish","french","chinese","japanese","portuguese","chinesesimp"
+"STR_KF_ZONE","the zone","the zone","zóna","die Zone","зона","strefa","a zóna","la zona","la zona","la zone","毒圈","エリア外","a zona","毒圈"
+"STR_KF_ENVIRONMENT","the environment","the environment","prostředí","die Umgebung","окружение","otoczenie","a környezet","l'ambiente","el entorno","l'environnement","環境","環境","o ambiente","环境"
+"STR_KF_INFECTED","an infected","an infected","nakažený","ein Infizierter","заражённый","zainfekowany","egy fertőzött","un infetto","un infectado","un infecté","感染者","感染者","um infectado","感染者"
+"STR_KF_ANIMAL","an animal","an animal","zvíře","ein Tier","животное","zwierzę","egy állat","un animale","un animal","un animal","動物","動物","um animal","动物"
+"STR_KF_BAREHANDS","bare hands","bare hands","holé ruce","bloße Hände","голыми руками","gołe ręce","puszta kéz","mani nude","manos desnudas","mains nues","徒手","素手","mãos nuas","徒手"
+"STR_KF_EXPLOSIVE","an explosion","an explosion","výbuch","eine Explosion","взрыв","wybuch","egy robbanás","un'esplosione","una explosión","une explosion","爆炸","爆発","uma explosão","爆炸"

--- a/Extra/RandomMenuGear/Scripts/4_World/RandomMenuGear.c
+++ b/Extra/RandomMenuGear/Scripts/4_World/RandomMenuGear.c
@@ -1,0 +1,202 @@
+/**
+ *  Rolls a random outfit onto the main-menu intro character.
+ *
+ *  Gear is applied straight to the spawned object with GameInventory.CreateAttachmentEx(). It is
+ *  deliberately NOT routed through MenuDefaultCharacterData.SetDefaultAttachment(): that map is
+ *  serialized to the server on connect (MenuDefaultCharacterData.SerializeCharacterData) and
+ *  written to the local character save, so writing into it would leak random menu gear into the
+ *  player's real spawn loadout. Decorating the object only keeps this purely cosmetic.
+ *
+ *  Pool convention: an empty-string entry means "leave this slot bare", so a slot can roll empty
+ *  some of the time. Vanilla's MenuDefaultCharacterData.GenerateRandomEquip uses the same trick.
+ *
+ *  Every classname below was verified against P:\dz\**\config.cpp. The weapon slots rely on
+ *  Rifle_Base declaring inventorySlot[] = {"Shoulder","Melee"} (P:\dz\data\config.cpp), which is
+ *  what makes a rifle render as a proper slung proxy on the static menu idle pose.
+ */
+class RandomMenuGear
+{
+	//--- Parallel arrays: s_Slots[i] is filled from s_Pools[i]. Ordered torso/legs/feet first, then
+	//--- the layered items, then the weapons, so nothing is attached before the layer under it.
+	protected static ref array<int> s_Slots;
+	protected static ref array<ref array<string>> s_Pools;
+
+	//--------------------------------------------------------------------------------------------
+	// Apply
+	//--------------------------------------------------------------------------------------------
+	//! Clears every managed slot on the character and re-rolls it. Safe to call repeatedly.
+	static void Apply(Man player)
+	{
+		if (!player)
+			return;
+
+		if (GetGame().IsDedicatedServer())
+			return;
+
+		GameInventory inv = player.GetInventory();
+		if (!inv)
+			return;
+
+		BuildPools();
+
+		int slotId;
+		EntityAI current;
+		array<string> pool;
+		string type;
+
+		for (int i = 0; i < s_Slots.Count(); ++i)
+		{
+			slotId = s_Slots.Get(i);
+			pool = s_Pools.Get(i);
+
+			//--- Clear whatever is there: leftovers from the character save AND from the last roll.
+			current = inv.FindAttachment(slotId);
+			if (current)
+				GetGame().ObjectDelete(current);
+
+			if (!pool)
+				continue;
+
+			if (pool.Count() == 0)
+				continue;
+
+			type = pool.GetRandomElement();
+			if (type == "")
+				continue;
+
+			inv.CreateAttachmentEx(type, slotId);
+		}
+	}
+
+	//--------------------------------------------------------------------------------------------
+	// BuildPools
+	//--------------------------------------------------------------------------------------------
+	//! Lazy one-time init. InventorySlots constants are populated by the engine from CfgSlots, so
+	//! they are only safe to read once the game is up - not at static-initializer time.
+	protected static void BuildPools()
+	{
+		if (s_Slots)
+			return;
+
+		s_Slots = new array<int>;
+		s_Pools = new array<ref array<string>>;
+
+		ref array<string> body = {
+			"TacticalShirt_Black",
+			"M65Jacket_Black",
+			"BomberJacket_Black",
+			"Hoodie_Black",
+			"Raincoat_Black",
+			"GorkaEJacket_Summer"
+		};
+		AddSlot(InventorySlots.BODY, body);
+
+		ref array<string> legs = {
+			"CargoPants_Black",
+			"GorkaPants_Summer",
+			"Jeans_Blue",
+			"CanvasPants_Beige"
+		};
+		AddSlot(InventorySlots.LEGS, legs);
+
+		ref array<string> feet = {
+			"CombatBoots_Black",
+			"MilitaryBoots_Black",
+			"AthleticShoes_Black",
+			"JungleBoots_Black"
+		};
+		AddSlot(InventorySlots.FEET, feet);
+
+		ref array<string> vest = {
+			"PlateCarrierVest",
+			"HighCapacityVest_Black",
+			"PressVest_Blue",
+			"SmershVest",
+			""
+		};
+		AddSlot(InventorySlots.VEST, vest);
+
+		ref array<string> back = {
+			"AliceBag_Green",
+			"MountainBag_Blue",
+			"AssaultBag_Black",
+			"HuntingBag",
+			"TortillaBag"
+		};
+		AddSlot(InventorySlots.BACK, back);
+
+		ref array<string> headgear = {
+			"BaseballCap_Black",
+			"Mich2001Helmet",
+			"GorkaHelmet",
+			"BoonieHat_Black",
+			"Ushanka_Black",
+			"TankerHelmet"
+		};
+		AddSlot(InventorySlots.HEADGEAR, headgear);
+
+		//--- Two empty entries: a mask covers the face, so it should be the exception not the rule.
+		ref array<string> mask = {
+			"GasMask",
+			"BalaclavaMask_Blackskull",
+			"Balaclava3Holes_Black",
+			"NioshFaceMask",
+			"",
+			""
+		};
+		AddSlot(InventorySlots.MASK, mask);
+
+		ref array<string> eyewear = {
+			"AviatorGlasses",
+			"TacticalGoggles",
+			"DesignerGlasses",
+			""
+		};
+		AddSlot(InventorySlots.EYEWEAR, eyewear);
+
+		ref array<string> gloves = {
+			"TacticalGloves_Black",
+			"WorkingGloves_Black"
+		};
+		AddSlot(InventorySlots.GLOVES, gloves);
+
+		ref array<string> armband = {
+			"Armband_Black",
+			"Armband_Red",
+			""
+		};
+		AddSlot(InventorySlots.ARMBAND, armband);
+
+		//--- Slung across the back.
+		ref array<string> shoulder = {
+			"M4A1",
+			"AKM",
+			"Mosin9130",
+			"SKS",
+			"Winchester70",
+			"FAL",
+			"CZ527",
+			"B95",
+			"Repeater"
+		};
+		AddSlot(InventorySlots.SHOULDER, shoulder);
+
+		ref array<string> melee = {
+			"Machete",
+			"FirefighterAxe",
+			"BaseballBat",
+			"Pickaxe",
+			"SledgeHammer"
+		};
+		AddSlot(InventorySlots.MELEE, melee);
+	}
+
+	//--------------------------------------------------------------------------------------------
+	// AddSlot
+	//--------------------------------------------------------------------------------------------
+	protected static void AddSlot(int slotId, array<string> types)
+	{
+		s_Slots.Insert(slotId);
+		s_Pools.Insert(types);
+	}
+}

--- a/Extra/RandomMenuGear/Scripts/4_World/RandomMenuGearIntroSceneCharacter.c
+++ b/Extra/RandomMenuGear/Scripts/4_World/RandomMenuGearIntroSceneCharacter.c
@@ -1,0 +1,18 @@
+/**
+ *  Every menu character creation funnels through CreateNewCharacterById - both the default-character
+ *  branch (CreateDefaultCharacter) and the saved-character branch (CharacterLoad). One override
+ *  therefore covers the initial menu load, the prev/next character arrows, and the return from the
+ *  character creation menu.
+ *
+ *  It does NOT cover simply re-showing the menu: MainMenu.OnShow() calls OnChangeCharacter(false),
+ *  which skips creation entirely. That path is handled in RandomMenuGearMainMenu.c.
+ */
+modded class IntroSceneCharacter
+{
+	override void CreateNewCharacterById(int character_id)
+	{
+		super.CreateNewCharacterById(character_id);
+
+		RandomMenuGear.Apply(GetCharacterObj());
+	}
+}

--- a/Extra/RandomMenuGear/Scripts/5_Mission/RandomMenuGearMainMenu.c
+++ b/Extra/RandomMenuGear/Scripts/5_Mission/RandomMenuGearMainMenu.c
@@ -1,0 +1,24 @@
+/**
+ *  Re-rolls the outfit every time the main menu is shown - coming back from the server browser,
+ *  options, credits, the character menu, or a disconnect. Vanilla OnShow() calls
+ *  OnChangeCharacter(false), which does not recreate the character, so the IntroSceneCharacter hook
+ *  never fires on this path and the gear would otherwise stay put.
+ *
+ *  This chains cleanly onto the mod's own `modded class MainMenu`
+ *  (Scripts/Client/5_Mission/Mission/MainMenu.c) - that one does not override OnShow().
+ */
+modded class MainMenu
+{
+	override void OnShow()
+	{
+		super.OnShow();
+
+		if (!m_ScenePC)
+			return;
+
+		if (!m_ScenePC.GetIntroCharacter())
+			return;
+
+		RandomMenuGear.Apply(m_ScenePC.GetIntroCharacter().GetCharacterObj());
+	}
+}

--- a/Extra/RandomMenuGear/config.cpp
+++ b/Extra/RandomMenuGear/config.cpp
@@ -1,0 +1,80 @@
+/**
+ *  RandomMenuGear - dresses the main-menu intro character in random gear every time the menu shows.
+ *
+ *  This folder is its own PBO because the build packs every folder holding a config.cpp with no
+ *  ancestor config.cpp. Keep exactly ONE config.cpp here and do not nest another one below it.
+ *
+ *  DISCIPLINE RULE: nothing under Extra/RandomMenuGear/ may reference a BattleRoyale* symbol. The
+ *  addon hooks the vanilla IntroSceneCharacter and MainMenu directly, so it works on any DayZ
+ *  install with or without Battle Royale loaded. That keeps a later extraction into a standalone
+ *  mod a build-plumbing job rather than a rewrite - and it keeps `config.cpp.disabled` working as a
+ *  one-rename kill switch.
+ *
+ *  WHY THIS EXISTS: the menu character usually renders naked because the local character save is
+ *  broken - vanilla either restores it through the engine-native MenuData.CreateCharacterPerson()
+ *  or falls back to MenuDefaultCharacterData.EquipDefaultCharacter() with an empty attachments map.
+ *  This addon deliberately does NOT fix the save. It decorates the spawned menu object only.
+ */
+class CfgPatches
+{
+    //--- Underscored so the config class name never collides with the script class RandomMenuGear,
+    //--- the same reason Party/config.cpp uses Vigrid_Party against its script class VigridParty.
+    //--- The PBO name comes from the folder path, not from here, so this stays Extra_RandomMenuGear.
+    class Random_Menu_Gear
+    {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+        requiredAddons[] =
+        {
+            "DZ_Data",
+            "DZ_Scripts"
+        };
+    };
+};
+
+class CfgMods
+{
+    class Random_Menu_Gear
+    {
+        dir = "Extra/RandomMenuGear";
+        credits = "Myst";
+        type = "mod";
+        name = "Random Menu Gear";
+
+        dependencies[] =
+        {
+            "World",
+            "Mission"
+        };
+
+        //--- Nothing consumes this today. Declared for consistency with the other Extra addons, so
+        //--- a future call site can guard itself with #ifdef RANDOM_MENU_GEAR.
+        defines[] =
+        {
+            "RANDOM_MENU_GEAR"
+        };
+
+        //--- Only declare a script module once its folder actually exists: the engine registers
+        //--- files by directory, and pointing a module at a missing folder is a load-time error.
+        class defs
+        {
+            class worldScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/RandomMenuGear/Scripts/4_World"
+                };
+            };
+            class missionScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/RandomMenuGear/Scripts/5_Mission"
+                };
+            };
+        };
+    };
+};

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
@@ -67,6 +67,12 @@ class BattleRoyaleDebug: BattleRoyaleDebugState
         if( b_UseVoteSystem )
         	AddTimer(2.0, this, "CheckReadyState", NULL, true);
 
+#ifdef KILLFEED
+        //--- Nothing that happens in the lobby belongs in the feed, and a feed running here would
+        //--- just advertise who is fighting whom before the match has started.
+        KillFeedAPI.SetActive( false );
+#endif
+
         super.Activate();
     }
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
@@ -51,6 +51,11 @@ class BattleRoyaleStartMatch: BattleRoyaleState
         //send start match RPC (this will enable UI such as kill count)
         GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "StartMatch", new Param1<bool>(true), true); //don't need a param, but id rather keep it just so i know nothing wierd occurs (eventually find out if we can remove it)
 
+#ifdef KILLFEED
+        //--- Kills count from here on, so the feed goes live with the match.
+        KillFeedAPI.SetActive( true );
+#endif
+
         int max_time = i_TimeToUnlock - 1;
         for(int i = max_time; i > 0; i--)
         {

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -314,6 +314,11 @@ class BattleRoyaleRound: BattleRoyaleState
 				    player.GetSymptomManager().QueueUpPrimarySymptom(SymptomIDs.SYMPTOM_PAIN_LIGHT);
                     //TODO: determine if this last health tick will kill the player
                     player.DecreaseHealthCoef( f_Damage ); //TODO: delta this by the # of zones that have ticked (more zones = more damage)
+#ifdef KILLFEED
+                    //--- Scripted damage reaches EEKilled with the player as their own killer, so
+                    //--- without this the kill feed cannot tell a zone death from starvation.
+                    KillFeedAPI.NoteEnvironmentalDamage( player, KillFeedCause.ZONE );
+#endif
                     player.time_until_damage = i_DamageTickTime; //reset timer
                 }
                 player.time_until_damage -= timeslice;

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
@@ -180,6 +180,11 @@ class BattleRoyaleLastRound: BattleRoyaleState
                 MessagePlayerUntranslated(player, "STR_BR_TAKING_DAMAGE");
                 player.GetSymptomManager().QueueUpPrimarySymptom(SymptomIDs.SYMPTOM_PAIN_HEAVY);
                 player.DecreaseHealthCoef( f_Damage );
+#ifdef KILLFEED
+                //--- Scripted damage reaches EEKilled with the player as their own killer, so
+                //--- without this the kill feed cannot tell a zone death from starvation.
+                KillFeedAPI.NoteEnvironmentalDamage( player, KillFeedCause.ZONE );
+#endif
                 player.time_until_damage = i_DamageTickTime; //reset timer
             }
             player.time_until_damage -= timeslice;

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/8_BattleRoyaleWin.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/8_BattleRoyaleWin.c
@@ -17,7 +17,12 @@ class BattleRoyaleWin: BattleRoyaleState
 	override void Activate()
 	{
 		super.Activate();
-	
+
+#ifdef KILLFEED
+		//--- The match is over; anything that dies from here on is not part of the story.
+		KillFeedAPI.SetActive( false );
+#endif
+
 		string winner_name = "<NO:WINNER>";
 		if(GetPlayers().Count() > 0)
 		{


### PR DESCRIPTION
Extra/KillFeed replaces the third-party nulledkillfeed.pbo. It hooks vanilla
PlayerBase.EEKilled itself, so it works on any DayZ server - Battle Royale is
not required - and it renders the killer's weapon with its attachments by
spawning a client-local ECE_LOCAL copy, re-attaching the accessory classnames
the server sent, and handing it to an ItemPreviewWidget, which is the same
mechanism as the vanilla quickbar.

Same discipline rule as Party/: nothing under Extra/KillFeed/ references a
BattleRoyale* symbol. Its own logger, settings, stringtable, layouts and RPC
namespace, reached only through KillFeedAPI.

Extra/RandomMenuGear re-dresses the main-menu intro character in a random
outfit plus a slung rifle and a melee weapon, re-rolled every time the menu is
shown. Cosmetic only: it decorates the spawned object and is deliberately not a
fix for the broken character save that makes the menu character render naked.
Gear is never written into MenuDefaultCharacterData, which is serialized to the
server on connect and would leak menu gear into the real spawn loadout.

Squashed from 3 commits:
  4447a80  Merge branch 'worktree-killfeed' - standalone KillFeed addon with 3D weapon previews
  1a63874  Fix stale cross-reference in the KillFeed note
  aa4c7b0  Merge branch 'worktree-random-menu-gear' - random main-menu character gear

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 7 of 31 replaying the local history onto `main`.
