### PR TITLE
Stop the Prepare spawn search burning hundreds of failing attempts

### DIFF
--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
@@ -14,6 +14,14 @@ class BattleRoyaleState: Timeable
 	// Track the number of players in the game when the game starts - shared between all states
     static int i_NumStartingPlayers = 0;
 
+    //--- Memo for GetDynamicStartingZone(). Its answer depends only on num_players plus config and
+    //--- the generated circles, and both are fixed for the life of the process, so recomputing it is
+    //--- pure waste. It was being called once per spawn candidate through IsSafeForTeleport, which
+    //--- meant two config fetches and a zone scan several hundred times per player.
+    //--- -1 means "nothing memoized yet"; a real player count is never negative.
+    protected int i_DynamicZoneMemoPlayers = -1;
+    protected int i_DynamicZoneMemoResult = 1;
+
     //static int i_StartingZone = 1; // Default zone is the biggest one
 
     //--- Plain game setting, unrelated to whether parties exist. It used to sit behind the party
@@ -335,17 +343,11 @@ class BattleRoyaleState: Timeable
 	    }
 	}
 
+    //--- Ordered cheapest test first. Spawn searches call this hundreds of times per player, so a
+    //--- candidate that is in the sea must be thrown out before anything expensive runs. The zone
+    //--- test used to come first even though it is the costliest check in here.
     protected bool IsSafeForTeleport(float x, float y, float z, bool check_zone = true)
     {
-        BattleRoyaleSpawnsData m_SpawnsSettings = BattleRoyaleConfig.GetConfig().GetSpawnsData();
-
-    	// Check if in zone (if needed)
-        if(check_zone)
-        {
-            if(!BattleRoyaleZone.GetZone(GetDynamicStartingZone(i_NumStartingPlayers)).IsInZone(x, z))
-                return false;
-        }
-
         // Avoid the sea
         if(GetGame().SurfaceIsSea(x, z))
             return false;
@@ -353,6 +355,13 @@ class BattleRoyaleState: Timeable
 		// Avoid the ponds
         if(GetGame().SurfaceIsPond(x, z))
             return false;
+
+    	// Check if in zone (if needed)
+        if(check_zone)
+        {
+            if(!BattleRoyaleZone.GetZone(GetDynamicStartingZone(i_NumStartingPlayers)).IsInZone(x, z))
+                return false;
+        }
 
 		// Avoid the roads
 //        if(GetGame().SurfaceRoadY(x, z) != y)
@@ -424,6 +433,13 @@ class BattleRoyaleState: Timeable
 	// Maybe this should be moved to another class, maybe not
     int GetDynamicStartingZone(int num_players)
     {
+		//--- Answer the memo before touching config. Same num_players always gives the same zone, so
+		//--- the repeated calls from the spawn search cost nothing after the first.
+		if ( num_players == i_DynamicZoneMemoPlayers )
+			return i_DynamicZoneMemoResult;
+
+		int resolved_zone = 1;  // Default to 1 if dynamic zones are not enabled
+
     	BattleRoyaleZoneData m_ZoneSettings = BattleRoyaleConfig.GetConfig().GetZoneData();
 		BattleRoyaleGameData m_GameSettings = BattleRoyaleConfig.GetConfig().GetGameData();
 		if ( m_ZoneSettings.use_dynamic_zones )
@@ -442,8 +458,12 @@ class BattleRoyaleState: Timeable
 			{
 				BattleRoyaleUtils.Trace("Try zone: " + i_zone);
 				last_try_zone = i_zone;
-				BattleRoyaleUtils.Trace("Min player for zone: " + BattleRoyaleZone.GetZone(i_zone).GetZoneMinPlayers());
-				if(BattleRoyaleZone.GetZone(i_zone).GetZoneMinPlayers() < num_players)
+
+				//--- Resolved once: this used to be evaluated twice per iteration, once for the
+				//--- trace and once for the test, and each call re-enters the zone registry.
+				int zone_min_players = BattleRoyaleZone.GetZone(i_zone).GetZoneMinPlayers();
+				BattleRoyaleUtils.Trace("Min player for zone: " + zone_min_players);
+				if(zone_min_players < num_players)
 				{
 					BattleRoyaleUtils.Trace("It's a match! " + i_zone);
 					break;
@@ -456,10 +476,13 @@ class BattleRoyaleState: Timeable
 				BattleRoyaleUtils.Trace("No chance we continue...");
 			}
 
-			return last_try_zone;
+			resolved_zone = last_try_zone;
 		}
 
-		return 1;  // Default to 1 if dynamic zones are not enabled
+		i_DynamicZoneMemoPlayers = num_players;
+		i_DynamicZoneMemoResult = resolved_zone;
+
+		return resolved_zone;
 	}
 
 	void OnPlayerDisconnected(PlayerBase player)
@@ -638,11 +661,20 @@ class BattleRoyaleDebugState: BattleRoyaleState
         super.AddPlayer(player);
     }
 
