### PR TITLE
Add the SafeZone addon, a narrow in-repo lobby truce

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,33 @@ NulledKillfeed is *not* covered — it is an obfuscated third-party PBO with no 
 
 Note `$profile:KillFeed\` is also used by NulledKillfeed (`Settings.json`). The filenames differ, so they coexist, but deleting the folder to remove one wipes the other.
 
+### Safe zone / lobby truce (`Extra/SafeZone/`)
+
+A standalone addon replacing DayZ Expansion's Safe Zone for the lobby. It builds into `extra_safezone.pbo` and defines `VIGRID_SAFEZONE`. It hooks vanilla `PlayerBase` and `WeaponManager` directly, so it works on any DayZ server — Battle Royale is not required.
+
+**Same discipline rule as `Party/` and `Extra/KillFeed/`: nothing under `Extra/SafeZone/` may reference a `BattleRoyale*` symbol.** It carries its own logger (`VigridSafeZoneLog`, CLI flags `-safezone-*`, `serverDZ.cfg` key `SafeZoneLogLevel`). It ships no assets, no settings file, no stringtable and no RPC namespace.
+
+While active it changes **exactly two things**, and this narrowness is the whole point:
+
+- `WeaponManager.CanFire` returns false, so pulling the trigger does nothing — no shot, no round consumed, no noise.
+- `PlayerBase.EEOnDamageCalculated` returns false for damage that another player inflicted, so the hit is discarded before it is applied.
+
+Everything else is deliberately left alone. Weapon raise, ADS, melee swings, reloading and user actions all behave normally — players can still aim and still punch each other in the lobby. Falls, drowning, infected, animals and the mod's own scripted zone damage all still land, because the predicate `VigridSafeZone_IsPlayerInflicted()` resolves the damage source to a player (directly, or via `GetHierarchyRootPlayer()` for a held weapon, or by explosive type) and returns false for anything else — including the victim as their own source, which is how `DecreaseHealthCoef` surfaces.
+
+This is why it is **not** a port of Expansion's safezone. Expansion calls `hic.OverrideRaise(true, false)`, which kills ADS for every item including melee, and hard-returns false from `DayZPlayerMeleeFightLogic_LightHeavy.HandleFightLogic`, which kills melee swings outright; its `EEOnDamageCalculated` cancels *all* damage, not just PvP. If Expansion's safezone is left enabled it stacks on top of this addon and those restrictions come back — set `"Enabled": 0` in the mission's `Expansion/Settings/SafeZoneSettings.json`.
+
+State is global rather than geographic, so there is no zone module, no actor list and no per-tick point-in-shape test. The server owns one static flag and mirrors it onto each player as the netsync bool `m_VigridSafeZoneActive` — netsync rather than an RPC broadcast specifically so a player joining an already-running lobby is disarmed too; `OnConnect` / `OnReconnect` re-assert it.
+
+The Battle Royale mod talks to it **only** through `VigridSafeZoneAPI` (`Extra/SafeZone/Scripts/4_World/VigridSafeZoneAPI.c`), two call sites, each wrapped in `#ifdef VIGRID_SAFEZONE`:
+
+```c
+#ifdef VIGRID_SAFEZONE
+    VigridSafeZoneAPI.SetActive( true );
+#endif
+```
+
+- On in `1_BattleRoyaleDebug.Activate()`, off in `5_BattleRoyaleStartMatch.HandleUnlock()` — the latter rather than `Activate()` because input stays locked through the warm-up countdown, so `HandleUnlock` is the first instant a player could actually shoot back. Defaults to off, so the PBO changes nothing on a server that never calls the API.
+
 ### Vigrid API / webhooks
 
 `Scripts/Server/3_Game/BattleRoyale/Webhook/` — REST via `GetRestApi().GetRestContext(BATTLEROYALE_API_ENDPOINT)`. Every call site is gated on `BattleRoyaleConfig.GetConfig().GetServerData().enable_vigrid_api`; `use_autolock` is a separate, independent gate that is *not* covered by it. Each webhook pairs with a `RestCallback` subclass that retries from `i_TryLeft`.
