### PR TITLE
Make the config layer idempotent, and stop it halting the script VM

### DIFF
--- a/Scripts/Server/3_Game/Config/BattleRoyaleConfig.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleConfig.c
@@ -4,11 +4,13 @@ class BattleRoyaleConfig
 	static ref BattleRoyaleConfig m_Instance;
 	ref map<string, ref BattleRoyaleDataBase> m_Configs;
 	//ref array<string> m_ConfigNames;
-	bool b_HasLoaded;
+	bool b_HasLoaded;  // set only once Load() has actually completed - see Load()
+	bool b_IsLoading;  // re-entrancy guard while Load() is in flight
 
 	void BattleRoyaleConfig()
 	{
 		b_HasLoaded = false;
+		b_IsLoading = false;
 		m_Configs = new map<string, ref BattleRoyaleDataBase>();
 		Init();
 	}
@@ -70,72 +72,89 @@ class BattleRoyaleConfig
 
 	void Load()
 	{
-		if ( !b_HasLoaded )
+		//--- b_HasLoaded means "a load COMPLETED", not "a load was attempted". It used to be set as the
+		//--- very first statement here, which made the !b_HasLoaded guard in GetConfig(string) unable to
+		//--- detect an aborted load - the early-out below left the singleton flagged loaded with zero
+		//--- configs and every accessor silently returning NULL. b_IsLoading takes over the re-entrancy
+		//--- job that flag-first assignment was doing.
+		if ( b_HasLoaded || b_IsLoading )
+			return;
+
+		b_IsLoading = true;
+
+		//load JSON data (or create it)
+		if( !FileExist(BATTLEROYALE_SETTINGS_FOLDER) )
 		{
-			b_HasLoaded = true;
+			BattleRoyaleUtils.Trace("Creating BattleRoyale Settings Folder");
+			MakeDirectory(BATTLEROYALE_SETTINGS_FOLDER);
+		}
 
-			//load JSON data (or create it)
-			if( !FileExist(BATTLEROYALE_SETTINGS_FOLDER) )
-			{
-				BattleRoyaleUtils.Trace("Creating BattleRoyale Settings Folder");
-				MakeDirectory(BATTLEROYALE_SETTINGS_FOLDER);
-			}
+		if( !FileExist(BATTLEROYALE_SETTINGS_MISSION_FOLDER) )
+		{
+			Print("Creating BattleRoyale Mission Settings Folder");
+			MakeDirectory(BATTLEROYALE_SETTINGS_MISSION_FOLDER);
+		}
 
-			if( !FileExist(BATTLEROYALE_SETTINGS_MISSION_FOLDER) )
-			{
-				Print("Creating BattleRoyale Mission Settings Folder");
-				MakeDirectory(BATTLEROYALE_SETTINGS_MISSION_FOLDER);
-			}
+		if(!m_Configs)
+		{
+			//--- Kept Warn + return rather than the old fatal Error(): m_Configs is built in the ctor
+			//--- and never cleared, so this is a can't-happen guard, and the useful behaviour if it ever
+			//--- did happen is to leave b_HasLoaded false and let GetConfig(string) report it - which a
+			//--- VM-halting Error() would make unreachable, since the return below would never run.
+			BattleRoyaleUtils.Warn("FAILED TO LOAD CONFIG DATA - m_Configs is NULL");
+			b_IsLoading = false;
+			return;  //--- deliberately leaves b_HasLoaded false so the failure stays detectable
+		}
 
-			if(!m_Configs)
+		//iterate over internal data in the dictionary
+		for(int i = 0; i < m_Configs.Count(); i++)
+		{
+			string key = m_Configs.GetKey(i);
+			BattleRoyaleDataBase config = m_Configs.GetElement(i);
+			if(config)
 			{
-				Error("FAILED TO LOAD CONFIG DATA");
-				return;
-			}
-
-			//iterate over internal data in the dictionary
-			for(int i = 0; i < m_Configs.Count(); i++)
-			{
-				string key = m_Configs.GetKey(i);
-				BattleRoyaleDataBase config = m_Configs.GetElement(i);
-				if(config)
+				string path = config.GetProfilePath();
+				if(path != "")
 				{
-					string path = config.GetProfilePath();
-					if(path != "")
+					if(FileExist( path ))
 					{
-						if(FileExist( path ))
-						{
-							BattleRoyaleUtils.Trace("Loading Config: " + path);
-							config.Load();
-							config.Save(); //re-save (if there are new config values that need added to the json file)
-						}
-						else
-						{
-							BattleRoyaleUtils.Trace("Creating Config: " + path);
-							config.Save();
-						}
+						BattleRoyaleUtils.Trace("Loading Config: " + path);
+						config.Load();
+						config.Save(); //re-save (if there are new config values that need added to the json file)
 					}
 					else
 					{
-						Error("Config with invalid path in BattleRoyale Configs");
-					}
-
-					string mission_path = config.GetMissionPath();
-					if(mission_path != "")
-					{
-						if(FileExist( mission_path ))
-						{
-							BattleRoyaleUtils.Trace("Loading Mission Config: " + mission_path);
-							config.LoadMission();
-						}
+						BattleRoyaleUtils.Trace("Creating Config: " + path);
+						config.Save();
 					}
 				}
 				else
 				{
-					Error("NULL CONFIG `" + key + "` IN CONFIG MAP");
+					//--- Warn, not Error: the global Error() is Error2() (endebug.c:90), which raises a
+					//--- VM exception and stops the script VM - it would take the server down over one
+					//--- misdeclared data class instead of skipping it and loading the other five.
+					BattleRoyaleUtils.Warn("Config with invalid path in BattleRoyale Configs");
+				}
+
+				string mission_path = config.GetMissionPath();
+				if(mission_path != "")
+				{
+					if(FileExist( mission_path ))
+					{
+						BattleRoyaleUtils.Trace("Loading Mission Config: " + mission_path);
+						config.LoadMission();
+					}
 				}
 			}
+			else
+			{
+				//--- Same reasoning as above - skip the bad entry, keep the rest of the configs.
+				BattleRoyaleUtils.Warn("NULL CONFIG `" + key + "` IN CONFIG MAP");
+			}
 		}
+
+		b_IsLoading = false;
+		b_HasLoaded = true;
 	}
 
 	//if a 3rd party needs to get config by string, it can do so here