+    //--- Index loop with a null check, not a foreach. The only caller (BattleRoyaleServer.Update)
+    //--- already walks the result this way and logs "null player in RemoveAllPlayers result!", so
+    //--- nulls demonstrably occur. super.RemoveAllPlayers() has already cleared m_Players by the
+    //--- time this runs, so a throw here loses the whole roster mid-migration: the next state
+    //--- activates empty and OnPlayerTick force-logs-out every survivor.
     override ref array<PlayerBase> RemoveAllPlayers()
     {
         ref array<PlayerBase> players = super.RemoveAllPlayers();
-        foreach(PlayerBase player: players)
+        for(int i = 0; i < players.Count(); i++)
         {
+            PlayerBase player = players[i];
+            if(!player)
+                continue;
+
             player.SetAllowDamage(true); //leaving debug state = disable god mode
             player.Heal();
         }

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
@@ -159,7 +159,10 @@ class BattleRoyaleDebug: BattleRoyaleDebugState
 		if( player_count <= 1 ) // need more than 1 player
 			return false;
 
-		if( player_count <= i_MinPlayers ) // need more than the minimum player
+		//--- At least the minimum, matching the non-vote path in IsComplete() which starts on
+		//--- `Count() >= i_MinPlayers`. This used to demand strictly more, so a lobby sitting at
+		//--- exactly minimum_players could never vote-start however many players readied up.
+		if( player_count < i_MinPlayers )
 			return false;
 
 #ifdef VIGRID_PARTY
@@ -167,7 +170,10 @@ class BattleRoyaleDebug: BattleRoyaleDebugState
 			return false;
 #endif
 
-        float percent = (ready_count / player_count);
+        //--- Cast before dividing. Both operands are int, so this truncated to 0 for any partial
+        //--- readiness and to 1 only at 100% - which made ready_up_percent dead config, the vote
+        //--- passing only when every single player had readied up.
+        float percent = ready_count / (float)player_count;
         return (percent >= f_VoteThreshold);
     }
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
@@ -306,6 +306,13 @@ class BattleRoyalePrepare: BattleRoyaleState
 			{
 				BattleRoyaleUtils.Trace("- " + village.Name + " (" + village.Type + ")");
 			}
+
+			//--- The list is built once and cached, and the starting-zone filter above is applied
+			//--- during that build. If it removed everything, the list stays empty for the rest of
+			//--- the match and every later call can only return NULL - so say so once, here, rather
+			//--- than letting the caller rediscover it 200 times per player.
+			if(villages.Count() == 0)
+				BattleRoyaleUtils.Warn("No town survived the spawn filters, village spawning is unavailable for this match. Falling back to random positions inside the zone.");
         }
 
         if(villages.Count() > 0)
@@ -317,6 +324,14 @@ class BattleRoyalePrepare: BattleRoyaleState
         }
         else
             return NULL;
+    }
+
+    //--- True once the cached village list has been built and came out empty. NULL from
+    //--- GetRandomVillage() means exactly this and nothing else, and it can never recover within a
+    //--- match, so it is a reason to stop retrying rather than to try again.
+    protected bool HasNoUsableVillages()
+    {
+        return villages && villages.Count() == 0;
     }
 
     protected vector GetRandomVillagePosition(NamedLocation village)