@@ -245,7 +272,7 @@ Note the imageset's internal name is `battleroyale_gui`, not the filename `dayzb
 
 ## Notes
 
-- `Extra/` holds 13 independent single-purpose sub-addons, each its own PBO, all built unconditionally. All are small script tweaks except `Extra/KillFeed/`, a self-contained addon documented under *Architecture → Kill feed*.
+- `Extra/` holds 14 independent single-purpose sub-addons, each its own PBO, all built unconditionally. All are small script tweaks except `Extra/KillFeed/` and `Extra/SafeZone/`, self-contained addons documented under *Architecture → Kill feed* and *Architecture → Safe zone / lobby truce*.
 - `Extra/RandomMenuGear/` re-dresses the main-menu intro character in a random outfit plus a slung rifle and a melee weapon, re-rolled on every menu show. It hooks vanilla `IntroSceneCharacter.CreateNewCharacterById` (creation, prev/next arrows) and `MainMenu.OnShow` (returning from a submenu — that path calls `OnChangeCharacter(false)` and never recreates the character). It is **not** a fix for the broken character save that makes the menu character render naked; it only decorates the spawned object. Gear is applied with `GameInventory.CreateAttachmentEx` and deliberately never written into `MenuDefaultCharacterData` — that map is serialized to the server on connect and saved locally, so writing to it would leak menu gear into the real spawn loadout. Same discipline rule as `Party/` and `Extra/KillFeed/`: no `BattleRoyale*` symbol may be referenced.
 - Spectating is not implemented — `GUI/layouts/hud/spectator/player.layout` exists but nothing references it. Death shows a screen, then forces disconnect.
 - `Workbench/version` (`0.8.100368`) is a DayZ build number read by nothing. The mod version is `BATTLEROYALE_VERSION`.

--- a/Extra/SafeZone/Scripts/3_Game/VigridSafeZoneConstants.c
+++ b/Extra/SafeZone/Scripts/3_Game/VigridSafeZoneConstants.c
@@ -1,0 +1,20 @@
+/**
+ *  SafeZone - shared constants. No guard: this file compiles on both client and server.
+ *
+ *  Short by design. The addon has no assets, no settings file and no RPC namespace: state reaches
+ *  the client on a netsync bool riding the player entity, so there is nothing else to name here.
+ */
+
+static const string VIGRID_SAFEZONE_VERSION = "0.1.0";
+
+#ifdef DIAG
+#define VIGRID_SAFEZONE_TRACE_ENABLED
+#endif
+
+//--- Log verbosity. Overridden at runtime by -safezone-trace/-safezone-debug/-safezone-info/
+//--- -safezone-warn/-safezone-none on the command line, or by SafeZoneLogLevel in serverDZ.cfg.
+#ifdef VIGRID_SAFEZONE_TRACE_ENABLED
+    static const int VIGRID_SAFEZONE_LOG_LEVEL = 4; // Trace
+#else
+    static const int VIGRID_SAFEZONE_LOG_LEVEL = 0; // Error only
+#endif

