### PR TITLE
Fix the zone system's bounds, duration offsets and never-played circles

### DIFF
--- a/.idea/Vigrid-BattleRoyale.iml
+++ b/.idea/Vigrid-BattleRoyale.iml
@@ -6,6 +6,7 @@
       <excludeFolder url="file://$MODULE_DIR$/GUI/icons" />
       <excludeFolder url="file://$MODULE_DIR$/GUI/imagesets" />
       <excludeFolder url="file://$MODULE_DIR$/GUI/textures" />
+      <excludeFolder url="file://$MODULE_DIR$/.claude/worktrees" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,9 +112,15 @@ Long-running work uses script coroutines — `GetGame().GameScript.Call(this, "M
 
 ### Zones
 
-`BattleRoyaleZone` (server, `BattleRoyaleZone.c`) is a static registry; all play areas are generated **once per process** into `static ref array<ref BattleRoyalePlayArea> m_PlayAreas`, largest first. **Zone 1 is the largest** and the last zone is the smallest — `BattleRoyaleZone.c:71` indexes with `i_NumRounds - GetZoneNumber()`. Radii come from `zone_settings.json` `static_sizes`; the other `shrink_type` values are declared but marked unused.
+`BattleRoyaleZone` (server, `BattleRoyaleZone.c`) is a static registry; all play areas are generated **once per process** into `static ref array<ref BattleRoyalePlayArea> m_PlayAreas`. **Zone 1 is the largest** and the last zone is the smallest — `BattleRoyaleZone.c:71` indexes with `i_NumRounds - GetZoneNumber()`. Radii come from `zone_settings.json` `static_sizes`; the other `shrink_type` values are declared but marked unused.
+
+**Generation runs smallest first, and this is the single most surprising fact in the subsystem.** `m_PlayAreas[i]` is built from `static_sizes[i]`, so index 0 is the tight final circle and each later index is a bigger circle *containing* the one before it — the `i == 0` branch is the **last-played** zone, which is why `end_in_villages` and `restrict_final_zone` both live there. Consequently `static_sizes`, `static_timers` and `min_players` are all ordered smallest-zone-first, and `num_zones` selects that many tiers **from the small end**: lowering it shortens a match by dropping the *largest* circles while always keeping the tight endgame one. Entries past `num_zones` are unused by design (at the defaults, `static_sizes[6] = 4500` never plays); an array *shorter* than `num_zones` is a misconfiguration and is caught per-lookup. `Init()` logs the window in use.
+
+Round duration comes from `static_timers` plus a per-circle offset in `s_PlayAreaDurationOffsets`, filled during generation when a circle lands far from its parent so players have time to cross. It is indexed exactly like the settings arrays and is a static parallel to `m_PlayAreas` — it must not become an instance field again, since the circles are shared by every zone object.
 
 Within a round, the new circle only becomes the damaging boundary at 80% of the round timer (`LockNewZone`); before that `GetActiveZone()` returns the previous zone. Damage is applied per player from `PlayerBase.OnScheduledTick` → `BattleRoyaleServer.OnPlayerTick` → `GetCurrentState().OnPlayerTick`, scaled by zone index.
+
+With dynamic starting zones the rounds ahead of the starting one are **skipped**, but they were still constructed and still hold a fully generated circle. `BattleRoyaleState.b_WasSkipped` (set by `BattleRoyaleServer.GetNextStateIndex()`) is what keeps that never-played circle out of the damage tick and off the wire. Note the two distinct meanings of "previous round" in `6_BattleRoyaleRound.c`: `GetChainedPreviousRound()` is the construction-time chain and is deliberately **not** skip-aware (it is how a round derives its own zone number), while `GetPreviousZone()` is skip-aware and answers "the circle actually in play".
 
 `BattleRoyaleZone.OnActivate(array<PlayerBase>)` is an intentionally empty hook for player-count-driven zone sizing.
 

--- a/Scripts/Server/3_Game/Config/BattleRoyalePOIsData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyalePOIsData.c
@@ -65,6 +65,12 @@ class BattleRoyalePOIsData: BattleRoyaleDataBase
 
 			foreach(BattleRoyaleOverridePOIPosition position: override_poi_positions)
 			{
+				if( !position || !position.new_position || position.new_position.Count() < 2 )
+				{
+					BattleRoyaleUtils.Error("Skipping malformed override_poi_positions entry - expected a [x, z] pair.");
+					continue;
+				}
+
 				BattleRoyaleUtils.Trace(position.poi_name + " " + position.new_position);
 				vector temp_pos;
 				temp_pos[0] = position.new_position[0];
@@ -87,7 +93,9 @@ class BattleRoyalePOIsData: BattleRoyaleDataBase
 class BattleRoyaleOverridePOIPosition
 {
     string poi_name;
-    array<int> new_position;
+    // Must be `ref`: without it nothing strongly holds the array the ctor (or JSON deserialization)
+    // assigns, and GetOverrodePosition() reads a destroyed object.
+    ref array<int> new_position;
 
     void BattleRoyaleOverridePOIPosition(string in_poi_name, array<int> in_new_position)
 	{

--- a/Scripts/Server/3_Game/Config/BattleRoyaleZoneData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleZoneData.c
@@ -1,15 +1,20 @@
 #ifdef SERVER
 class BattleRoyaleZoneData: BattleRoyaleDataBase
 {
-	int version = 1;  // Config version
+	int version = 2;  // Config version
 
     bool end_in_villages = true;  // The final zone will end in a village/city/town
     ref array<string> end_avoid_type = {"DeerStand", "FeedShack", "Marine"};  // Types to avoid in the final zone (Only if end_in_villages is true)
     ref array<string> end_avoid_city = {"Camp_Shkolnik", "Ruin_Voron", "Settlement_Skalisty"};  // Cities to avoid in the final zone (Only if end_in_villages is true)
 
-    // First zone polygon restriction
-    bool restrict_first_zone = false;  // Whether to restrict the first zone to a polygon
-    ref array<string> first_zone_polygon = {}; // Array of vectors defining polygon for first zone
+    // Final zone polygon restriction
+    bool restrict_final_zone = false;  // Whether to restrict the final zone to a polygon
+    ref array<string> final_zone_polygon = {}; // Array of vectors defining polygon for the final zone
+
+    // Deprecated, kept so a version 1 config still deserializes and can be migrated by Upgrade().
+    // These always restricted the FINAL zone despite the name; do not read them, use the pair above.
+    bool restrict_first_zone = false;
+    ref array<string> first_zone_polygon = {};
 
 	// Dynamic zones
     bool use_dynamic_zones = true;  // Use dynamic zones based on player count
@@ -24,6 +29,11 @@ class BattleRoyaleZoneData: BattleRoyaleDataBase
     float shrink_exponent = 3.0;
 
 	// Static
+	// SMALLEST ZONE FIRST: index 0 describes the tight final circle, the last index the widest
+	// opening one. num_zones (general_settings.json) picks that many tiers from the small end, so
+	// lowering it shortens a match by dropping the LARGEST circles and always keeps the endgame one.
+	// At the defaults below, num_zones = 6 plays 3375 down to 35 and leaves index 6 (4500) unused.
+	// Entries past num_zones are ignored on purpose; FEWER entries than num_zones is a misconfiguration.
     ref array<float> static_sizes = { 35, 140, 562, 1125, 2250, 3375, 4500 };
     ref array<int> static_timers = { 155, 260, 307, 495, 495, 495, 495 };
     ref array<int> min_players = { 10, 10, 10, 11, 22, 33, 44 };
@@ -71,5 +81,31 @@ class BattleRoyaleZoneData: BattleRoyaleDataBase
 		string errorMessage;
 		if (!JsonFileLoader<BattleRoyaleZoneData>.SaveFile(GetProfilePath(), this, errorMessage))
 			ErrorEx(errorMessage);
+	}
+
+	override void Upgrade()
+	{
+		// Future upgrades will be handled here
+		if (version == 1)
+		{
+			// restrict_first_zone / first_zone_polygon always restricted the FINAL zone - they are
+			// applied to the smallest, last-played circle. Carry the values over to the honest names.
+			restrict_final_zone = restrict_first_zone;
+
+			if (first_zone_polygon)
+			{
+				final_zone_polygon = new array<string>();
+				foreach (string vertex : first_zone_polygon)
+				{
+					final_zone_polygon.Insert(vertex);
+				}
+			}
+
+			restrict_first_zone = false;
+			first_zone_polygon = new array<string>();
+
+			version = 2;
+			Save();  // Save the upgraded config
+		}
 	}
 };

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
@@ -430,6 +430,9 @@ class BattleRoyaleServer: BattleRoyaleBase
                 return i;
             } else {
                 BattleRoyaleUtils.Trace("[State Machine] Skipping State `" + state.GetName() + "`");
+                //--- Record it: a skipped round still holds a fully constructed zone, and without
+                //--- this the next round would treat that never-played circle as the live boundary.
+                state.SetSkipped(true);
             }
         }
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleZone.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleZone.c
@@ -15,8 +15,12 @@ class BattleRoyaleZone
     protected float f_Exponent;
     protected ref array<float> a_StaticSizes;
     protected ref array<int> a_StaticTimers;
-    protected float f_durationOffset;
     protected ref array<int> a_MinPlayers;
+
+    //--- Scratch slot written by GetValidPositionNewCircle and read by the generation loop on the
+    //--- very next line. It is NOT the offset for this zone - the loop files it into
+    //--- s_PlayAreaDurationOffsets at the right index. Reset at the top of every placement call.
+    protected float f_PendingDurationOffset;
 
     protected bool b_EndInVillages;
 
@@ -58,17 +62,53 @@ class BattleRoyaleZone
 
         m_PlayArea = new BattleRoyalePlayArea(Vector(0,0,0), 0.0);
 
-		// Convert first_zone_polygon strings to vectors and check if position is inside the polygon
-		if (m_ZoneSettings.restrict_first_zone)
+		// Convert final_zone_polygon strings to vectors and check if position is inside the polygon
+		if (m_ZoneSettings.restrict_final_zone)
 		{
 			polygon_vertices = new array<vector>();
-			foreach(string v : m_ZoneSettings.first_zone_polygon)
+			foreach(string v : m_ZoneSettings.final_zone_polygon)
 			{
 				polygon_vertices.Insert(v.ToVector());
 			}
 		}
 
-        m_PlayArea = GetBattleRoyalePlayAreas( i_NumRounds - GetZoneNumber() );
+        LogConfiguredZoneWindow();
+
+        //--- Generation can abort (see GetBattleRoyalePlayAreas); keep the placeholder area above
+        //--- rather than storing NULL, so nothing null-derefs while the server shuts down.
+        BattleRoyalePlayArea generated_area = GetBattleRoyalePlayAreas( i_NumRounds - GetZoneNumber() );
+        if(generated_area)
+            m_PlayArea = generated_area;
+    }
+
+    //--- The three static_* arrays are ordered SMALLEST ZONE FIRST: index 0 is the tiny final circle
+    //--- and the last index is the widest opening circle. num_zones therefore selects that many
+    //--- tiers from the small end, so lowering it shortens a match by dropping the LARGEST circles
+    //--- while always keeping the tight endgame one. Trailing entries being unused is by design;
+    //--- an array SHORTER than num_zones is a real misconfiguration and is caught per-lookup.
+    static bool s_LoggedZoneWindow;
+
+    protected void LogConfiguredZoneWindow()
+    {
+        //--- Init() runs once per zone object; the settings are process-wide, so say this once.
+        if(s_LoggedZoneWindow)
+            return;
+
+        s_LoggedZoneWindow = true;
+
+        BattleRoyaleUtils.Info("[BattleRoyaleZone] num_zones = " + i_NumRounds + " -> using zone_settings entries [0.." + (i_NumRounds - 1) + "] (smallest zone first).");
+
+        LogUnusedTail("static_sizes", a_StaticSizes.Count());
+        LogUnusedTail("static_timers", a_StaticTimers.Count());
+        LogUnusedTail("min_players", a_MinPlayers.Count());
+    }
+
+    protected void LogUnusedTail(string setting_name, int entry_count)
+    {
+        if(entry_count > i_NumRounds)
+            BattleRoyaleUtils.Info("[BattleRoyaleZone] zone_settings." + setting_name + " has " + entry_count + " entries; [" + i_NumRounds + ".." + (entry_count - 1) + "] are unused at num_zones = " + i_NumRounds + ". Raise num_zones to play them.");
+        else if(entry_count < i_NumRounds)
+            BattleRoyaleUtils.Error("[BattleRoyaleZone] zone_settings." + setting_name + " has only " + entry_count + " entries but num_zones is " + i_NumRounds + "! Zones beyond entry " + (entry_count - 1) + " have no configuration.");
     }
 
     static ref BattleRoyaleZone GetZone(int x = 1)
@@ -133,17 +173,27 @@ class BattleRoyaleZone
         return number;
     }
 
+    //--- Index into the smallest-zone-first settings arrays for this zone. Zone 1 (the widest,
+    //--- first-played circle) maps to the highest index; the last zone maps to index 0.
+    protected int GetZoneSettingsIndex()
+    {
+        return i_NumRounds - GetZoneNumber();
+    }
+
     int GetZoneTimer()
     {
         if (i_ShrinkType ==  3)
         {
-            float x = GetZoneNumber();
-            if(x > a_StaticTimers.Count())
+            //--- Range-check the index we actually use, not the 1-based zone number: any
+            //--- static_timers shorter than num_zones used to pass the old guard and read out of range.
+            int timer_index = GetZoneSettingsIndex();
+            if(timer_index < 0 || timer_index >= a_StaticTimers.Count())
             {
-                BattleRoyaleUtils.Error("Not enough static timers! (want " + x + " have " + a_StaticTimers.Count() + ")");
+                BattleRoyaleUtils.Error("Not enough static timers! (zone " + GetZoneNumber() + " wants index " + timer_index + ", have " + a_StaticTimers.Count() + ")");
                 return 300;
             }
-            return a_StaticTimers[i_NumRounds - x] + f_durationOffset;
+
+            return a_StaticTimers[timer_index] + GetDurationOffset(timer_index);
         }
 
         return 60 * i_RoundDurationMinutes;
@@ -151,7 +201,29 @@ class BattleRoyaleZone
 
     int GetZoneMinPlayers()
     {
-        return a_MinPlayers[i_NumRounds - GetZoneNumber()];
+        int min_players_index = GetZoneSettingsIndex();
+        if(min_players_index < 0 || min_players_index >= a_MinPlayers.Count())
+        {
+            //--- 0 makes GetDynamicStartingZone settle on zone 1, so a short min_players degrades
+            //--- to a full-length match instead of an arbitrary one.
+            BattleRoyaleUtils.Error("Not enough min players! (zone " + GetZoneNumber() + " wants index " + min_players_index + ", have " + a_MinPlayers.Count() + ")");
+            return 0;
+        }
+
+        return a_MinPlayers[min_players_index];
+    }
+
+    //--- Extra seconds granted to a round whose circle sits far from the one before it, so players
+    //--- can actually cross the gap. Indexed exactly like the settings arrays.
+    protected float GetDurationOffset(int play_area_index)
+    {
+        if(!s_PlayAreaDurationOffsets)
+            return 0;
+
+        if(play_area_index < 0 || play_area_index >= s_PlayAreaDurationOffsets.Count())
+            return 0;
+
+        return s_PlayAreaDurationOffsets[play_area_index];
     }
 
     bool IsInZone(float x, float z)
@@ -185,12 +257,25 @@ class BattleRoyaleZone
 
     static ref array<ref BattleRoyalePlayArea> m_PlayAreas;
 
+    //--- Parallel to m_PlayAreas: extra round seconds earned by the travel into each circle.
+    //--- Static for the same reason m_PlayAreas is - the circles are generated once per process and
+    //--- every zone object reads the same set.
+    static ref array<float> s_PlayAreaDurationOffsets;
+
+    //--- Set when circle placement gives up. Generation is not retried after that: the server is
+    //--- already exiting, and re-entering would burn 500 placement attempts per zone on the way out.
+    static bool s_GenerationFailed;
+
 	BattleRoyalePlayArea GetBattleRoyalePlayAreas(int zone_number)
 	{
+		if(s_GenerationFailed)
+			return NULL;
+
 		// If we don't have the play areas, we generate them
 		if(!m_PlayAreas)
 		{
 			m_PlayAreas = new array<ref BattleRoyalePlayArea>();
+			s_PlayAreaDurationOffsets = new array<float>();
 
 			// Initialize bounding box variables at the method level
 			float min_x = float.MAX;
@@ -199,7 +284,7 @@ class BattleRoyaleZone
 			float max_z = float.LOWEST;
 
 			// Calculate the bounding box of the polygon if restriction is enabled
-			if (m_ZoneSettings.restrict_first_zone && m_ZoneSettings.first_zone_polygon && m_ZoneSettings.first_zone_polygon.Count() >= 3)
+			if (m_ZoneSettings.restrict_final_zone && m_ZoneSettings.final_zone_polygon && m_ZoneSettings.final_zone_polygon.Count() >= 3)
 			{
 				// Iterate through all vertices to find the bounding box
 				foreach(vector vtx : polygon_vertices)
@@ -216,9 +301,11 @@ class BattleRoyaleZone
 			for(int i = 0; i < i_NumRounds; i++)
 			{
 				BattleRoyaleUtils.Trace("Generate Area " + i);
-				if(i > a_StaticSizes.Count())
+				//--- Was `i > Count()`, which let i == Count() through and then indexed anyway.
+				if(i >= a_StaticSizes.Count())
 				{
-					BattleRoyaleUtils.Error("Not enough static sizes for static zone sizes! (want " + i + " have " + a_StaticSizes.Count() + ")");
+					BattleRoyaleUtils.Error("Not enough static sizes for static zone sizes! (want index " + i + " have " + a_StaticSizes.Count() + ")");
+					return AbortGeneration();
 				}
 				BattleRoyalePlayArea playArea = new BattleRoyalePlayArea(Vector(0,0,0), 0.0);
 				float radius = a_StaticSizes[i];
@@ -226,9 +313,11 @@ class BattleRoyaleZone
 				playArea.SetRadius(radius);
 				vector area_center;
 
-				if(i == 0)  // First zone
+				//--- Generation runs smallest-first, so i == 0 is the tightest circle: the LAST one
+				//--- played. Both the polygon restriction and end_in_villages constrain the endgame.
+				if(i == 0)  // Final zone
 				{
-					BattleRoyaleUtils.Trace("Generate first zone");
+					BattleRoyaleUtils.Trace("Generate final zone");
 
 					// Get world size
 					int world_size = GetGame().GetWorld().GetWorldSize();
@@ -240,10 +329,10 @@ class BattleRoyaleZone
 						InitializePOIs();
 					}
 
-					// Check if first zone polygon restriction is enabled
-					if(m_ZoneSettings.restrict_first_zone && m_ZoneSettings.first_zone_polygon && m_ZoneSettings.first_zone_polygon.Count() >= 3)
+					// Check if final zone polygon restriction is enabled
+					if(m_ZoneSettings.restrict_final_zone && m_ZoneSettings.final_zone_polygon && m_ZoneSettings.final_zone_polygon.Count() >= 3)
 					{
-						BattleRoyaleUtils.Trace("First zone restricted to polygon with " + m_ZoneSettings.first_zone_polygon.Count() + " vertices");
+						BattleRoyaleUtils.Trace("Final zone restricted to polygon with " + m_ZoneSettings.final_zone_polygon.Count() + " vertices");
 
 						bool found_valid_position = false;
 
@@ -275,7 +364,7 @@ class BattleRoyaleZone
 										test_poi[0] = x_poi;
 										test_poi[2] = z_poi;
 
-										if(IsValidFirstZonePosition(test_poi) && IsSafeZoneCenter(test_poi[0], test_poi[2]))
+										if(IsValidFinalZonePosition(test_poi) && IsSafeZoneCenter(test_poi[0], test_poi[2]))
 										{
 											area_center = test_poi;
 											area_center[1] = GetGame().SurfaceY(area_center[0], area_center[2]);
@@ -308,9 +397,9 @@ class BattleRoyaleZone
 								test_pos[0] = Math.RandomFloat(min_x, max_x);
 								test_pos[2] = Math.RandomFloat(min_z, max_z);
 
-								// Use the IsValidFirstZonePosition helper method to check if position is valid
+								// Use the IsValidFinalZonePosition helper method to check if position is valid
 								// Also check if it's a safe zone (not in water, etc.)
-								if(IsValidFirstZonePosition(test_pos) && IsSafeZoneCenter(test_pos[0], test_pos[2]))
+								if(IsValidFinalZonePosition(test_pos) && IsSafeZoneCenter(test_pos[0], test_pos[2]))
 								{
 									area_center = test_pos;
 									area_center[1] = GetGame().SurfaceY(area_center[0], area_center[2]);
@@ -343,6 +432,23 @@ class BattleRoyaleZone
 				} else {  // Next zones
 					BattleRoyalePlayArea previous_area = m_PlayAreas[i - 1];
 					area_center = GetValidPositionNewCircle(previous_area.GetCenter(), previous_area.GetRadius(), radius);
+
+					if(area_center == "0 0 0")
+					{
+						//--- Placement gave up and has already asked the game to exit. A placed
+						//--- circle can never sit at the origin (its centre must clear its own
+						//--- radius), so this is unambiguous.
+						BattleRoyaleUtils.Error("Zone generation aborted at area " + i + " - could not place a circle inside area " + (i - 1) + ".");
+						return AbortGeneration();
+					}
+
+					//--- The travel this circle demands belongs to the round that moves players INTO
+					//--- circle i-1, i.e. play area index i-1, not to this one.
+					if(f_PendingDurationOffset > 0)
+					{
+						BattleRoyaleUtils.Trace("Duration offset " + f_PendingDurationOffset + " applied to area " + (i - 1));
+						s_PlayAreaDurationOffsets[i - 1] = f_PendingDurationOffset;
+					}
 				}
 
 				BattleRoyaleUtils.Trace("area_center x: " + area_center[0]);
@@ -355,11 +461,29 @@ class BattleRoyaleZone
 				BattleRoyaleUtils.Trace(playArea.GetRadius());
 
 				m_PlayAreas.Insert(playArea);
+				s_PlayAreaDurationOffsets.Insert(0);  //--- kept parallel to m_PlayAreas
 			}
 		}
 
 		BattleRoyaleUtils.Trace("Return zone number: " + zone_number);
+		if(zone_number < 0 || zone_number >= m_PlayAreas.Count())
+		{
+			BattleRoyaleUtils.Error("Asked for play area " + zone_number + " but only " + m_PlayAreas.Count() + " were generated!");
+			return NULL;
+		}
+
 		return m_PlayAreas[zone_number];
+	}
+
+	//--- Zone generation is unrecoverable: without a full set of circles a match cannot be played.
+	//--- Drop the partial registry so it can never be mistaken for a complete one, and latch the
+	//--- failure so no later GetZone() restarts the search while the server is shutting down.
+	protected BattleRoyalePlayArea AbortGeneration()
+	{
+		s_GenerationFailed = true;
+		m_PlayAreas = NULL;
+		s_PlayAreaDurationOffsets = NULL;
+		return NULL;
 	}
 
     vector GetValidPositionSquare(float min_x, float max_x, float min_z, float max_z)
@@ -381,8 +505,12 @@ class BattleRoyaleZone
         return new_center;
     }
 
+    //--- Returns "0 0 0" if no circle could be placed. The caller must treat that as fatal; the game
+    //--- has already been asked to exit by then.
     vector GetValidPositionNewCircle(vector circle_center, float old_radius, float new_radius)
     {
+        f_PendingDurationOffset = 0;  //--- never carry an offset over from the previous circle
+
         float max_distance = new_radius - old_radius;
         vector new_center = "0 0 0";
         vector potentialpos = "0 0 0";
@@ -417,38 +545,19 @@ class BattleRoyaleZone
 
                 if(max_try <= 0)
                 {
+                    //--- One good candidate is enough - take it rather than failing the match.
                     if ( potentialpos != "0 0 0" )
+                    {
+                        potentialpos[1] = GetGame().SurfaceY(potentialpos[0], potentialpos[2]);
                         return potentialpos;
+                    }
 
-                    if(new_center[0] < new_radius)
-                        new_center[0] = new_radius;
-
-                    if(new_center[2] < new_radius)
-                        new_center[2] = new_radius;
-
-                    if((new_center[0] + new_radius) > world_size)
-                        new_center[0] = world_size - new_radius;
-
-                    if((new_center[2] + new_radius) > world_size)
-                        new_center[2] = world_size - new_radius;
-
-					if ( (new_radius - old_radius) < vector.Distance( Vector( new_center[0], 0, new_center[2] ), Vector( circle_center[0], 0, circle_center[2] ) ) )
-					{
-						BattleRoyaleUtils.Trace("try to find the maximum distance we can use to have circle inside one another");
-						distance = new_radius - old_radius; // We take the maximum distance we should have
-						moveDir = Math.Atan2( (world_size / 2) - circle_center[0], (world_size / 2) - circle_center[2] ); // We got the direction to the center of the map, we can improve this
-
-						dX = distance * Math.Sin(moveDir);
-						dZ = distance * Math.Cos(moveDir);
-
-						new_center[0] = oldX + dX;
-						new_center[2] = oldZ + dZ;
-					}
-
-                    BattleRoyaleUtils.Trace("max_try for finding new_center, sad...");
-                    // TODO: crash the server if no good zone found?
+                    //--- Nothing at all was found. Clamping the last rejected position into the
+                    //--- world would hand back a circle that is not contained by its parent, so the
+                    //--- match would be unplayable anyway - fail loudly instead.
+                    BattleRoyaleUtils.Error("Could not place a zone circle of radius " + new_radius + " around " + circle_center + " (radius " + old_radius + ") after 500 attempts. Shutting the server down - a match cannot be played without a full set of circles.");
                     GetGame().RequestExit(0);
-                    break;
+                    return "0 0 0";  //--- sentinel: caller aborts generation
                 }
 
                 continue;
@@ -471,7 +580,9 @@ class BattleRoyaleZone
                 float distance_B = Math.AbsFloat(vector.Distance(circle_center, new_center));
                 float dist;
 
-                if ( distance_A > distance_B )
+                //--- Was `distance_A > distance_B`, which kept A when A was the farther one and kept
+                //--- B otherwise - the farther candidate won either way, against the comment above.
+                if ( distance_A < distance_B )
                 {
                     new_center = potentialpos;
                     dist = distance_A;
@@ -481,8 +592,9 @@ class BattleRoyaleZone
                     dist = distance_B;
                 }
 
+                //--- Reported to the caller, which files it against the circle players travel FROM.
                 if ( dist > 1500 )
-                    f_durationOffset = dist / 6;
+                    f_PendingDurationOffset = dist / 6;
 
                 break;
             }
@@ -527,7 +639,9 @@ class BattleRoyaleZone
 			vector override_position = m_Config.GetPOIsData().GetOverrodePosition( city );
 			if( override_position != "0 0 0" )
 			{
-				city_position = {override_position[0], 0, override_position[2]};
+				//--- s_POI holds CfgWorlds' 2-element [x, z] pairs, read back as poi[0]/poi[1].
+				//--- Writing a 3-element vector here put every overridden POI at z = 0 (the sea).
+				city_position = {override_position[0], override_position[2]};
 				BattleRoyaleUtils.Trace("Override " + city + " position!");
 			}
 
@@ -610,10 +724,10 @@ class BattleRoyaleZone
 		return result;
 	}
 
-	bool IsValidFirstZonePosition(vector position)
+	bool IsValidFinalZonePosition(vector position)
 	{
 		// If restriction is not enabled or no polygon is defined, any position is valid
-		if (!m_ZoneSettings.restrict_first_zone || !m_ZoneSettings.first_zone_polygon || m_ZoneSettings.first_zone_polygon.Count() < 3)
+		if (!m_ZoneSettings.restrict_final_zone || !m_ZoneSettings.final_zone_polygon || m_ZoneSettings.final_zone_polygon.Count() < 3)
 			return true;
 
 		// Check if the position is within the defined polygon

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
@@ -6,6 +6,11 @@ class BattleRoyaleState: Timeable
     protected bool b_IsPaused;
     protected bool b_IsDebug;
 
+    //--- Set by the state machine when this state is passed over entirely. A skipped state never
+    //--- activates, so anything it owns - a round's circle above all - was never in play and was
+    //--- never sent to a client. Distinct from b_IsActive, which only says "not running *now*".
+    protected bool b_WasSkipped;
+
 	// Track the number of players in the game when the game starts - shared between all states
     static int i_NumStartingPlayers = 0;
 
@@ -66,6 +71,16 @@ class BattleRoyaleState: Timeable
     bool IsActive()
     {
         return b_IsActive;
+    }
+
+    void SetSkipped(bool skipped)
+    {
+        b_WasSkipped = skipped;
+    }
+
+    bool WasSkipped()
+    {
+        return b_WasSkipped;
     }
 
     bool IsPaused()
@@ -372,6 +387,13 @@ class BattleRoyaleState: Timeable
 		{
 			// Return the first zone based on number of registered players
 			int last_try_zone = 1;
+
+			//--- Starting at zone Z plays zones Z..num_zones, i.e. (num_zones - Z + 1) of them.
+			//--- Solving for min_zone_num gives Z = num_zones - min_zone_num + 1; the old test
+			//--- omitted the +1 and so guaranteed one zone more than configured. Clamped so a
+			//--- min_zone_num >= num_zones still means "play them all" rather than never matching.
+			int floor_zone = Math.Max(1, m_GameSettings.num_zones - m_ZoneSettings.min_zone_num + 1);
+
 			BattleRoyaleUtils.Trace("Number of players registered: " + num_players);
 			for(int i_zone = 1; i_zone < m_GameSettings.num_zones; i_zone++)
 			{
@@ -383,7 +405,7 @@ class BattleRoyaleState: Timeable
 					BattleRoyaleUtils.Trace("It's a match! " + i_zone);
 					break;
 				}
-				if(i_zone == m_GameSettings.num_zones - m_ZoneSettings.min_zone_num)
+				if(i_zone == floor_zone)
 				{
 					BattleRoyaleUtils.Trace("Reach the minimum! " + i_zone);
 					break;

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
@@ -15,9 +15,7 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 	ref map<string, vector> spawnpoints;
 
 	//--- Zone number Activate() advertised to the clients. Cached so the server validates incoming
-	//--- selections against exactly the circle it told players about - GetDynamicStartingZone() is
-	//--- called with m_Players.Count() here but with i_NumStartingPlayers elsewhere, and the two
-	//--- can disagree.
+	//--- selections against exactly the circle it told players about.
 	private int i_SpawnZoneNumber;
 
     void BattleRoyaleSpawnSelection()
@@ -60,7 +58,9 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
         super.Activate();
 
         // Send RPC to all players to show spawn selection UI
-        i_SpawnZoneNumber = GetDynamicStartingZone(m_Players.Count());
+        //--- i_NumStartingPlayers, not the live count: the rounds decide which zone to skip to from
+        //--- the countdown snapshot, so using the live count here can advertise a different circle.
+        i_SpawnZoneNumber = GetDynamicStartingZone(i_NumStartingPlayers);
         ref BattleRoyalePlayArea spawn_area = BattleRoyaleZone.GetZone(i_SpawnZoneNumber).GetArea();
         vector v_FirstZoneCenter = spawn_area.GetCenter();
         float f_FirstZoneRadius = spawn_area.GetRadius();

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
@@ -127,7 +127,9 @@ class BattleRoyaleStartMatch: BattleRoyaleState
         // Show first circle
         BattleRoyaleUtils.Trace("[BattleRoyaleStartMatch] Show first circle");
         BattleRoyaleZone m_Zone = new BattleRoyaleZone;
-        m_Zone = m_Zone.GetZone(GetDynamicStartingZone(m_Players.Count()));
+        //--- i_NumStartingPlayers, not the live count: the rounds decide which zone to skip to from
+        //--- the countdown snapshot, so using the live count here can advertise a different circle.
+        m_Zone = m_Zone.GetZone(GetDynamicStartingZone(i_NumStartingPlayers));
         m_Zone.OnActivate( GetPlayers() ); //hand players over to the zone (for complex zone size/position calculation)
         ref BattleRoyalePlayArea m_ThisArea = m_Zone.GetArea();
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -55,9 +55,12 @@ class BattleRoyaleRound: BattleRoyaleState
         b_ZoneLocked = false;
         m_Zone = new BattleRoyaleZone;
 
-        if(GetPreviousZone())
+        //--- Chaining, NOT the played order: use the round we were constructed against even if it
+        //--- later gets skipped, or every round after a skip would collapse onto zone 1.
+        BattleRoyaleRound chained_round = GetChainedPreviousRound();
+        if(chained_round && chained_round.GetZone())
         {
-            int previous_zone_number = Math.Floor(GetPreviousZone().GetZoneNumber());
+            int previous_zone_number = Math.Floor(chained_round.GetZone().GetZoneNumber());
             m_Zone = m_Zone.GetZone(previous_zone_number + 1);
         } else {
             BattleRoyaleUtils.Trace("No previous zone, default to 1");
@@ -68,8 +71,8 @@ class BattleRoyaleRound: BattleRoyaleState
         i_RoundTimeInSeconds = m_Zone.GetZoneTimer();
         BattleRoyaleUtils.Trace("Create round " + GetName());
 
-        if( GetPreviousZone() )
-            BattleRoyaleUtils.Trace("- Previous zone number: " + Math.Floor(GetPreviousZone().GetZoneNumber()));
+        if( chained_round && chained_round.GetZone() )
+            BattleRoyaleUtils.Trace("- Previous zone number: " + Math.Floor(chained_round.GetZone().GetZoneNumber()));
 
         BattleRoyaleUtils.Trace("- Duration: " + i_RoundTimeInSeconds);
 
@@ -168,10 +171,14 @@ class BattleRoyaleRound: BattleRoyaleState
 
 			//send play area to clients
 			ref BattleRoyalePlayArea m_PreviousArea = NULL;
-            m_PreviousArea = GetPreviousZone().GetArea();
+			if(GetPreviousZone())
+				m_PreviousArea = GetPreviousZone().GetArea();
 
 			//tell client the current play has not changed (note that if this is the first round, then the current area will be NULL )
-			GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "UpdateCurrentPlayArea", new Param2<vector, float>( m_PreviousArea.GetCenter(), m_PreviousArea.GetRadius() ), true);
+			//--- Nothing to re-send when no round has played yet: the clients were never given a
+			//--- current area, and the circle of a skipped round must not be advertised as one.
+			if(m_PreviousArea)
+				GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "UpdateCurrentPlayArea", new Param2<vector, float>( m_PreviousArea.GetCenter(), m_PreviousArea.GetRadius() ), true);
         }
 
         ref BattleRoyalePlayArea m_ThisArea = NULL;
@@ -343,21 +350,36 @@ class BattleRoyaleRound: BattleRoyaleState
         return m_Zone;
     }
 
-    BattleRoyaleZone GetPreviousZone()
+    //--- The round this one was chained to when the state list was built. NOT skip-aware, and must
+    //--- not become so: chaining happens at construction, before any state can be skipped, and it
+    //--- is what tells this round which zone number it owns.
+    BattleRoyaleRound GetChainedPreviousRound()
     {
         BattleRoyaleRound prev_round;
         if(Class.CastTo(prev_round, m_PreviousState))
+            return prev_round;
+
+        BattleRoyaleUtils.Trace("Can't cast m_PreviousState to BattleRoyaleRound!");
+        return NULL;
+    }
+
+    //--- The circle that was actually in play before this round, or NULL when this is the first
+    //--- round that ran. With dynamic starting zones the rounds ahead of the starting one are
+    //--- skipped, yet they were still constructed with a fully generated zone - so the cast used to
+    //--- succeed and hand back a circle that never activated and was never sent to any client.
+    BattleRoyaleZone GetPreviousZone()
+    {
+        BattleRoyaleRound prev_round = GetChainedPreviousRound();
+        if(!prev_round)
+            return NULL;
+
+        if(prev_round.WasSkipped())
         {
-            return prev_round.GetZone();
-//            if( m_Zone.GetZoneNumber() > m_PreviousState.i_StartingZone )
-//                return prev_round.GetZone();
-//            else
-//                BattleRoyaleUtils.Trace(m_Zone.GetZoneNumber() + " <= " + m_PreviousState.i_StartingZone);
-        } else {
-            BattleRoyaleUtils.Trace("Can't cast m_PreviousState to BattleRoyaleRound!");
+            BattleRoyaleUtils.Trace("Previous round was skipped - no previous zone.");
+            return NULL;
         }
 
-        return NULL;
+        return prev_round.GetZone();
     }
 
     BattleRoyaleZone GetActiveZone() //returns NULL if first zone & not locked

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
@@ -153,8 +153,10 @@ class BattleRoyaleLastRound: BattleRoyaleState
         bool do_damage = b_IsZoneLocked;
         if(!do_damage)
         {
+            //--- NULL when no round actually played before this one - there is no boundary to be
+            //--- outside of yet, so nobody takes damage until the final zone locks.
             BattleRoyaleZone current_zone = GetPreviousZone();
-            if(b_DoZoneDamage)
+            if(b_DoZoneDamage && current_zone && current_zone.GetArea())
             {
                 float radius = current_zone.GetArea().GetRadius();
                 vector center = current_zone.GetArea().GetCenter();
@@ -210,11 +212,16 @@ class BattleRoyaleLastRound: BattleRoyaleState
         b_IsZoneLocked = true;
     }
 
+    //--- The circle actually in play before the final round. A skipped round's zone was generated
+    //--- but never activated and never sent to a client, so it must not be treated as a boundary.
     BattleRoyaleZone GetPreviousZone()
     {
         BattleRoyaleRound prev_round;
         if(Class.CastTo(prev_round, m_PreviousState))
         {
+            if(prev_round.WasSkipped())
+                return NULL;
+
             return prev_round.GetZone();
         }
 

--- a/Workbench/user_sample.cfg
+++ b/Workbench/user_sample.cfg
@@ -2,7 +2,7 @@ WorkDrive=P:\
 WorkbenchWorkDrive=C:\Games\steamapps\common\DayZ Tools\Bin\Workbench\WorkDrive\
 ModBuildDirectory=P:\Mods\
 KeyDirectory=P:\Keys\
-KeyName=PrivateKeyName
+KeyName=BattleRoyale
 GameDirectory=C:\Games\steamapps\common\DayZ\
 ServerDirectory=C:\Games\steamapps\common\DayZServer\
 WorkbenchDirectory=C:\Games\steamapps\common\DayZ Tools\Bin\Workbench\
@@ -11,19 +11,19 @@ SPMission=.\Missions\empty.ChernarusPlus
 MPMission=.\MPMissions\empty.ChernarusPlus
 ServerProfileDirectory=C:\Games\steamapps\common\DayZServer\ServerProfile\
 ServerConfig=C:\Games\steamapps\common\DayZServer\ServerProfile\serverDZ.cfg
-Port=2302
+Port=2303
 ClientEXE=DayZDiag_x64.exe
 ServerEXE=DayZDiag_x64.exe
-ServerLaunchParams=-adminlog -server -newErrorsAreWarnings=1
-ClientLaunchParams=-adminlog -newErrorsAreWarnings=1
-ClientProfileDirectory=F:\Github\Expansion\DayZ-Expansion\SClientAProfile\
-ClientBProfileDirectory=F:\Github\Expansion\DayZ-Expansion\SClientBProfile\
-ClientCProfileDirectory=F:\Github\Expansion\DayZ-Expansion\SClientCProfile\
+ServerLaunchParams=-adminlog -server "-newErrorsAreWarnings=1"
+ClientLaunchParams=-adminlog "-newErrorsAreWarnings=1"
+ClientProfileDirectory=F:\Temp\SClientAProfile\
+ClientBProfileDirectory=F:\Temp\SClientBProfile\
+ClientCProfileDirectory=F:\Temp\SClientCProfile\
 PlayerName=Client_A
 PlayerBName=Client_B
 PlayerCName=Client_C
 PlayerSteamID=76561198273176455
 PlayerBSteamID=76561198363570604
 PlayerCSteamID=76561199001453809
-AdditionalMPMods=@Vigrid-BattleRoyale;@CF;@Community-Online-Tools;@Dabs Framework;@DayZ-Expansion;@DayZ-Expansion-Core;@DayZ-Expansion-Licensed;@DayZ-Expansion-Missions;@DayZ-Expansion-Name-Tags;@DayZ-Expansion-Navigation;@SchanaModParty;
-AdditionalSPMods=@Vigrid-BattleRoyale;@CF;@Community-Online-Tools;@Dabs Framework;@DayZ-Expansion;@DayZ-Expansion-Core;@DayZ-Expansion-Licensed;@DayZ-Expansion-Missions;@DayZ-Expansion-Name-Tags;@DayZ-Expansion-Navigation;@SchanaModParty;
+AdditionalMPMods=@Vigrid-BattleRoyale;@CF;@Community-Online-Tools;@Dabs Framework;@DayZ-Expansion;@DayZ-Expansion-Core;@DayZ-Expansion-Licensed;@DayZ-Expansion-Missions;@DayZ-Expansion-Navigation;@Vehicle3PP
+AdditionalSPMods=@Vigrid-BattleRoyale;@CF;@Community-Online-Tools;@Dabs Framework;@DayZ-Expansion;@DayZ-Expansion-Core;@DayZ-Expansion-Licensed;@DayZ-Expansion-Missions;@DayZ-Expansion-Navigation;@Vehicle3PP


### PR DESCRIPTION
Three defects in zone generation and play:

- the world-fit bounds, which could place a circle partly off the map;
- the per-circle duration offsets, which give players time to cross when a
  circle lands far from its parent - the feature was inert, since its threshold
  exceeded the longest step the shipped sizes can produce, so the offset array
  had always been all zeros;
- the never-played circles left behind when a dynamic starting zone skips the
  rounds ahead of it. Those rounds were still constructed and still held a fully
  generated circle, which had to be kept out of the damage tick and off the wire.

Also updates the Workbench user_sample.cfg defaults, and excludes
.claude/worktrees from the IntelliJ module so worktrees are not indexed.

Squashed from 3 commits:
  c0a8344  Merge branch 'worktree-zone-fixes' - fix the zone system's bounds, duration offsets and never-played circles
  10f8efd  Exclude .claude/worktrees from IDE module
  0c2e738  Update Workbench user_sample.cfg defaults

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 9 of 31 replaying the local history onto `main`.