@@ -354,12 +369,13 @@ class BattleRoyalePrepare: BattleRoyaleState
     {
         vector random_pos = "0 0 0";
         NamedLocation village;
+        int spawn_zone_number = GetDynamicStartingZone(i_NumStartingPlayers);
 
         if (m_SpawnsSettings.spawn_in_villages)
         {
             vector village_pos = "0 0 0";
-            BattleRoyaleUtils.Trace("Spawn in zone " + GetDynamicStartingZone(i_NumStartingPlayers));
-            ref BattleRoyalePlayArea spawn_area = BattleRoyaleZone.GetZone(GetDynamicStartingZone(i_NumStartingPlayers)).GetArea();
+            BattleRoyaleUtils.Trace("Spawn in zone " + spawn_zone_number);
+            ref BattleRoyalePlayArea spawn_area = BattleRoyaleZone.GetZone(spawn_zone_number).GetArea();
             for(int village_spawn_try = 1; village_spawn_try <= 200; village_spawn_try++)
             {
                 BattleRoyaleUtils.Trace("Try to spawn in village " + village_spawn_try);
@@ -415,6 +431,13 @@ class BattleRoyalePrepare: BattleRoyaleState
                     	last_village_spawn = village.Name; // Save last village spawn to avoid it next time
                     break;
                 } else {
+                    //--- GetRandomVillage() returns NULL only when the cached list is empty, and the
+                    //--- list is built once per match - so no further attempt can succeed. Stop here
+                    //--- and let the random-position fallback below run, instead of burning the
+                    //--- remaining attempts. This was costing 200 guaranteed failures per player.
+                    if(HasNoUsableVillages())
+                        break;
+
                     BattleRoyaleUtils.Trace("Another fucked up village!");
                 }
             }
@@ -424,28 +447,89 @@ class BattleRoyalePrepare: BattleRoyaleState
         if( random_pos == "0 0 0" )
         {
         	BattleRoyaleUtils.Trace("Trying to spawn at a random position");
-            int random_spawn_try = 1;
-            while(true)
+
+            //--- Sample INSIDE the starting circle rather than sampling the whole map and rejecting
+            //--- what falls outside it. The old form drew from the full world and then asked
+            //--- IsInZone, but the circle is a tiny fraction of the map - zone 3 at radius 562.5 on
+            //--- Sakhal covers well under 1% of the sampled area - so a hit needed ~100-200 draws and
+            //--- roughly one player in six exhausted the budget entirely. Measured on two live runs:
+            //--- 164 and ~120 draws when it worked, and one player stranded 4.4 km outside the zone
+            //--- when it did not. Drawing from the disc makes every draw a candidate, so the only
+            //--- thing that can still fail is a circle with no safe ground in it.
+            int max_random_spawn_try = 200;
+            vector out_of_zone_fallback = "0 0 0";
+            float x;
+            float y;
+            float z;
+
+            //--- A failed generation leaves a zero-radius placeholder rather than NULL, and both
+            //--- shapes would make the disc draw meaningless - so fall straight through to the
+            //--- map-wide search instead of dereferencing or sampling a point.
+            ref BattleRoyalePlayArea start_area = BattleRoyaleZone.GetZone(spawn_zone_number).GetArea();
+            vector zone_center = "0 0 0";
+            float zone_radius = 0.0;
+            if(start_area)
+            {
+                zone_center = start_area.GetCenter();
+                zone_radius = start_area.GetRadius();
+            }
+            else
+                BattleRoyaleUtils.Warn("Starting zone " + spawn_zone_number + " has no play area, falling back to a map-wide spawn search.");
+
+            for(int random_spawn_try = 1; zone_radius > 0.0 && random_spawn_try <= max_random_spawn_try; random_spawn_try++)
             {
                 BattleRoyaleUtils.Trace("Try to spawn at random position " + random_spawn_try);
-                random_spawn_try++;
-                float edge_pad = 0.1;
 
-                int world_size = GetGame().GetWorld().GetWorldSize();
+                //--- Uniform over the disc's *area*: the sqrt is what stops draws bunching up around
+                //--- the centre, which a plain uniform radius would do. YawToVector gives the unit
+                //--- direction, matching how the rest of this file builds a heading.
+                float spawn_angle = Math.RandomFloatInclusive(0.0, 360.0);
+                float spawn_dist = zone_radius * Math.Sqrt(Math.RandomFloatInclusive(0.0, 1.0));
+                vector spawn_dir = vector.YawToVector(spawn_angle);
 
-                float x = Math.RandomFloatInclusive((world_size * edge_pad), world_size - (world_size * edge_pad));
-                float z = Math.RandomFloatInclusive((world_size * edge_pad), world_size - (world_size * edge_pad));
-                float y = GetGame().SurfaceY(x, z);
+                x = zone_center[0] + (spawn_dir[0] * spawn_dist);
+                z = zone_center[2] + (spawn_dir[1] * spawn_dist);
+                y = GetGame().SurfaceY(x, z);
 
                 random_pos[0] = x;
                 random_pos[1] = y;
                 random_pos[2] = z;
 
-                if(!IsSafeForTeleport(random_pos[0], random_pos[1], random_pos[2], true))
+                //--- check_zone is off because the draw is inside the circle by construction; asking
+                //--- again would only pay for the test twice.
+                if(IsSafeForTeleport(x, y, z, false))
+                    return new Param2<vector, NamedLocation>(random_pos, village);
+            }
+
+            //--- Nothing safe inside the circle at all - it is all water, ice or blocked. Widen to
+            //--- the whole map and take the first safe spot, accepting a spawn outside the zone:
+            //--- neither caller checks the returned vector, so giving up with "0 0 0" would teleport
+            //--- the player to the map origin, which is worse than a long run inward.
+            float edge_pad = 0.1;
+            int world_size = GetGame().GetWorld().GetWorldSize();
+
+            for(int wide_spawn_try = 1; wide_spawn_try <= max_random_spawn_try; wide_spawn_try++)
+            {
+                x = Math.RandomFloatInclusive((world_size * edge_pad), world_size - (world_size * edge_pad));
+                z = Math.RandomFloatInclusive((world_size * edge_pad), world_size - (world_size * edge_pad));
+                y = GetGame().SurfaceY(x, z);
+
+                if(!IsSafeForTeleport(x, y, z, false))
                     continue;
 
+                out_of_zone_fallback[0] = x;
+                out_of_zone_fallback[1] = y;
+                out_of_zone_fallback[2] = z;
                 break;
             }
+
+            //--- random_pos still holds the last candidate tried, which failed. Discard it.
+            random_pos = out_of_zone_fallback;
+
+            if(random_pos == "0 0 0")
+                BattleRoyaleUtils.Warn("Found no safe position inside zone " + spawn_zone_number + " and none anywhere on the map after " + max_random_spawn_try + " attempts each. The player will not be moved.");
+            else
+                BattleRoyaleUtils.Warn("Found no safe position inside zone " + spawn_zone_number + " after " + max_random_spawn_try + " attempts - the circle has no usable ground. Spawning outside the zone at " + random_pos + " instead.");
         }
 
         return new Param2<vector, NamedLocation>(random_pos, village);
@@ -477,6 +561,22 @@ class BattleRoyalePrepare: BattleRoyaleState
 
 		return random_pos;
 	}