--- a/Extra/SafeZone/Scripts/3_Game/VigridSafeZoneLog.c
+++ b/Extra/SafeZone/Scripts/3_Game/VigridSafeZoneLog.c
@@ -1,0 +1,93 @@
+/**
+ *  SafeZone - logging. No guard: compiles on both client and server.
+ *
+ *  A deliberate near-duplicate of the host mod's logger. The discipline rule keeps this addon free
+ *  of BattleRoyale* symbols, so it carries its own. It also carries its own CLI flags and its own
+ *  serverDZ.cfg key, so the addons' verbosity can be tuned independently.
+ *
+ *  Runtime verbosity, highest priority first:
+ *    -safezone-trace | -safezone-debug | -safezone-info | -safezone-warn | -safezone-none    (CLI)
+ *    SafeZoneLogLevel = 1..4 in serverDZ.cfg, negative to silence               (server only)
+ *    VIGRID_SAFEZONE_LOG_LEVEL                                                  (compile default)
+ */
+class VigridSafeZoneLog
+{
+    static const int NONE = 0;
+    static const int WARN = 1;
+    static const int INFO = 2;
+    static const int DEBUG = 3;
+    static const int TRACE = 4;
+
+    static void LogMessage(int level, string message)
+    {
+        if (!CheckLogLevel(level))
+            return;
+
+        int hour;
+        int minute;
+        int second;
+        GetHourMinuteSecond(hour, minute, second);
+
+        string stamp = hour.ToStringLen(2) + ":" + minute.ToStringLen(2) + ":" + second.ToStringLen(2);
+
+        if (level == NONE)
+        {
+            Error2("", stamp + " [SafeZone] " + message);
+            return;
+        }
+
+        PrintFormat("%1 [SafeZone][%2] %3", stamp, level, message);
+    }
+
+    static void Error(string message)
+    {
+        LogMessage(NONE, message);
+    }
+
+    static void Warn(string message)
+    {
+        LogMessage(WARN, message);
+    }
+
+    static void Info(string message)
+    {
+        LogMessage(INFO, message);
+    }
+
+    static void Debug(string message)
+    {
+        LogMessage(DEBUG, message);
+    }
+
+    static void Trace(string message)
+    {
+        LogMessage(TRACE, message);
+    }
+
+    static bool CheckLogLevel(int level)
+    {
+        //--- Command line wins.
+        if (IsCLIParam("safezone-none"))
+            return false;
+        if (IsCLIParam("safezone-trace"))
+            return TRACE >= level;
+        if (IsCLIParam("safezone-debug"))
+            return DEBUG >= level;
+        if (IsCLIParam("safezone-info"))
+            return INFO >= level;
+        if (IsCLIParam("safezone-warn"))
+            return WARN >= level;
+
+#ifdef SERVER
+        //--- Then serverDZ.cfg. 0 is indistinguishable from "key absent", so it falls through to
+        //--- the compile-time default; a negative value silences the addon outright.
+        int config_level = GetGame().ServerConfigGetInt("SafeZoneLogLevel");
+        if (config_level > 0)
+            return config_level >= level;
+        if (config_level < 0)
+            return false;
+#endif
+
+        return VIGRID_SAFEZONE_LOG_LEVEL >= level;
+    }
+}

--- a/Extra/SafeZone/Scripts/4_World/Classes/Weapons/WeaponManager.c
+++ b/Extra/SafeZone/Scripts/4_World/Classes/Weapons/WeaponManager.c
@@ -1,0 +1,27 @@
+/**
+ *  SafeZone - the firing half of the truce.
+ *
+ *  WeaponManager.CanFire is the single script-side gate on the fire path: DayZPlayerImplement's
+ *  HandleWeapons consults it once and every GetWeaponManager().Fire(weapon) call sits inside that
+ *  branch. Refusing here means the trigger does nothing at all - no shot, no muzzle flash, no round
+ *  consumed, no noise - while leaving weapon raise, ADS, reloading, bullet ejection and firearm
+ *  melee bashing completely untouched.
+ *
+ *  That last part is the whole point. Expansion's safezone has no firing block; it stops shooting
+ *  as a side effect of hic.OverrideRaise(true, false), which also costs you the ability to aim
+ *  anything, melee included. Blocking the trigger directly is both narrower and more precise.
+ *
+ *  No guard: this compiles on both sides. The client refusal is the one players actually feel; the
+ *  server refuses too, and a client that patches this out still lands zero damage because
+ *  PlayerBase.EEOnDamageCalculated discards the hit.
+ */
+modded class WeaponManager
+{
+    override bool CanFire(Weapon_Base wpn)
+    {
+        if (m_player && m_player.VigridSafeZone_IsActive())
+            return false;
+
+        return super.CanFire(wpn);
+    }
+}