@@ -143,7 +162,9 @@ class BattleRoyaleConfig
 	{
 		if(!b_HasLoaded)
 		{
-			Error("Requesting Config (" + key + ") Data from Unloaded Config?");
+			//--- Warn, not Error: this branch exists to RECOVER by loading, and the global Error() halts
+			//--- the VM (endebug.c:90 -> Error2), so the Load() below would never have been reached.
+			BattleRoyaleUtils.Warn("Requesting Config (" + key + ") Data from Unloaded Config?");
 			Load();
 		}
 

--- a/Scripts/Server/3_Game/Config/BattleRoyaleGameData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleGameData.c
@@ -106,10 +106,17 @@ class BattleRoyaleGameData: BattleRoyaleDataBase
 	override void Upgrade()
 	{
 		// Future upgrades will be handled here
-		if (version == 1)
+		if (version < 2)
 		{
-			// Set default shortcut for the first item (HuntingKnife) if not set
-			player_starting_items_shortcut.Insert(0);
+			// The key was INTRODUCED in v2, so a v1 file does not carry it and the field initialiser
+			// above survives deserialization - there is nothing to set. Only fill an array that
+			// genuinely came back empty; inserting unconditionally produced [0, 0], binding the knife
+			// to two hotbar slots, which Save() then made permanent.
+			if (!player_starting_items_shortcut || player_starting_items_shortcut.Count() == 0)
+			{
+				player_starting_items_shortcut = new array<int>();
+				player_starting_items_shortcut.Insert(0);  // HuntingKnife
+			}
 
 			version = 2;
 			Save();  // Save the upgraded config

--- a/Scripts/Server/3_Game/Config/BattleRoyaleLobbyData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleLobbyData.c
@@ -83,16 +83,26 @@ class BattleRoyaleLobbyData: BattleRoyaleDataBase
 	{
 		if (version < 2)
 		{
-			// Add default items to the lobby items
-			player_lobby_items.Insert("TShirt_DBR");
-			player_lobby_items.Insert("Jeans_Black");
-			player_lobby_items.Insert("Sneakers_Black");
-			player_lobby_items.Insert("Apple");
-			player_lobby_items.Insert("Zucchini");
-			player_lobby_items.Insert("Apple");
+			// Both keys were INTRODUCED in v2, so a v1 file has neither and deserialization leaves the
+			// field initialisers above untouched - there is nothing to add. Only fill an array that
+			// genuinely came back empty; inserting unconditionally is what used to double the loadout
+			// to 12 items and give a shortcut array of [4, 4], which Save() then made permanent.
+			if (!player_lobby_items || player_lobby_items.Count() == 0)
+			{
+				player_lobby_items = new array<string>();
+				player_lobby_items.Insert("TShirt_DBR");
+				player_lobby_items.Insert("Jeans_Black");
+				player_lobby_items.Insert("Sneakers_Black");
+				player_lobby_items.Insert("Apple");
+				player_lobby_items.Insert("Zucchini");
+				player_lobby_items.Insert("Apple");
+			}
 
-			// Set default shortcut to the Zucchini
-			player_lobby_items_shortcut.Insert(4);  // Zucchini
+			if (!player_lobby_items_shortcut || player_lobby_items_shortcut.Count() == 0)
+			{
+				player_lobby_items_shortcut = new array<int>();
+				player_lobby_items_shortcut.Insert(4);  // Zucchini
+			}
 
 			version = 2;
 			Save();

--- a/Scripts/Server/3_Game/Config/BattleRoyalePOIsData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyalePOIsData.c
@@ -1,13 +1,15 @@
 #ifdef SERVER
 class BattleRoyalePOIsData: BattleRoyaleDataBase
 {
-	int version = 1;  // Config version
+	int version = 2;  // Config version
 
-	// Allow to override the position of the POIs
-	ref array<ref BattleRoyaleOverridePOIPosition> override_poi_positions = {
-		new BattleRoyaleOverridePOIPosition("Settlement_Chernogorsk", { 100, 200 }),
-		new BattleRoyaleOverridePOIPosition("Settlement_Novodmitrovsk", { 300, 400 })
-	};
+	// Allow to override the position of the POIs.
+	// Empty by default ON PURPOSE: these entries are applied for real, they are not inert placeholders
+	// like the dummy SteamID in general_settings.json. The key is the CfgWorlds class name (the same
+	// name BattleRoyaleZone.InitializePOIs and 4_BattleRoyalePrepare look up), the value an [x, z] pair.
+	// Example:
+	//   new BattleRoyaleOverridePOIPosition("Settlement_Chernogorsk", { 6600, 2800 })
+	ref array<ref BattleRoyaleOverridePOIPosition> override_poi_positions = {};
 
 	[NonSerialized()]
 	ref map<string, vector> m_OverrideSpawnPositions;
@@ -54,12 +56,57 @@ class BattleRoyalePOIsData: BattleRoyaleDataBase
 			ErrorEx(errorMessage);
 	}
 
+	override void Upgrade()
+	{
+		if (version < 2)
+		{
+			// v1 shipped two example overrides that were applied for real - GetOverrodePosition() is
+			// keyed on the CfgWorlds class name, which is exactly what those entries carried, so on any
+			// map using those names both POIs were dropped at the map corner. Clear them, but only when
+			// the list is still verbatim what shipped, so an edited or extended list is left alone.
+			if (IsShippedExampleOverride())
+			{
+				BattleRoyaleUtils.Warn("Removing the two example override_poi_positions entries - they were applied as real overrides.");
+				override_poi_positions = new array<ref BattleRoyaleOverridePOIPosition>();
+			}
+
+			version = 2;
+			Save();  // Save the upgraded config
+		}
+	}
+
+	// True only when override_poi_positions is still exactly the pair of examples shipped in version 1.
+	protected bool IsShippedExampleOverride()
+	{
+		if (!override_poi_positions || override_poi_positions.Count() != 2)
+			return false;
+
+		if (!MatchesEntry(override_poi_positions[0], "Settlement_Chernogorsk", 100, 200))
+			return false;
+
+		return MatchesEntry(override_poi_positions[1], "Settlement_Novodmitrovsk", 300, 400);
+	}
+
+	protected bool MatchesEntry(BattleRoyaleOverridePOIPosition entry, string expected_name, int expected_x, int expected_z)
+	{
+		if (!entry || entry.poi_name != expected_name)
+			return false;
+
+		if (!entry.new_position || entry.new_position.Count() != 2)
+			return false;
+
+		return (entry.new_position[0] == expected_x && entry.new_position[1] == expected_z);
+	}
+
 	vector GetOverrodePosition(string poi_name)
 	{
 		if( !m_OverrideSpawnPositions )
 		{
-			Load();
-
+			//--- Deliberately does NOT call Load() here. Everything reaching this method comes through
+			//--- BattleRoyaleConfig.GetConfig(), which already ran Load() AND LoadMission(); re-reading
+			//--- the profile JSON into this instance would overwrite the mission-folder overrides that
+			//--- LoadMission() applied. The map build below stays lazy for exactly that reason - it has
+			//--- to run after the mission pass, not during it.
 			BattleRoyaleUtils.Trace("Load m_OverrideSpawnPositions!");
 			m_OverrideSpawnPositions = new map<string, vector>();
 
@@ -67,7 +114,12 @@ class BattleRoyalePOIsData: BattleRoyaleDataBase
 			{
 				if( !position || !position.new_position || position.new_position.Count() < 2 )
 				{
-					BattleRoyaleUtils.Error("Skipping malformed override_poi_positions entry - expected a [x, z] pair.");
+					//--- Warn, NOT Error: BattleRoyaleUtils.Error routes to the engine's Error2(), which
+					//--- raises a VM exception and stops the script VM - on a server that kills init
+					//--- right here, in MissionServer.OnInit -> BattleRoyaleServer.Init -> InitializePOIs,
+					//--- with the stack landing in crash_*.log rather than the .rpt. This branch already
+					//--- continues, so one malformed entry must never take the server down with it.
+					BattleRoyaleUtils.Warn("Skipping malformed override_poi_positions entry - expected a [x, z] pair.");
 					continue;
 				}
 
@@ -97,7 +149,13 @@ class BattleRoyaleOverridePOIPosition
     // assigns, and GetOverrodePosition() reads a destroyed object.
     ref array<int> new_position;
 
-    void BattleRoyaleOverridePOIPosition(string in_poi_name, array<int> in_new_position)
+    // Every parameter defaults so the class stays default-constructible. JsonSerializer instantiates
+    // the elements of a `ref array<ref ...>` itself, which is why every vanilla JSON helper class
+    // (JsonUndergroundAreaBreadcrumb, BreadcrumbExternalValueController, ...) declares no constructor
+    // at all. Deserialization does work without the defaults - a live run has produced populated
+    // entries - so this is hygiene, not a fix: it stops the class depending on the engine's willingness
+    // to construct a type that offers no no-argument path. Same shape as vanilla's NutritionalProfile.
+    void BattleRoyaleOverridePOIPosition(string in_poi_name = "", array<int> in_new_position = NULL)
 	{
 		this.poi_name = in_poi_name;
 		this.new_position = in_new_position;


### PR DESCRIPTION
The v1->v2 Upgrade() on BattleRoyaleLobbyData and BattleRoyaleGameData appended
defaults on top of the field initialisers. Both keys were introduced in v2, so a
v1 file carries neither, deserialization leaves the initialisers intact, and
there was nothing to add - the inserts just doubled the lobby loadout to 12
items and bound the knife to two hotbar slots. Save() then made it permanent.
Each array is now filled only when it comes back null or empty.

BattleRoyalePOIsData.GetOverrodePosition() called Load() on first use,
re-reading the profile JSON into the instance and silently wiping the
mission-folder overrides LoadMission() had applied. Removed; every call site
already arrives via a fully-loaded singleton.

BattleRoyaleConfig set b_HasLoaded as the first statement of Load(), so the
guard in GetConfig(string) could never detect an aborted load. It now means "a
load completed" and is set last, with re-entrancy moved to a separate flag.

override_poi_positions shipped two live dummy entries, so a fresh install
relocated two POIs to the map corner. The default is now empty, with an
Upgrade() that clears the pair only when it is still verbatim what shipped.

Second half: both BattleRoyaleUtils.Error and the global Error() route to the
engine's Error2(), which raises a VM exception and stops the script VM - on a
server that kills init where the call happened. A live run hit exactly this via
two placeholder POI entries, taking down MissionServer.OnInit. The recoverable
sites now Warn and skip or recover; the four "Setting Constructor Returned NULL"
checks in Init() stay fatal, since those genuinely should stop the server.

Squashed from 2 commits:
  426088d  Fix the Config / JSON section: idempotent upgrades, mission overrides, load flag
  21f41ee  Stop the config layer halting the script VM on recoverable errors

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 10 of 31 replaying the local history onto `main`.