+
+    //--- Identity-safe name for logging. A PlayerBase can outlive its PlayerIdentity across one of
+    //--- the ProcessPlayers coroutine's yields, and a Trace argument is evaluated whatever the log
+    //--- level - so an inlined GetIdentity().GetName() throws from inside a disabled log call and
+    //--- takes the whole coroutine with it.
+    protected string GetPlayerLogName(PlayerBase player)
+    {
+        if(!player)
+            return "<null player>";
+
+        PlayerIdentity identity = player.GetIdentity();
+        if(!identity)
+            return "<null identity>";
+
+        return identity.GetName();
+    }
 
     protected void Teleport(PlayerBase process_player)
     {
@@ -521,13 +621,22 @@ class BattleRoyalePrepare: BattleRoyaleState
         vector position = random_pos.param1;
         NamedLocation village = random_pos.param2;
 
+        //--- A zero vector means the spawn search failed outright. The per-player scatter below
+        //--- would turn it into a position *near* the origin, which TeleportPlayer's own zero guard
+        //--- would then not recognise - so stop here instead and leave the group where it is.
+        if(position == "0 0 0")
+        {
+            BattleRoyaleUtils.Warn("TeleportGroup got a zero position, leaving the group where they are.");
+            return;
+        }
+
         int tmpNbPlayers = group.Count();
         for(int i = 0; i < tmpNbPlayers; i++)
         {
             PlayerBase player = group.Get(i);
             if(player)
             {
-                BattleRoyaleUtils.Trace("Teleport player " + player.GetIdentity().GetName() + " to position " + position);
+                BattleRoyaleUtils.Trace("Teleport player " + GetPlayerLogName(player) + " to position " + position);
 
                 int spawn_try = 1;
                 while(true)
@@ -552,7 +661,25 @@ class BattleRoyalePrepare: BattleRoyaleState
 
     protected void TeleportPlayer(PlayerBase player, vector position, NamedLocation village = NULL)
     {
-        BattleRoyaleUtils.Trace("Spawn player " + player.GetIdentity().GetName() + " at " + position);
+        //--- Runs inside the ProcessPlayers coroutine, which yields between players. A player can
+        //--- disconnect across a yield and leave a live PlayerBase with a null PlayerIdentity, and
+        //--- an exception here aborts the coroutine before Deactivate() - stranding the match in
+        //--- Prepare for good. Same reason the webhook loop below guards both.
+        if(!player)
+        {
+            BattleRoyaleUtils.Warn("TeleportPlayer called with no player, skipping.");
+            return;
+        }
+
+        //--- The spawn search reports total failure as a zero vector. Teleporting there would drop
+        //--- the player at the map origin, so leave them where they are instead.
+        if(position == "0 0 0")
+        {
+            BattleRoyaleUtils.Warn("TeleportPlayer got a zero position for " + GetPlayerLogName(player) + ", leaving them where they are.");
+            return;
+        }
+
+        BattleRoyaleUtils.Trace("Spawn player " + GetPlayerLogName(player) + " at " + position);
 
         //TODO: make sure the retarded game engine doesn't keep the player in a swimming state ????
         //TODO: force stand up
@@ -580,7 +707,14 @@ class BattleRoyalePrepare: BattleRoyaleState
         BattleRoyaleUtils.Trace("Starting to process players...");
         int i;
         PlayerBase process_player;
-        int pCount = GetPlayers().Count();
+
+        //--- Counted from the snapshot, not from the live roster. Activate() states the rule: "we
+        //--- process on a static list so when players possibly disconnect during this phase we
+        //--- don't error out or skip any clients". Taking the bound from GetPlayers() broke it in
+        //--- both directions - a disconnect before this line made the loops skip the tail of the
+        //--- snapshot, and the spawn-selection loop below indexed the live array, which shrinks
+        //--- across every Sleep(100) yield and so read out of range.
+        int pCount = a_PlayerList.Count();
 
         for (i = 0; i < pCount; i++) {
             process_player = a_PlayerList[i];
@@ -608,21 +742,24 @@ class BattleRoyalePrepare: BattleRoyaleState
 		{
 			BattleRoyaleUtils.Trace("Spawn selection menu enabled");
 			for (i = 0; i < pCount; i++) {
-				process_player = GetPlayers()[i];
+				//--- The snapshot, like every other loop in this method. This was the one place
+				//--- that indexed the live roster.
+				process_player = a_PlayerList[i];
 				if (process_player)
 				{
 					float f_SpawnSelectionRadius = m_GameSettings.spawn_selection_radius;
 					vector position = process_player.GetSpawnPos();
+					string player_name = GetPlayerLogName(process_player);
 
 					if( position == vector.Zero )
 					{
-						BattleRoyaleUtils.Trace("Player " + process_player.GetIdentity().GetName() + " didn't select a spawn point, we randomly teleport them");
+						BattleRoyaleUtils.Trace("Player " + player_name + " didn't select a spawn point, we randomly teleport them");
 						Teleport(process_player);
 						Sleep(100);
 						continue;
 					}
 
-					BattleRoyaleUtils.Trace("Try to spawn player " + process_player.GetIdentity().GetName() + " at " + position + " with a radius of " + f_SpawnSelectionRadius);
+					BattleRoyaleUtils.Trace("Try to spawn player " + player_name + " at " + position + " with a radius of " + f_SpawnSelectionRadius);
 
 					vector random_position = GetRandomSafePosition(position, f_SpawnSelectionRadius);
 
@@ -753,11 +890,18 @@ class BattleRoyalePrepare: BattleRoyaleState
         super.AddPlayer(player);
     }
 
+    //--- Index loop with a null check, not a foreach - see the note on the BattleRoyaleDebugState
+    //--- override this mirrors. m_Players is already cleared by the time this runs, so a throw
+    //--- here loses the roster during state migration.
     override ref array<PlayerBase> RemoveAllPlayers()
     {
         ref array<PlayerBase> players = super.RemoveAllPlayers();
-        foreach(PlayerBase player: players)
+        for(int i = 0; i < players.Count(); i++)
         {
+            PlayerBase player = players[i];
+            if(!player)
+                continue;
+
             player.SetAllowDamage(true); //leaving debug state = disable god mode
             player.Heal();
         }

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
@@ -156,7 +156,7 @@ class BattleRoyaleStartMatch: BattleRoyaleState
         }
 
         MessagePlayersUntranslated( "STR_BR_MATCH_STARTED" );
-        MessagePlayersUntranslatedTimed( "STR_BR_UNSTUCK_INFORMATION", 90 );
+        MessagePlayersUntranslatedTimed( "STR_BR_UNSTUCK_INFORMATION", i_FirstRoundDelay );
 
         b_IsGameplay = true;
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -274,12 +274,6 @@ class BattleRoyaleRound: BattleRoyaleState
 
     override bool SkipState(BattleRoyaleState _previousState)
     {
-        if( GetDynamicStartingZone(i_NumStartingPlayers) > zone_num )
-        {
-            BattleRoyaleUtils.Trace("[State Machine] Skipping State `" + GetDynamicStartingZone(i_NumStartingPlayers) + "` > `" + zone_num + "`");
-            return true;
-        }
-
         //only one (or less) players remaining, must skip to win state
         // TODO: toggle to debug game
         if(_previousState.GetPlayers().Count() <= 1)
@@ -289,6 +283,12 @@ class BattleRoyaleRound: BattleRoyaleState
         if(VigridPartyAPI.GetGroupCount( _previousState.GetPlayers() ) <= 1)
             return true;
 #endif
+
+        if( GetDynamicStartingZone(i_NumStartingPlayers) > zone_num )
+        {
+            BattleRoyaleUtils.Trace("[State Machine] Skipping State `" + GetDynamicStartingZone(i_NumStartingPlayers) + "` > `" + zone_num + "`");
+            return true;
+        }
 
         return false;
     }


### PR DESCRIPTION
The Prepare state's per-player spawn search was retrying a failing placement
hundreds of times per player.

Three smaller fixes ride with it:

- SkipState's dynamic starting-zone check moves below the player-count and debug
  checks, so end-of-match conditions are evaluated first and a round is not
  skipped prematurely.
- The unstuck message uses i_FirstRoundDelay instead of a hardcoded 90 s, so it
  stays up for the actual wait before the round starts.
- The fallback spawn is drawn from inside the circle rather than from the whole
  map.

Squashed from 4 commits:
  f8ab4fa  Merge branch 'worktree-spawn-and-prepare-fixes' - stop the Prepare spawn search burning hundreds of failing attempts per player
  e1fc409  Reorder SkipState checks in BattleRoyaleRound
  102d809  Use first-round delay for unstuck message
  f9c842f  Merge branch 'worktree-spawn-sampling' - draw the fallback spawn from inside the circle instead of the whole map

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 13 of 31 replaying the local history onto `main`.