--- a/Extra/SafeZone/Scripts/4_World/Entities/ManBase/PlayerBase.c
+++ b/Extra/SafeZone/Scripts/4_World/Entities/ManBase/PlayerBase.c
@@ -1,0 +1,129 @@
+/**
+ *  SafeZone - the damage half of the truce, plus the state that carries it to the client.
+ *
+ *  No guard: this file compiles on both sides on purpose. The server owns the flag and decides what
+ *  damage lands; the client needs the same flag locally so WeaponManager can refuse the trigger
+ *  without a round trip.
+ */
+modded class PlayerBase
+{
+    //--- Netsynced. Registered in Init() below, so the registration order is identical on both
+    //--- sides - which it must be, since both sides compile this same file.
+    protected bool m_VigridSafeZoneActive;
+
+    override void Init()
+    {
+        super.Init();
+
+        RegisterNetSyncVariableBool("m_VigridSafeZoneActive");
+    }
+
+#ifdef SERVER
+    override void OnConnect()
+    {
+        super.OnConnect();
+
+        //--- Covers the player who joins an already-running lobby: SetActive() only reached the
+        //--- players who were connected at the time it was called.
+        VigridSafeZone_Refresh();
+    }
+
+    override void OnReconnect()
+    {
+        super.OnReconnect();
+
+        //--- A reconnect reuses the existing entity, so the flag is already right server side and
+        //--- VigridSafeZone_Apply would no-op. Push it anyway: it costs nothing and it means a
+        //--- rejoining player can never end up armed in a lobby because a sync was missed.
+        VigridSafeZone_Refresh();
+    }
+
+    /**
+     *  Server side only. Re-assert the current truce on this player, syncing unconditionally.
+     */
+    void VigridSafeZone_Refresh()
+    {
+        m_VigridSafeZoneActive = VigridSafeZoneState.IsActive();
+        SetSynchDirty();
+    }
+#endif
+
+    /**
+     *  Server side only. Set the flag and push it to the owning client.
+     */
+    void VigridSafeZone_Apply(bool active)
+    {
+        if (m_VigridSafeZoneActive == active)
+            return;
+
+        m_VigridSafeZoneActive = active;
+        SetSynchDirty();
+    }
+
+    bool VigridSafeZone_IsActive()
+    {
+        return m_VigridSafeZoneActive;
+    }
+
+    /**
+     *  Engine event fired right before damage is applied; returning false discards the hit outright.
+     *
+     *  This is the same choke point DayZ Expansion uses for its safezone, but the predicate is much
+     *  narrower. Expansion cancels everything - a safezone player cannot be hurt by anything at all.
+     *  Here only another player's doing is cancelled, so falls, drowning, infected, animals and any
+     *  scripted damage the host game applies still land exactly as they would with the addon absent.
+     *
+     *  Note the trade-off: a discarded hit produces no hit reaction on the victim, so a punch lands
+     *  visually for the attacker but the target does not flinch. TotalDamageResult is getter-only,
+     *  so scaling the damage to zero instead is not available - cancelling is the only clean route.
+     */
+    override bool EEOnDamageCalculated(TotalDamageResult damageResult, int damageType, EntityAI source, int component, string dmgZone, string ammo, vector modelPos, float speedCoef)
+    {
+        if (!super.EEOnDamageCalculated(damageResult, damageType, source, component, dmgZone, ammo, modelPos, speedCoef))
+            return false;
+
+        if (!m_VigridSafeZoneActive)
+            return true;
+
+        if (!VigridSafeZone_IsPlayerInflicted(source))
+            return true;
+
+        return false;
+    }
+
+    /**
+     *  Did another player cause this hit?
+     *
+     *  Scripted damage - DecreaseHealthCoef and friends - arrives with the victim as their own
+     *  source, and so falls through as false. That is deliberate: swallowing it would break every
+     *  host game that damages players itself.
+     */
+    bool VigridSafeZone_IsPlayerInflicted(EntityAI source)
+    {
+        if (!source)
+            return false;
+
+        //--- Bare hands: the attacker is the source entity itself.
+        PlayerBase attacker = PlayerBase.Cast(source);
+
+        //--- Firearms and melee weapons: the source is the item, the attacker is whoever holds it.
+        if (!attacker)
+            attacker = PlayerBase.Cast(source.GetHierarchyRootPlayer());
+
+        if (attacker)
+            return attacker != this;
+
+        //--- Explosives have no player left in their hierarchy once thrown or placed, but nothing
+        //--- else leaves one lying around either. Classified by type, the same way the host mod's
+        //--- own kill reporting does it. IsExplosive() covers Grenade_Base via ExplosivesBase;
+        //--- LandMineTrap descends from TrapBase instead and needs naming separately.
+        ItemBase item = ItemBase.Cast(source);
+        if (item && item.IsExplosive())
+            return true;
+
+        if (source.IsInherited(LandMineTrap))
+            return true;
+
+        return false;
+    }
+}

