### PR TITLE
Make the kill feed rows hug their text, and suppress other mods' feeds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,10 @@ The Battle Royale mod talks to it **only** through `KillFeedAPI` (`Extra/KillFee
 
 A row renders the killer's weapon **with its attachments** by spawning a client-local `ECE_LOCAL` copy, re-attaching the accessory classnames the server sent, and handing it to an `ItemPreviewWidget` — the same mechanism as the vanilla quickbar. At most `KILLFEED_MAX_ROWS` preview entities exist at once; each is `Delete()`d when its row expires.
 
+`KillFeedSuppress` (`Scripts/4_World/Server/`) turns off other mods' kill feeds so a death is not announced twice, gated on the `suppress_other_killfeeds` setting. Each block is behind that mod's own define — currently only `#ifdef EXPANSIONMODKILLFEED`, which clears `GetExpansionSettings().GetNotification().EnableKillFeed`. That is Expansion's own documented switch, checked at both of its hooks in its modded `PlayerBase`, so clearing it is complete; the change is **in memory only**, so the admin's `NotificationSettings.json` is untouched and removing this addon restores the previous behaviour. Applied from `MissionServer.OnInit` plus one re-apply 10s later, in case another mod loads its settings afterwards.
+
+NulledKillfeed is *not* covered — it is an obfuscated third-party PBO with no API to call. Remove it from `Workbench/ExtraPBOs/` or zero every `"active"` in its own `$profile:KillFeed\Settings.json`.
+
 Note `$profile:KillFeed\` is also used by NulledKillfeed (`Settings.json`). The filenames differ, so they coexist, but deleting the folder to remove one wipes the other.
 
 ### Vigrid API / webhooks

--- a/Extra/KillFeed/GUI/layouts/killfeed.layout
+++ b/Extra/KillFeed/GUI/layouts/killfeed.layout
@@ -23,7 +23,7 @@ FrameWidgetClass KillFeedRoot {
      visible 1
      ignorepointer 1
      position 0 150
-     size 470 250
+     size 700 240
      halign right_ref
      hexactpos 0
      vexactpos 1

--- a/Extra/KillFeed/GUI/layouts/killfeed_row.layout
+++ b/Extra/KillFeed/GUI/layouts/killfeed_row.layout
@@ -1,8 +1,13 @@
+// Child positions and sizes here are placeholders: KillFeedUI.LayoutRow() measures the bound text
+// with GetTextSize() and overwrites every SetPos/SetSize, so the row can hug its content. Keep them
+// plausible anyway so the layout still reads correctly in Workbench.
 PanelWidgetClass RowRoot {
  visible 1
  ignorepointer 1
+ inheritalpha 0
  position 0 0
- size 470 56
+ size 460 42
+ halign right_ref
  hexactpos 1
  vexactpos 1
  hexactsize 1
@@ -11,28 +16,33 @@ PanelWidgetClass RowRoot {
  style DayZDefaultPanel
  {
   TextWidgetClass RowKiller {
-   inheritalpha 1
+   inheritalpha 0
    ignorepointer 1
    position 8 0
-   size 140 56
+   size 132 42
    hexactpos 1
    vexactpos 1
    hexactsize 1
    vexactsize 1
-   style Bold
+   color 1 1 1 1
    text "Killer"
-   font "gui/fonts/etelkatextpro"
-   "exact text" 0
+   font "gui/fonts/etelkatextpro22"
+   "shadow size" 3
+   "shadow color" 0 0 0 1
+   "shadow offset" 1 1
+   "exact text" 1
+   "exact text size" 20
    "size to text h" 0
    "size to text v" 0
-   "text halign" right
+   "text halign" left
    "text valign" center
   }
   PanelWidgetClass RowMiddle {
    visible 1
    ignorepointer 1
-   position 156 0
-   size 140 56
+   inheritalpha 0
+   position 150 0
+   size 144 42
    hexactpos 1
    vexactpos 1
    hexactsize 1
@@ -42,10 +52,10 @@ PanelWidgetClass RowRoot {
     ItemPreviewWidgetClass RowWeapon {
      visible 1
      clipchildren 0
-     inheritalpha 1
+     inheritalpha 0
      ignorepointer 1
      position 0 0
-     size 140 56
+     size 144 42
      hexactpos 1
      vexactpos 1
      hexactsize 1
@@ -56,14 +66,15 @@ PanelWidgetClass RowRoot {
     }
     ImageWidgetClass RowCauseIcon {
      visible 0
-     inheritalpha 1
+     inheritalpha 0
      ignorepointer 1
-     position 0 12
-     size 32 32
+     position 0 9
+     size 24 24
      hexactpos 1
      vexactpos 1
      hexactsize 1
      vexactsize 1
+     color 1 1 1 1
      image0 "set:dayz_gui image:iconSkull"
      mode blend
      "src alpha" 1
@@ -72,17 +83,22 @@ PanelWidgetClass RowRoot {
     }
     TextWidgetClass RowCauseText {
      visible 0
-     inheritalpha 1
+     inheritalpha 0
      ignorepointer 1
-     position 38 0
-     size 102 56
+     position 34 0
+     size 110 42
      hexactpos 1
      vexactpos 1
      hexactsize 1
      vexactsize 1
+     color 1 1 1 1
      text ""
-     font "gui/fonts/etelkatextpro"
-     "exact text" 0
+     font "gui/fonts/etelkatextpro22"
+     "shadow size" 3
+     "shadow color" 0 0 0 1
+     "shadow offset" 1 1
+     "exact text" 1
+     "exact text size" 20
      "size to text h" 0
      "size to text v" 0
      "text halign" left
@@ -91,38 +107,47 @@ PanelWidgetClass RowRoot {
    }
   }
   TextWidgetClass RowVictim {
-   inheritalpha 1
+   inheritalpha 0
    ignorepointer 1
    position 304 0
-   size 106 56
+   size 112 42
    hexactpos 1
    vexactpos 1
    hexactsize 1
    vexactsize 1
-   style Bold
+   color 1 1 1 1
    text "Victim"
-   font "gui/fonts/etelkatextpro"
-   "exact text" 0
+   font "gui/fonts/etelkatextpro22"
+   "shadow size" 3
+   "shadow color" 0 0 0 1
+   "shadow offset" 1 1
+   "exact text" 1
+   "exact text size" 20
    "size to text h" 0
    "size to text v" 0
    "text halign" left
    "text valign" center
   }
   TextWidgetClass RowDistance {
-   inheritalpha 1
+   inheritalpha 0
    ignorepointer 1
-   position 414 0
-   size 48 56
+   position 420 0
+   size 52 42
    hexactpos 1
    vexactpos 1
    hexactsize 1
    vexactsize 1
+   color 1 1 1 1
    text ""
-   font "gui/fonts/etelkatextpro"
-   "exact text" 0
+   font "gui/fonts/etelkatextpro16"
+   "shadow size" 3
+   "shadow color" 0 0 0 1
+   "shadow offset" 1 1
+   "exact text" 1
+   "exact text size" 16
    "size to text h" 0
    "size to text v" 0
-   "text halign" right
+   "text halign" left
    "text valign" center
   }
  }

--- a/Extra/KillFeed/Scripts/3_Game/KillFeedConstants.c
+++ b/Extra/KillFeed/Scripts/3_Game/KillFeedConstants.c
@@ -44,7 +44,24 @@ static const string KILLFEED_ATTACHMENT_SEPARATOR = ";";
 //--- and the client cannot read it; pushing them per-connect is a possible follow-up.
 static const int KILLFEED_MAX_ROWS = 4;         //!< rows on screen; also caps live preview entities
 static const int KILLFEED_ROW_SECONDS = 8;      //!< how long a row stays up
-static const int KILLFEED_ROW_HEIGHT = 60;      //!< px between row origins, must clear the row layout
+static const int KILLFEED_ROW_HEIGHT = 46;      //!< px between row origins, must clear KILLFEED_ROW_INNER_HEIGHT
+static const int KILLFEED_ROW_INNER_HEIGHT = 42; //!< the row background's own height
+
+//--- Row geometry, applied by KillFeedUI.LayoutRow(). The row is measured and sized in script
+//--- rather than by a spacer, so the background ends exactly where the text ends.
+static const int KILLFEED_ROW_PAD = 8;          //!< inset at each end of the row
+static const int KILLFEED_ROW_GAP = 10;         //!< space between cells
+static const int KILLFEED_ICON_WIDTH = 24;      //!< cause icon, must match killfeed_row.layout
+
+//--- Weapon cell. ItemPreviewWidget fits the model inside its box preserving aspect, so a fixed
+//--- box leaves dead space whenever the weapon is not as long as the box is wide - a crossbow in a
+//--- 144px cell rendered ~50px and left ~90px of empty background before the victim name.
+//--- The cell is therefore sized per weapon from its config `itemSize[]`, which is the item's
+//--- inventory footprint in grid cells and a good proxy for the model's aspect: rifles are {8,3}
+//--- to {10,3}, SMGs {4,3} to {6,3}, pistols {3,2}.
+static const float KILLFEED_WEAPON_ASPECT = 3.0;  //!< fallback when itemSize is missing
+static const int KILLFEED_WEAPON_MIN_WIDTH = 48;  //!< keeps a tiny item from becoming a smear
+static const int KILLFEED_WEAPON_MAX_WIDTH = 170; //!< keeps a freak config from spanning the row
 
 //--- Icon shown in place of the weapon preview when there is nothing to render. A vanilla imageset
 //--- on purpose: depending on another mod's texture would break the standalone promise.

--- a/Extra/KillFeed/Scripts/3_Game/Server/KillFeedData.c
+++ b/Extra/KillFeed/Scripts/3_Game/Server/KillFeedData.c
@@ -10,11 +10,15 @@
  */
 class KillFeedData
 {
-    int version = 1;
+    int version = 2;
 
     bool enabled = true;                  //!< master switch; false stops the server broadcasting
     bool show_distance = true;            //!< include the metre count on gunshot rows
     bool show_environment_deaths = true;  //!< zone, falls, starvation, infected and animals
+
+    //--- Turn off other mods' kill feeds so a death is not announced twice. Only mods that are
+    //--- actually loaded are touched; see KillFeedSuppress.
+    bool suppress_other_killfeeds = true;
 
     string GetPath()
     {
@@ -43,10 +47,15 @@ class KillFeedData
 
     void Upgrade()
     {
-        //--- No migrations yet. When one is needed: add an `if (version == N)` branch that fills
-        //--- the new fields, set version to N+1, then Save().
-        if (version < 1)
-            version = 1;
+        if (version < 2)
+        {
+            //--- New in v2. Default it on: a server running this addon alongside another kill feed
+            //--- was announcing every death twice, which is the reason the option exists.
+            suppress_other_killfeeds = true;
+
+            version = 2;
+            Save();
+        }
     }
 }
 #endif

--- a/Extra/KillFeed/Scripts/4_World/Server/KillFeedSuppress.c
+++ b/Extra/KillFeed/Scripts/4_World/Server/KillFeedSuppress.c
@@ -1,0 +1,47 @@
+#ifdef SERVER
+/**
+ *  KillFeed - turn off other mods' kill feeds, so a death is announced once rather than twice.
+ *
+ *  Every block here is guarded by the other mod's own define, so the addon still compiles and runs
+ *  on a server where that mod is absent. Nothing is referenced unconditionally.
+ *
+ *  Deliberately flips each mod's *own* documented switch rather than overriding its classes: the
+ *  intent is "leave it configured off", not "break it". Nothing here is persisted - it is an
+ *  in-memory change applied after that mod has loaded its settings from disk, so an admin's own
+ *  JSON is left exactly as they wrote it and removing this addon restores the previous behaviour.
+ */
+class KillFeedSuppress
+{
+    static void Apply()
+    {
+        KillFeedData settings = KillFeedConfig.GetConfig().GetSettings();
+        if (!settings.suppress_other_killfeeds)
+            return;
+
+        SuppressExpansion();
+    }
+
+    /**
+     *  DayZ-Expansion gates its whole kill feed on one setting, checked at both of its hooks in its
+     *  own modded PlayerBase (EEKilled and EEHitBy). Clearing it is therefore complete - the module
+     *  is simply never asked to report anything.
+     *
+     *  EnableKillFeed only exists when Expansion's kill feed addon is loaded, hence the define; the
+     *  field is declared inside the same guard in ExpansionNotificationSettings.
+     */
+    private static void SuppressExpansion()
+    {
+#ifdef EXPANSIONMODKILLFEED
+        ExpansionNotificationSettings notifications = GetExpansionSettings().GetNotification();
+        if (!notifications)
+            return;
+
+        if (!notifications.EnableKillFeed)
+            return;
+
+        notifications.EnableKillFeed = false;
+        KillFeedLog.Info("Disabled the DayZ-Expansion kill feed (EnableKillFeed = false, in memory only)");
+#endif
+    }
+}
+#endif

--- a/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedRowModel.c
+++ b/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedRowModel.c
@@ -14,6 +14,10 @@ class KillFeedRowModel
     //--- Not a ref: an engine-owned Object, released with Delete() rather than by refcount.
     EntityAI preview;
 
+    //--- Width/height of the rendered model, so the row can size its weapon cell to fit rather
+    //--- than reserving a fixed box. Read from the weapon's config; see KILLFEED_WEAPON_ASPECT.
+    float preview_aspect = KILLFEED_WEAPON_ASPECT;
+
     void KillFeedRowModel(KillFeedEntry source_entry)
     {
         entry = source_entry;
@@ -81,6 +85,15 @@ class KillFeedRowModel
 
         weapon.DisableSimulation(true);
         weapon.SetAllowDamage(false);
+
+        //--- itemSize[] is the inventory footprint in grid cells, e.g. {8,3} for an M4A1. Read off
+        //--- the entity rather than by config path so class inheritance resolves.
+        vector item_size = weapon.ConfigGetVector("itemSize");
+        if (item_size[0] > 0 && item_size[1] > 0)
+            preview_aspect = item_size[0] / item_size[1];
+
+        KillFeedLog.Trace(string.Format("Preview %1: itemSize %2x%3, aspect %4",
+            source_entry.weapon_type, item_size[0], item_size[1], preview_aspect));
 
         return weapon;
     }

--- a/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedUI.c
+++ b/Extra/KillFeed/Scripts/5_Mission/Client/KillFeedUI.c
@@ -20,6 +20,7 @@ class KillFeedUI
 
     private ref array<Widget> m_RowWidgets;
     private ref array<TextWidget> m_RowKillers;
+    private ref array<Widget> m_RowMiddles;
     private ref array<ItemPreviewWidget> m_RowWeapons;
     private ref array<ImageWidget> m_RowCauseIcons;
     private ref array<TextWidget> m_RowCauseTexts;
@@ -32,6 +33,7 @@ class KillFeedUI
 
         m_RowWidgets = new array<Widget>();
         m_RowKillers = new array<TextWidget>();
+        m_RowMiddles = new array<Widget>();
         m_RowWeapons = new array<ItemPreviewWidget>();
         m_RowCauseIcons = new array<ImageWidget>();
         m_RowCauseTexts = new array<TextWidget>();
@@ -133,6 +135,7 @@ class KillFeedUI
 
             m_RowWidgets.Insert(row);
             m_RowKillers.Insert(TextWidget.Cast(row.FindAnyWidget("RowKiller")));
+            m_RowMiddles.Insert(row.FindAnyWidget("RowMiddle"));
             m_RowWeapons.Insert(ItemPreviewWidget.Cast(row.FindAnyWidget("RowWeapon")));
             m_RowCauseIcons.Insert(ImageWidget.Cast(row.FindAnyWidget("RowCauseIcon")));
             m_RowCauseTexts.Insert(TextWidget.Cast(row.FindAnyWidget("RowCauseText")));
@@ -220,8 +223,10 @@ class KillFeedUI
                 continue;
             }
 
-            Bind(i, m_Model.Get(i));
+            //--- Show before binding: GetTextSize measures a laid-out widget, and vanilla's own
+            //--- measure sites call Show(true) first (actiontargetscursor.c:1148-1151).
             row.Show(true);
+            Bind(i, m_Model.Get(i));
         }
 
         m_Root.Show(model_count > 0);
@@ -274,6 +279,126 @@ class KillFeedUI
             if (!has_model)
                 cause.SetText(CausePhrase(entry.cause));
         }
+
+        LayoutRow(index, model, has_model);
+    }
+
+    /**
+     *  Place the four cells and shrink the row to fit them.
+     *
+     *  Done in script rather than with a spacer's "Size To Content H": a spacer can only collapse to
+     *  the sum of its children, and these children are fixed-width boxes, so it had nothing to
+     *  collapse to and the background stretched the full declared width.
+     *
+     *  GetTextSize reports the currently set text in pixels and is valid in the same frame as
+     *  SetText - vanilla measures exactly this way in actiontargetscursor.c:1141-1153.
+     */
+    private void LayoutRow(int index, KillFeedRowModel model, bool has_model)
+    {
+        Widget row = m_RowWidgets.Get(index);
+        if (!row)
+            return;
+
+        int x = KILLFEED_ROW_PAD;
+        int text_w;
+        int text_h;
+
+        //--- Killer. A zone death has nobody to credit, so the cell contributes nothing at all
+        //--- rather than an empty gap.
+        TextWidget killer = m_RowKillers.Get(index);
+        if (killer)
+        {
+            //--- Update() before every read-back: the row was only just shown, and a stale layout
+            //--- measures as zero. TabberUI.c:126 and sizetochild.c:35 do the same.
+            killer.Update();
+            killer.GetTextSize(text_w, text_h);
+            killer.Show(text_w > 0);
+
+            if (text_w > 0)
+            {
+                killer.SetPos(x, 0);
+                killer.SetSize(text_w, KILLFEED_ROW_INNER_HEIGHT);
+                x = x + text_w + KILLFEED_ROW_GAP;
+            }
+        }
+
+        //--- Middle cell: the weapon box, or the icon plus its phrase.
+        int middle_w = KILLFEED_ICON_WIDTH;
+        if (has_model)
+        {
+            //--- Match the box to the model's aspect. A fixed box left dead space for anything
+            //--- shorter than it was wide, which is what put a gap before the victim name.
+            float wanted = KILLFEED_ROW_INNER_HEIGHT * model.preview_aspect;
+            middle_w = Math.Round(Math.Clamp(wanted, KILLFEED_WEAPON_MIN_WIDTH, KILLFEED_WEAPON_MAX_WIDTH));
+
+            //--- The preview widget itself defines the render viewport, so it has to be resized
+            //--- too - resizing only its parent panel would leave the model in its old box.
+            ItemPreviewWidget preview = m_RowWeapons.Get(index);
+            if (preview)
+                preview.SetSize(middle_w, KILLFEED_ROW_INNER_HEIGHT);
+        }
+        else
+        {
+            TextWidget cause = m_RowCauseTexts.Get(index);
+            if (cause)
+            {
+                cause.Update();
+                cause.GetTextSize(text_w, text_h);
+                cause.SetPos(KILLFEED_ICON_WIDTH + KILLFEED_ROW_GAP, 0);
+                cause.SetSize(text_w, KILLFEED_ROW_INNER_HEIGHT);
+                middle_w = middle_w + KILLFEED_ROW_GAP + text_w;
+            }
+        }
+
+        Widget middle = m_RowMiddles.Get(index);
+        if (middle)
+        {
+            middle.SetPos(x, 0);
+            middle.SetSize(middle_w, KILLFEED_ROW_INNER_HEIGHT);
+        }
+        x = x + middle_w + KILLFEED_ROW_GAP;
+
+        TextWidget victim = m_RowVictims.Get(index);
+        if (victim)
+        {
+            victim.Update();
+            victim.GetTextSize(text_w, text_h);
+            victim.Show(text_w > 0);
+
+            if (text_w > 0)
+            {
+                victim.SetPos(x, 0);
+                victim.SetSize(text_w, KILLFEED_ROW_INNER_HEIGHT);
+                x = x + text_w + KILLFEED_ROW_GAP;
+            }
+        }
+
+        //--- Distance is blank for melee and for every environmental cause.
+        TextWidget distance = m_RowDistances.Get(index);
+        if (distance)
+        {
+            distance.Update();
+            distance.GetTextSize(text_w, text_h);
+            distance.Show(text_w > 0);
+
+            if (text_w > 0)
+            {
+                distance.SetPos(x, 0);
+                distance.SetSize(text_w, KILLFEED_ROW_INNER_HEIGHT);
+                x = x + text_w + KILLFEED_ROW_GAP;
+            }
+        }
+
+        //--- The trailing gap becomes the right-hand inset.
+        int total = x - KILLFEED_ROW_GAP + KILLFEED_ROW_PAD;
+
+        KillFeedLog.Trace(string.Format("LayoutRow %1: width %2", index, total));
+
+        row.SetSize(total, KILLFEED_ROW_INNER_HEIGHT);
+
+        //--- Re-anchor after the resize. With halign right_ref, x = 0 puts the row's right edge
+        //--- flush against the parent's, whatever its width.
+        row.SetPos(0, index * KILLFEED_ROW_HEIGHT);
     }
 
     /**

--- a/Extra/KillFeed/Scripts/5_Mission/Server/KillFeedMissionServer.c
+++ b/Extra/KillFeed/Scripts/5_Mission/Server/KillFeedMissionServer.c
@@ -15,7 +15,20 @@ modded class MissionServer
         //--- Touching the singleton is what creates the profile folder and writes the file.
         KillFeedConfig.GetConfig();
 
+        KillFeedSuppress.Apply();
+
+        //--- Re-apply once the mission has settled. Another mod's settings may finish loading after
+        //--- this point, which would restore the switch we just cleared; nobody can die in the
+        //--- meantime, so a single late pass is enough.
+        GetGame().GetCallQueue(CALL_CATEGORY_SYSTEM).CallLaterByName(this, "SuppressOtherKillFeeds", 10000, false);
+
         KillFeedLog.Info("KillFeed " + KILLFEED_VERSION + " ready");
+    }
+
+    //! Second pass, see OnInit. Safe to run when nothing needs suppressing - it no-ops.
+    void SuppressOtherKillFeeds()
+    {
+        KillFeedSuppress.Apply();
     }
 }
 #endif


### PR DESCRIPTION
Several passes over the row, all from seeing the feed in game.

Text was washed out. Every TextWidget carried inheritalpha 1, which multiplies
the widget's alpha by its parent's - and the row root is 40% black, so the text
drew at 40% opacity. Vanilla does the opposite wherever text sits on a
translucent panel. Now inheritalpha 0 on every child, an explicit white rather
than leaning on the implicit default, and the vanilla shadow treatment for HUD
text over terrain.

A short name left a wide empty panel. Making the row a WrapSpacer with "Size To
Content H" did not shrink it: with hexactsize 1 the declared size acts as a
MINIMUM the content grows from, not a maximum, and the rigid 144 px weapon cell
sets the same floor. The row root is a plain PanelWidget again, and LayoutRow()
measures the bound text with GetTextSize() and places the four cells itself -
vanilla's own pattern. Cells with nothing to show now contribute nothing, so a
zone death, with no killer and no distance, produces a genuinely short row.

The weapon cell is sized per weapon from the item's config itemSize[], read off
the entity so class inheritance resolves, instead of a fixed 144 px that left
the model filling about a third of it.

KillFeedSuppress turns off other mods' kill feeds so a death is not announced
twice, gated on a new suppress_other_killfeeds setting. Only Expansion is
covered, through its own documented EnableKillFeed switch, checked at both of
its hooks - so clearing it is complete. The write is in memory only, so the
admin's NotificationSettings.json is untouched and removing this addon restores
the previous behaviour.

Squashed from 5 commits:
  61bfa78  Merge branch 'worktree-killfeed-rowsize' - shrink the kill feed row and pin its text size
  743c146  Make kill feed rows hug their text, and readable again
  ef4e426  Make kill feed rows hug their text, and readable again
  48a77ad  Size the kill feed weapon cell to the weapon
  c30766f  Turn off other mods' kill feeds

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 8 of 31 replaying the local history onto `main`.