--- a/Extra/SafeZone/Scripts/4_World/Server/VigridSafeZoneState.c
+++ b/Extra/SafeZone/Scripts/4_World/Server/VigridSafeZoneState.c
@@ -1,0 +1,45 @@
+#ifdef SERVER
+/**
+ *  SafeZone - the authoritative flag, server side.
+ *
+ *  The truce is global rather than geographic: a host game that has a lobby phase already knows
+ *  when peace applies, and asking it is cheaper and exact where polling positions against circle
+ *  geometry is neither. That is the whole reason this addon is a fraction of the size of
+ *  Expansion's zone system - there is no zone module, no actor list and no per-tick point-in-shape
+ *  test to run.
+ *
+ *  The flag is mirrored onto every player as a netsync bool rather than broadcast over an RPC. The
+ *  engine then replays it to a client that joins later for free, which is exactly the case an RPC
+ *  broadcast would miss: someone connecting into an already-running lobby has to be disarmed too.
+ */
+class VigridSafeZoneState
+{
+    //--- Defaults to off, so dropping this PBO on a server that never calls the API changes nothing.
+    private static bool s_Active;
+
+    static bool IsActive()
+    {
+        return s_Active;
+    }
+
+    static void SetActive(bool active)
+    {
+        if (s_Active == active)
+            return;
+
+        s_Active = active;
+
+        array<Man> players = new array<Man>();
+        GetGame().GetPlayers(players);
+
+        for (int i = 0; i < players.Count(); i++)
+        {
+            PlayerBase player = PlayerBase.Cast(players[i]);
+            if (player)
+                player.VigridSafeZone_Apply(active);
+        }
+
+        VigridSafeZoneLog.Info("Truce active=" + active + " applied to " + players.Count() + " player(s)");
+    }
+}
+#endif

--- a/Extra/SafeZone/Scripts/4_World/VigridSafeZoneAPI.c
+++ b/Extra/SafeZone/Scripts/4_World/VigridSafeZoneAPI.c
@@ -1,0 +1,45 @@
+#ifdef SERVER
+/**
+ *  SafeZone - the public API. THIS IS THE ENTIRE CONTRACT with the host game.
+ *
+ *  The addon has no opinion of its own about when peace applies - it does nothing at all until a
+ *  host game says so. A host game with a lobby phase turns it on when the lobby opens and off at
+ *  the instant the match actually goes live.
+ *
+ *  While active, exactly two things change and nothing else does:
+ *
+ *    - pulling the trigger on a firearm does nothing: no shot, no round consumed, no noise;
+ *    - damage inflicted by another player is discarded.
+ *
+ *  Raising a weapon, aiming down sights, swinging melee, reloading and every user action all behave
+ *  normally, and so does everything that is not another player: falls, drowning, infected, animals
+ *  and any scripted damage the host game applies itself still land.
+ *
+ *  Every method is safe to call at any time, including before anything is initialised, so a host
+ *  game never has to null-check.
+ *
+ *  Usage from the host game (guard every call site, so removing the addon still builds):
+ *
+ *      #ifdef VIGRID_SAFEZONE
+ *          VigridSafeZoneAPI.SetActive(true);
+ *      #endif
+ */
+class VigridSafeZoneAPI
+{
+    /**
+     *  Turn the truce on or off. Idempotent, and applies to players already connected as well as to
+     *  anyone who joins while it is on.
+     *
+     *  Not persisted - a fresh server starts with the truce off.
+     */
+    static void SetActive(bool active)
+    {
+        VigridSafeZoneState.SetActive(active);
+    }
+
+    static bool IsActive()
+    {
+        return VigridSafeZoneState.IsActive();
+    }
+}
+#endif

--- a/Extra/SafeZone/config.cpp
+++ b/Extra/SafeZone/config.cpp
@@ -1,0 +1,84 @@
+/**
+ *  SafeZone - a narrow, self-contained truce switch. While active: a trigger pull does nothing, and
+ *  damage inflicted by another player is discarded. Nothing else changes.
+ *
+ *  Deliberately NOT a clone of DayZ Expansion's safezone. Expansion turns a safezone into a general
+ *  pacifier - it calls hic.OverrideRaise(true, false), which kills weapon raise and therefore ADS
+ *  for every item including melee, and it hard-returns false from HandleFightLogic, so melee swings
+ *  do not even play. This addon leaves raise, ADS and melee animation completely alone: players
+ *  waiting in a lobby can still aim and still punch each other, they just cannot do harm.
+ *
+ *  This folder is its own PBO because the build packs every folder holding a config.cpp with no
+ *  ancestor config.cpp. Keep exactly ONE config.cpp here and do not nest another one below it.
+ *
+ *  DISCIPLINE RULE: nothing under Extra/SafeZone/ may reference a BattleRoyale* symbol. The host mod
+ *  consumes this addon through VigridSafeZoneAPI only, and every one of its call sites is wrapped in
+ *  #ifdef VIGRID_SAFEZONE. The addon hooks vanilla PlayerBase and WeaponManager directly, so it
+ *  works on any DayZ server with or without Battle Royale loaded. That keeps a later extraction into
+ *  a standalone @Vigrid-SafeZone mod a build-plumbing job rather than a rewrite - and it keeps
+ *  `config.cpp.disabled` working as a one-rename kill switch.
+ *
+ *  The addon ships no assets, no settings file and no UI text, so unlike KillFeed there is no asset
+ *  prefix constant to keep in sync.
+ */
+class CfgPatches
+{
+    class VigridSafeZone
+    {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+        requiredAddons[] =
+        {
+            "DZ_Data",
+            "DZ_Scripts"
+        };
+    };
+};
+
+class CfgMods
+{
+    class VigridSafeZone
+    {
+        dir = "Extra/SafeZone";
+        credits = "Myst";
+        type = "mod";
+        name = "Vigrid Safe Zone";
+
+        dependencies[] =
+        {
+            "Game",
+            "World"
+        };
+
+        //--- Consumed by the Battle Royale mod to guard its call sites. defines[] are visible
+        //--- across CfgMods entries - the same mechanism that made #ifdef Carim work.
+        defines[] =
+        {
+            "VIGRID_SAFEZONE"
+        };
+
+        //--- Only declare a script module once its folder actually exists: the engine registers
+        //--- files by directory, and pointing a module at a missing folder is a load-time error.
+        //--- There is no 5_Mission folder here on purpose - the addon needs no mission bootstrap.
+        class defs
+        {
+            class gameScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/SafeZone/Scripts/3_Game"
+                };
+            };
+            class worldScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/SafeZone/Scripts/4_World"
+                };
+            };
+        };
+    };
+};

--- a/Scripts/Client/5_Mission/GUI/InGameMenu.c
+++ b/Scripts/Client/5_Mission/GUI/InGameMenu.c
@@ -12,7 +12,30 @@ modded class InGameMenu
 
         SetServerInfoVisibility( false ); //Don't ever show what server you're on for DayZBR
 
+        HideExpansionNewsFeed();
+
         return result;
+    }
+
+    //--- Expansion builds its news feed in InGameMenu.Init() and parents it to layoutRoot. Its
+    //--- default links are placeholder Discord/Twitter entries pointing at google.com, and the
+    //--- default text is "CHANGE ME". None of it belongs on a DayZBR server, so drop the panel.
+    //--- Deliberately reached through m_NewsFeed rather than by widget name: naming the
+    //--- ExpansionNewsFeed type here would be a hard compile dependency, the member is not.
+    protected void HideExpansionNewsFeed()
+    {
+        if ( m_NewsFeed )
+            m_NewsFeed.GetLayoutRoot().Show( false );
+    }
+
+    //--- Expansion_OnGeneralSettingsUpdated() runs again whenever the server pushes its general
+    //--- settings, which is after Init() on a fresh connect. Today it only ever hides the feed, so
+    //--- this override is insurance against that changing rather than a fix for a live re-show.
+    override void Expansion_OnGeneralSettingsUpdated()
+    {
+        super.Expansion_OnGeneralSettingsUpdated();
+
+        HideExpansionNewsFeed();
     }
 
     override protected void SetGameVersion()

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
@@ -73,6 +73,13 @@ class BattleRoyaleDebug: BattleRoyaleDebugState
         KillFeedAPI.SetActive( false );
 #endif
 
+#ifdef VIGRID_SAFEZONE
+        //--- Lobby truce: the trigger does nothing and nothing another player does can hurt you.
+        //--- Aiming and melee swings still work, so players can still punch each other while they
+        //--- wait - which is the point, and the reason this is not Expansion's safezone.
+        VigridSafeZoneAPI.SetActive( true );
+#endif
+
         super.Activate();
     }
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
@@ -160,6 +160,12 @@ class BattleRoyaleStartMatch: BattleRoyaleState
 
         b_IsGameplay = true;
 
+#ifdef VIGRID_SAFEZONE
+        //--- Lift the lobby truce here rather than in Activate(): input is still locked through the
+        //--- warm-up countdown, so this is the first instant a player could actually shoot back.
+        VigridSafeZoneAPI.SetActive( false );
+#endif
+
         OpenLeaderboardMatch();
     }
 


### PR DESCRIPTION
Extra/SafeZone replaces DayZ Expansion's Safe Zone for the lobby. It hooks
vanilla PlayerBase and WeaponManager directly, so it works on any DayZ server -
Battle Royale is not required - and it follows the same discipline rule as
Party/ and Extra/KillFeed/: no BattleRoyale* symbol, its own logger, no shared
settings.

While active it changes exactly two things, and that narrowness is the point:
WeaponManager.CanFire returns false, so pulling the trigger does nothing - no
shot, no round consumed, no noise - and PlayerBase.EEOnDamageCalculated discards
damage another player inflicted. Weapon raise, ADS, melee swings, reloading and
user actions all behave normally, so players can still aim and still punch each
other in the lobby. Falls, drowning, infected, animals and the mod's own
scripted zone damage all still land.

That is why it is not a port of Expansion's safezone, which kills ADS for every
item, hard-returns from the melee fight logic, and cancels all damage rather
than just PvP.

State is global rather than geographic - one static flag mirrored onto each
player as a netsync bool, specifically so a player joining an already-running
lobby is disarmed too.

Also hides DayZ Expansion's news feed panel on the in-game menu.

Squashed from 2 commits:
  b0722d9  Merge branch 'lobby-safezone-addon' - replace Expansion's Safe Zone with a narrow in-repo lobby truce
  0ea1737  Merge branch 'worktree-hide-socials-panel' - hide DayZ Expansion's news feed panel on the in-game menu

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 14 of 31 replaying the local history onto `main`.
