### PR TITLE
Document every Extra/ sub-addon with a README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Build result: `Workbench/Logs/Build.log`, plus marker files `Build.success` / `B
 | `_LaunchServer.bat <SteamID>` | Clear logs + storage, then start the dedicated server. |
 | `SetupLaunch.bat <MP\|SP>` | Preamble for every `Launch*.bat`: config, validation, mod list, kill running game. Deliberately no `setlocal` — it exports into the caller. |
 
-Each `config.cpp` with no ancestor `config.cpp` becomes one PBO — currently 8 mod PBOs (`Data`, `GUI`, `LanguageCore`, `Models_Shapes`, `Sounds`, `Scripts_Client`, `Scripts_Server`, `Party`) plus 12 `Extra_*`. Renaming a top-level folder renames its PBO.
+Each `config.cpp` with no ancestor `config.cpp` becomes one PBO — currently 8 mod PBOs (`Data`, `GUI`, `LanguageCore`, `Models_Shapes`, `Sounds`, `Scripts_Client`, `Scripts_Server`, `Party`) plus 13 `extra_*`. Renaming a top-level folder renames its PBO. PBO names are lowercased by the build, so `Extra/KillFeed` packs as `extra_killfeed.pbo`.
 
 ## Testing
 
@@ -274,7 +274,7 @@ Note the imageset's internal name is `battleroyale_gui`, not the filename `dayzb
 
 ## Notes
 
-- `Extra/` holds 14 independent single-purpose sub-addons, each its own PBO, all built unconditionally. All are small script tweaks except `Extra/KillFeed/` and `Extra/SafeZone/`, self-contained addons documented under *Architecture → Kill feed* and *Architecture → Safe zone / lobby truce*.
+- `Extra/` holds 14 independent single-purpose sub-addons, each its own PBO. 13 are built; `Extra/DisableFogChernarusPlus/` is parked as `config.cpp.disabled` and produces no PBO. All are small script tweaks except `Extra/KillFeed/` and `Extra/SafeZone/`, self-contained addons documented under *Architecture → Kill feed* and *Architecture → Safe zone / lobby truce*. Each folder carries its own `README.md`, indexed by `Extra/README.md`.
 - `Extra/RandomMenuGear/` re-dresses the main-menu intro character in a random outfit plus a slung rifle and a melee weapon, re-rolled on every menu show. It hooks vanilla `IntroSceneCharacter.CreateNewCharacterById` (creation, prev/next arrows) and `MainMenu.OnShow` (returning from a submenu — that path calls `OnChangeCharacter(false)` and never recreates the character). It is **not** a fix for the broken character save that makes the menu character render naked; it only decorates the spawned object. Gear is applied with `GameInventory.CreateAttachmentEx` and deliberately never written into `MenuDefaultCharacterData` — that map is serialized to the server on connect and saved locally, so writing to it would leak menu gear into the real spawn loadout. Same discipline rule as `Party/` and `Extra/KillFeed/`: no `BattleRoyale*` symbol may be referenced.
 - Spectating is not implemented — `GUI/layouts/hud/spectator/player.layout` exists but nothing references it. Death shows a screen, then forces disconnect.
 - `Workbench/version` (`0.8.100368`) is a DayZ build number read by nothing. The mod version is `BATTLEROYALE_VERSION`.

--- a/Extra/ChangeFeedbackURL/README.md
+++ b/Extra/ChangeFeedbackURL/README.md
@@ -1,0 +1,51 @@
+# Change Feedback URL
+
+Repoints the vanilla **Feedback** button away from Bohemia's bug tracker and at this mod's GitHub
+repository, so a player reporting a problem lands somewhere the mod's maintainers actually read.
+
+|                 |                                                              |
+|-----------------|--------------------------------------------------------------|
+| **PBO**         | `extra_changefeedbackurl.pbo`                                 |
+| **Side**        | client-facing, but unguarded — it compiles on the server too  |
+| **Stages**      | `5_Mission`                                                   |
+| **`defines[]`** | none                                                          |
+| **Standalone**  | **no** — depends on the main mod (see Caveats)                |
+
+## How it works
+
+DayZ has three separate Feedback buttons, each with its own handler. All three are overridden with the
+same one-line body, `GetGame().OpenURL( GITHUB_URL );`:
+
+| File | Class | Method | Vanilla URL it replaces |
+|---|---|---|---|
+| `Scripts/5_Mission/GUI/InGameMenu.c` | `InGameMenu` | `OpenFeedback()` | `https://report.bistudio.com/projects/dayz` |
+| `Scripts/5_Mission/GUI/NewUI/MainMenu/MainMenu.c` | `MainMenu` | `OpenFeedback()` | `https://report.bistudio.com/projects/dayz` |
+| `Scripts/5_Mission/GUI/NewUI/MainMenu/MainMenuNewsFeed.c` | `MainMenuNewsfeed` | `OpenFeedback()` | `https://feedback.bistudio.com/tag/dayz` |
+
+None of the three calls `super`, so the vanilla URL is replaced outright rather than opening both.
+
+## Changing the URL
+
+The destination is **not** defined here. It comes from the main mod:
+
+```c
+// Scripts/Client/2_GameLib/BattleRoyaleConstants.c:24
+static const string GITHUB_URL = "https://github.com/LeMyst/Vigrid-BattleRoyale";
+```
+
+Edit it there and every Feedback button follows.
+
+## Caveats
+
+- **Not standalone.** `requiredAddons[]` lists only `DZ_Scripts`, yet the code reads `GITHUB_URL`,
+  a symbol owned by `BattleRoyale_Scripts_Client`. It compiles today only because `2_GameLib` is an
+  earlier stage than `5_Mission` — this PBO will not build or run without the main mod. Either add
+  `BattleRoyale_Scripts_Client` to `requiredAddons[]`, or inline the URL, before reusing it elsewhere.
+- The main mod also declares `modded class MainMenu` and `modded class InGameMenu`, and
+  `Extra/RandomMenuGear` declares a third `modded class MainMenu`. These chain rather than conflict —
+  none of the others touches `OpenFeedback`.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely and the
+vanilla Bohemia links come back.

--- a/Extra/DefaultFullAuto/README.md
+++ b/Extra/DefaultFullAuto/README.md
@@ -1,0 +1,46 @@
+# Default Full Auto
+
+Every weapon that has a full-auto fire mode spawns already switched to it, so a player who picks a
+rifle up mid-fight does not have to remember to toggle the selector first.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_defaultfullauto.pbo`                             |
+| **Side**        | server (`#ifdef SERVER`)                                |
+| **Stages**      | `4_World`                                               |
+| **`defines[]`** | none                                                    |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+## How it works
+
+`modded class Weapon_Base` overrides `EEInit()`, calls `super.EEInit()` first, then walks every muzzle
+on the weapon looking for an auto-fire mode:
+
+```c
+for (int i = 0; i < GetMuzzleCount(); i++)
+{
+    int newMuzzleMode = GetCurrentMode(i);          // fallback: whatever the config default was
+    for (int j = 0; j < GetMuzzleModeCount(i); j++)
+    {
+        SetCurrentMode(i, j);
+        if (GetCurrentModeAutoFire(i)) { newMuzzleMode = j; break; }
+    }
+    SetCurrentMode(i, newMuzzleMode);
+}
+```
+
+The scan works by *mutating* the current mode and reading `GetCurrentModeAutoFire` back, then
+committing the winner on the last line. Weapons with no auto mode keep their config default, so
+semi-only guns are untouched.
+
+Because this hooks `EEInit` rather than `EEOnCECreate`, it applies to **every** weapon created
+server-side — loot spawns, admin-spawned guns and scripted loadouts alike.
+
+## Caveats
+
+- `Extra/SpawnWeaponChambered` also does `modded class Weapon_Base { override void EEInit() }`. The two
+  are compatible: both call `super.EEInit()` first and they touch disjoint state (fire mode vs. chamber).
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely.

--- a/Extra/DisableFogChernarusPlus/README.md
+++ b/Extra/DisableFogChernarusPlus/README.md
@@ -1,0 +1,58 @@
+# Disable Fog (Chernarus+)
+
+Removes volumetric and camera fog from the Chernarus+ terrain, so distant players are not hidden by
+weather in a mode where sightlines decide fights.
+
+> **This addon is currently disabled and does not ship.** Its config file is named
+> `config.cpp.disabled`, so the build never sees it and no PBO is produced.
+
+|                 |                                                                 |
+|-----------------|-----------------------------------------------------------------|
+| **PBO**         | none — disabled (would be `extra_disablefogchernarusplus.pbo`)    |
+| **Side**        | n/a — no script at all; a config patch loads wherever the PBO does |
+| **Stages**      | none — this addon registers no script modules                     |
+| **`defines[]`** | none                                                              |
+| **Standalone**  | yes — no scripts, no `BattleRoyale*` symbol referenced             |
+
+## Why it is parked
+
+**It targets Chernarus+ only, and this mod runs on Vigrid.** The patch hardcodes the world classes
+`CAWorld` and `ChernarusPlus`, so on Vigrid it does nothing at all. It is kept rather than deleted
+because it is still correct for anyone running the mod on Chernarus+, and because it is the repo's
+reference example of the disable-by-rename technique.
+
+## How it works
+
+There is no script. The whole addon is a `CfgWorlds` override that zeroes the fog parameters on both
+the shared base world class and Chernarus+ itself:
+
+```cpp
+class CAWorld: DefaultWorld       // and, identically, class ChernarusPlus: CAWorld
+{
+    class Weather
+    {
+        class VolFog
+        {
+            CameraFog  = 0;
+            UseDynamic = 0;
+            Item1[] = {0,0,0,0,0};
+            Item2[] = {0,0,0,0,0};
+        };
+    };
+};
+```
+
+`requiredAddons[]` is `DZ_Worlds_Chernarusplus_World` — the only addon in `Extra/` that does not
+require `DZ_Scripts`, since it has no script to compile.
+
+## Caveats
+
+- Patching `CAWorld` means **every** CAWorld-derived terrain that does not re-specify its own `VolFog`
+  inherits the zeroed values, not just Chernarus+.
+- Fog is a gameplay-balance lever as much as a visual one. Turning it off removes a concealment
+  mechanic; that is the point, but it is worth being deliberate about.
+
+## Enabling
+
+Rename `config.cpp.disabled` → `config.cpp` and rebuild. The folder will then be packed as
+`extra_disablefogchernarusplus.pbo`.

--- a/Extra/KillFeed/README.md
+++ b/Extra/KillFeed/README.md
@@ -1,0 +1,136 @@
+# Kill Feed
+
+An on-screen feed of recent deaths, showing who killed whom, with what weapon (rendered as a real 3D
+model with its attachments) and at what range. It replaces the third-party `nulledkillfeed.pbo`.
+
+It hooks vanilla `PlayerBase.EEKilled` itself, so it works on **any** DayZ server — Battle Royale is
+not required.
+
+|                 |                                                                     |
+|-----------------|---------------------------------------------------------------------|
+| **PBO**         | `extra_killfeed.pbo`                                                 |
+| **Side**        | both — split by `#ifdef` per file, not by folder                     |
+| **Stages**      | `3_Game`, `4_World`, `5_Mission`                                     |
+| **`defines[]`** | `KILLFEED`                                                           |
+| **Requires**    | `DZ_Data`, `DZ_Scripts`, **`JM_CF_Scripts`** (CF, for the RPC manager) |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced                           |
+
+## Settings
+
+`$profile:KillFeed\killfeed_settings.json`, created on first boot.
+
+| Key | Default | Meaning |
+|---|---|---|
+| `version` | `2` | migration marker, do not edit |
+| `enabled` | `true` | master switch; `false` stops the server broadcasting entirely |
+| `show_distance` | `true` | append the metre count on gunshot rows |
+| `show_environment_deaths` | `true` | when `false`, every row with no killer is dropped — zone, falls, starvation, infected, animals |
+| `suppress_other_killfeeds` | `true` | turn off other mods' feeds so a death is not announced twice |
+
+The file is re-saved immediately after loading, so fields added in a later version appear in an
+existing server's JSON on next boot. There is **no `$mission:` override** — profile only.
+
+## Public API
+
+The Battle Royale mod talks to this addon only through `KillFeedAPI` (`Scripts/4_World/KillFeedAPI.c`),
+and every call site is wrapped in `#ifdef KILLFEED` so the mod still builds with the addon removed:
+
+```c
+static void KillFeedAPI.SetActive(bool active)
+static bool KillFeedAPI.IsActive()
+static void KillFeedAPI.NoteEnvironmentalDamage(PlayerBase victim, int cause)
+```
+
+Five call sites in the mod:
+
+| State | Call |
+|---|---|
+| `1_BattleRoyaleDebug` | `SetActive(false)` — feed off in the lobby |
+| `5_BattleRoyaleStartMatch` | `SetActive(true)` — feed on with the match |
+| `6_BattleRoyaleRound` | `NoteEnvironmentalDamage(player, KillFeedCause.ZONE)` |
+| `7_BattleRoyaleLastRound` | same, last-round damage tick |
+| `8_BattleRoyaleWin` | `SetActive(false)` — match over |
+
+### Why `NoteEnvironmentalDamage` exists
+
+Scripted damage — the mod's `DecreaseHealthCoef` zone tick — reaches `EEKilled` with the victim listed
+as their own killer. Without a hint, a zone death is indistinguishable from starvation. So the zone
+damage sites push a hint, which the death consumes.
+
+Hints expire after `KILLFEED_HINT_TTL_MS` (10 s) and are always cleared when read, so a stale hint can
+never mislabel a later death. It is designed to be called on every damage tick.
+
+## How a killer is attributed
+
+`KillFeedDeath` follows vanilla's own `PluginAdminLog.PlayerKilled` cascade, in order:
+
+1. No source, or the victim is their own source → consume a hint (defaults to `ENVIRONMENT`).
+2. `Grenade_Base` / `LandMineTrap` → `EXPLOSIVE`, killer resolved from the activator.
+3. Source is a weapon or melee weapon → killer is the item's hierarchy parent; `MELEE`, or `WEAPON`
+   plus the rounded 3D distance.
+4. Source is a player → `BAREHANDS`.
+5. `ZombieBase` → `INFECTED`; `AnimalBase` → `ANIMAL`.
+
+Then two filters: environmental rows are dropped if disabled, and a killer name equal to the victim
+name is blanked — it reads as a bug.
+
+Explosive attribution is deliberately **reflective** (`EnScript.GetClassVar(source, "m_ActivatorId", …)`)
+so the addon never names the host mod's grenade classes. On a bare DayZ server that field is absent
+and the row simply renders without a killer.
+
+## Networking
+
+One namespace, server → client only; the client never talks back.
+
+- Namespace `RPC-KillFeed`, message `KF_Entry`, sent guaranteed with **no identity**, which is what
+  makes CF fan it out to every client.
+- Payload: killer, victim, weapon, attachments, distance, cause. Attachment classnames travel as one
+  string joined by `;` — a character that cannot appear in a DayZ classname.
+- CF dispatches by **method name**, so the handler on `KillFeedRPC` must stay named `KF_Entry`.
+
+## Rendering
+
+A row shows the killer's weapon with its attachments by spawning a client-local `ECE_LOCAL` copy,
+re-attaching the classnames the server sent, and handing it to an `ItemPreviewWidget` — the same
+mechanism as the vanilla quickbar. At most `KILLFEED_MAX_ROWS` preview entities exist at once, and each
+is `Delete()`d when its row expires.
+
+The weapon cell is sized per weapon from its config `itemSize`, clamped to 48–170 px, so a crossbow
+does not leave 90 px of dead space before the victim's name.
+
+## Suppressing other feeds
+
+`KillFeedSuppress` turns off other mods' kill feeds when `suppress_other_killfeeds` is set. Each block
+is behind that mod's own define — currently only `#ifdef EXPANSIONMODKILLFEED`, which clears
+`GetExpansionSettings().GetNotification().EnableKillFeed`. That is Expansion's own documented switch,
+and the change is **in memory only**, so the admin's `NotificationSettings.json` is untouched and
+removing this addon restores the previous behaviour.
+
+It is applied from `MissionServer.OnInit` plus one re-apply 10 s later, in case another mod loads its
+settings afterwards.
+
+**NulledKillfeed is not covered** — it is an obfuscated third-party PBO with no API to call. If you run
+it, either remove it from `Workbench/ExtraPBOs/` or zero every `"active"` in its own
+`$profile:KillFeed\Settings.json`.
+
+## Logging
+
+`-killfeed-trace` / `-killfeed-debug` / `-killfeed-info` / `-killfeed-warn` / `-killfeed-none` on the
+command line, or `KillFeedLogLevel` in `serverDZ.cfg` (server only; negative disables). Diag builds
+default to trace.
+
+## Caveats
+
+- `$profile:KillFeed\` is **shared with NulledKillfeed's `Settings.json`**. The filenames differ so
+  they coexist, but deleting the folder to remove one wipes the other.
+- Display tuning (`KILLFEED_MAX_ROWS`, `KILLFEED_ROW_SECONDS`, row geometry) is **compile-time
+  constants, not settings** — the settings class is `#ifdef SERVER` and the client cannot read it.
+- `KILLFEED_ICON_DEFAULT` is declared but never read; the skull icon actually comes from `image0` in
+  `killfeed_row.layout`, so changing that constant does nothing.
+- `KILLFEED_PREFIX` is the single place the asset path appears — keep it in sync if the folder moves.
+
+## Disabling
+
+Set `"enabled": false` in the settings JSON to keep the PBO but silence the feed. To remove it
+entirely, rename `config.cpp` → `config.cpp.disabled` and rebuild — the mod's own call sites are all
+`#ifdef KILLFEED`, so it still builds without this addon.

--- a/Extra/LimitUnconsciousTime/README.md
+++ b/Extra/LimitUnconsciousTime/README.md
@@ -1,0 +1,74 @@
+# Limit Unconscious Time
+
+Caps how long a player can be knocked out. In vanilla, unconsciousness lasts until shock regenerates
+past the wake threshold, which in a battle royale means a player can be out of the match for minutes
+with nothing to do. This force-wakes them after **5 seconds**.
+
+|                 |                                                    |
+|-----------------|----------------------------------------------------|
+| **PBO**         | `extra_limitunconscioustime.pbo`                    |
+| **Side**        | server (`#ifdef SERVER`)                            |
+| **Stages**      | `4_World`                                           |
+| **`defines[]`** | none                                                |
+| **Standalone**  | **no** — depends on the main mod (see Caveats)      |
+
+## How it works
+
+`modded class UnconsciousnessMdfr` overrides three methods on the vanilla unconsciousness modifier.
+
+**`ActivateCondition`** — stamps `player.m_UnconsciousStartTime` with the current time when the player
+goes down, then defers to vanilla's own condition (shock at or below 25).
+
+**`DeactivateCondition`** — the actual limit:
+
+```c
+if (GetGame().GetTime() - player.m_UnconsciousStartTime > (UNCONSCIOUSNESS_MAX_TIME * 1000))
+{
+    player.SetHealth("", "Shock", SHOCK_DAMAGE_AFTER_UNCONSCIOUSNESS);
+    return true;    // wake up
+}
+return super.DeactivateCondition(player);
+```
+
+Two constants drive it (both at the top of `Unconsciousness.c`, marked with a `// TODO: move to config`):
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `UNCONSCIOUSNESS_MAX_TIME` | `5.0` | seconds before a forced wake-up |
+| `SHOCK_DAMAGE_AFTER_UNCONSCIOUSNESS` | `PlayerConstants.CONSCIOUS_THRESHOLD + 0.1` = **50.1** | shock the player is set to on waking — just past the threshold, so they wake and stay awake |
+
+`GetGame().GetTime()` is in milliseconds, hence the `* 1000`. Below the limit, vanilla rules still
+apply (shock at or above 50 **and** a regular pulse).
+
+## Configuration
+
+Unconsciousness can be switched off entirely — two independent kill-switches, either one is enough.
+Both are read only by this addon and are documented nowhere else:
+
+| Where | Key | Effect |
+|---|---|---|
+| `serverDZ.cfg` | `BRDisableUnconsciousness = 1;` | disables unconsciousness |
+| server command line | `-br-disable-unconsciousness` | same |
+
+When disabled, a player who would have gone down instead stays conscious and is **forced prone**:
+
+```c
+HumanCommandMove hcm = player.GetCommand_Move();
+if (hcm) hcm.ForceStance(DayZPlayerConstants.STANCEIDX_PRONE);
+```
+
+## Caveats
+
+- **Not standalone.** `requiredAddons[]` lists only `DZ_Scripts`, but the code reads
+  `player.m_UnconsciousStartTime` (declared by the main mod's `PlayerBase`,
+  `Scripts/Server/4_World/Entities/ManBase/PlayerBase.c`) and calls `BattleRoyaleUtils`. It works today
+  by incidental load order, not by contract — `TODO.md` tracks adding `BattleRoyale_Scripts_Server` to
+  `requiredAddons[]`.
+- In the **disabled** path the player keeps their low shock, so the vanilla condition keeps
+  re-evaluating on every modifier tick and re-issues the prone command each time.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely and
+vanilla unconsciousness duration returns. To keep the addon but turn the mechanic off at runtime, use
+the `serverDZ.cfg` key above instead.

--- a/Extra/PreventPlayerModifiers/README.md
+++ b/Extra/PreventPlayerModifiers/README.md
@@ -1,0 +1,53 @@
+# Prevent Player Modifiers
+
+Turns off the vanilla survival simulation — hunger, thirst, illness and broken legs. A battle royale
+match lasts minutes, so metabolism and disease add bookkeeping without adding decisions, and a broken
+leg is effectively a death sentence with no time to heal.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_preventplayermodifiers.pbo`                      |
+| **Side**        | mixed — see Caveats                                     |
+| **Stages**      | `4_World`                                               |
+| **`defines[]`** | none                                                    |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+## How it works
+
+Eight files, nine modded classes, three different techniques:
+
+| Class | Override | Effect |
+|---|---|---|
+| `HungerMdfr` | `OnTick` → empty | No energy drain, no hungry sound state, no starvation damage. The modifier still activates; it just does nothing. |
+| `ThirstMdfr` | `OnTick` → empty | Same, for water and dehydration damage. |
+| `CommonColdMdfr` | `ActivateCondition` → `false` | Never contract common cold. |
+| `InfluenzaMdfr` | `ActivateCondition` → `false` | Never contract influenza. |
+| `PneumoniaMdfr` | `ActivateCondition` → `false` | Never contract pneumonia. |
+| `WoundInfectStage1Mdfr` | `ActivateCondition` → `false` | Never contract wound infection. Vanilla's stage-1 deactivate condition is the inverse of activate, so an already-active infection also clears. |
+| `WoundInfectStage2Mdfr` | `ActivateCondition` → `false` | As above, second stage. |
+| `BrokenLegsMdfr` | `OnActivate`, `OnReconnect`, `Activate` → all empty | Legs never break: no `SetBrokenLegs`, no fracture notifier, and the modifier cannot enter the active set at all. |
+| `HeatComfortAnimHandler` | `Update` → returns immediately | No heat-comfort symptom animations (shivering, rattling, overheating). Not a modifier — this is the client-side animation handler. |
+
+## Not covered
+
+These vanilla diseases are left fully active, in case you expected a clean sweep:
+
+`Cholera`, `Salmonella`, `Contamination1/2/3`, `HeavyMetal`, `BrainDisease`.
+
+Bleeding, blood loss and shock are also untouched — they are core combat mechanics, not survival ones.
+
+## Caveats
+
+- **The `#ifdef SERVER` guard is inconsistent.** Only `BrokenLegs.c` has one; the other seven files
+  have no guard and therefore compile and run client-side too. For `HeatComfortAnimHandler` that is
+  arguably load-bearing (it is a client-side handler), but for the `*Mdfr` classes the modifier manager
+  is server-authoritative, so the client copies are redundant. Tracked in `TODO.md`.
+- The three disease files declare `override protected bool ActivateCondition`, but vanilla
+  `CommonColdMdfr.ActivateCondition` is declared **without** `protected`. Worth knowing if this ever
+  produces a compile warning.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely and full
+vanilla survival mechanics return. There is no runtime switch — remove individual `.c` files if you
+want to keep only some of the effects.

--- a/Extra/PreventWeaponRaise/README.md
+++ b/Extra/PreventWeaponRaise/README.md
@@ -1,0 +1,47 @@
+# Prevent Weapon Raise
+
+Stops the weapon from being forced upward when the muzzle is close to a wall or doorway. Vanilla's
+lift-weapon behaviour is a realism touch that reads as unresponsive in close-quarters fights, so it is
+removed here.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_preventweaponraise.pbo`                          |
+| **Side**        | client (`#ifndef SERVER`)                               |
+| **Stages**      | `4_World`                                               |
+| **`defines[]`** | none                                                    |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+## How it works
+
+`modded class PlayerBase` overrides `CheckLiftWeapon()` and does **not** call `super`, discarding
+vanilla's obstruction raycast entirely. All that is left is the un-lift path:
+
+```c
+override void CheckLiftWeapon()
+{
+    if (GetInstanceType() == DayZPlayerInstanceType.INSTANCETYPE_CLIENT)
+    {
+        // Never lift weapon and sync it to false if already lifted
+        if (m_LiftWeapon_player)
+            SendLiftWeaponSync(false);
+    }
+}
+```
+
+So the lift state is never set, and if something else already set it, it is synced back to `false`.
+
+Despite the addon's name, this affects **only** the obstruction lift. Raising the weapon normally,
+aiming down sights and melee are all untouched.
+
+## Caveats
+
+- Vanilla's `CheckLiftWeapon` also computes and syncs a separate weapon-obstruction value. This
+  override never writes it, so a nonzero obstruction value set before the addon loaded can be left
+  stale.
+- Skipping the check means a player can fire with the muzzle inside geometry. That is the intended
+  trade-off, but it does allow shooting through thin cover in ways vanilla prevents.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely.

--- a/Extra/README.md
+++ b/Extra/README.md
@@ -1,0 +1,67 @@
+# Extra addons
+
+`Extra/` holds independent, single-purpose sub-addons. Each is a small self-contained tweak that could
+be lifted out of this repository and shipped on its own; none is required for the Battle Royale mod to
+function.
+
+**14 folders, 13 of which build** — `DisableFogChernarusPlus` is currently parked.
+
+## How this folder works
+
+- **One PBO per folder.** The build packs every folder that holds a `config.cpp` with no ancestor
+  `config.cpp`. Keep exactly one `config.cpp` per addon and do not nest another below it.
+- **Rename to disable.** `config.cpp` → `config.cpp.disabled` removes an addon from the build with a
+  single rename. `DisableFogChernarusPlus/` is the worked example.
+- **PBO names are lowercase**, derived from the folder path: `Extra/KillFeed` →
+  `extra_killfeed.pbo`.
+- **Discipline rule: no `Extra/` addon may reference a `BattleRoyale*` symbol.** That is what keeps
+  each one extractable into a standalone mod as a build-plumbing job rather than a rewrite. Two addons
+  currently break this rule and are marked below.
+- **Side is set by the `#ifdef` on line 1 of each `.c` file**, not by the folder it lives in. An
+  unguarded file compiles and runs on both client and server.
+
+Adding a new one: create a folder with its own `config.cpp` and `Scripts/<stage>/`, and it becomes its
+own PBO automatically. See the root `CLAUDE.md` for the script-module and stage conventions.
+
+## The addons
+
+| Addon | PBO | Side | What it does |
+|---|---|---|---|
+| [ChangeFeedbackURL](ChangeFeedbackURL/README.md) | `extra_changefeedbackurl.pbo` | client | Points the vanilla Feedback button at this mod's GitHub repo instead of Bohemia's tracker. **Not standalone** |
+| [DefaultFullAuto](DefaultFullAuto/README.md) | `extra_defaultfullauto.pbo` | server | Weapons spawn already set to full auto where they have one |
+| [DisableFogChernarusPlus](DisableFogChernarusPlus/README.md) | *disabled* | — | Removes fog on Chernarus+. Parked: it does nothing on Vigrid |
+| [KillFeed](KillFeed/README.md) | `extra_killfeed.pbo` | both | On-screen death feed with weapon models, attachments and range |
+| [LimitUnconsciousTime](LimitUnconsciousTime/README.md) | `extra_limitunconscioustime.pbo` | server | Force-wakes an unconscious player after 5 seconds. **Not standalone** |
+| [PreventPlayerModifiers](PreventPlayerModifiers/README.md) | `extra_preventplayermodifiers.pbo` | both | Disables hunger, thirst, broken legs and four diseases |
+| [PreventWeaponRaise](PreventWeaponRaise/README.md) | `extra_preventweaponraise.pbo` | client | Stops the weapon being forced up against walls |
+| [RandomMenuGear](RandomMenuGear/README.md) | `extra_randommenugear.pbo` | client | Re-dresses the main-menu character randomly on every menu show |
+| [SafeZone](SafeZone/README.md) | `extra_safezone.pbo` | both | Lobby truce — no firing, no player-inflicted damage |
+| [SpawnCarFull](SpawnCarFull/README.md) | `extra_spawncarfull.pbo` | server | Vehicles spawn with 30–100 % fuel, plus full coolant and oil |
+| [SpawnWeaponChambered](SpawnWeaponChambered/README.md) | `extra_spawnweaponchambered.pbo` | server | Weapons spawn with a round chambered and a magazine where possible |
+| [SpawnWithAmmoAndMagazine](SpawnWithAmmoAndMagazine/README.md) | `extra_spawnwithammoandmagazine.pbo` | server | Loot firearms spawn with magazines on the ground beside them |
+| [SpawnWithBattery](SpawnWithBattery/README.md) | `extra_spawnwithbattery.pbo` | server | Battery-powered loot spawns with a battery fitted |
+| [Vehicle3PPDefaultFix](Vehicle3PPDefaultFix/README.md) | `extra_vehicle3ppdefaultfix.pbo` | both | Forces common vehicles into the third-party Vehicle3PP whitelist |
+
+## Runtime configuration
+
+Most of these have no settings at all. The ones that do:
+
+| Addon | Where |
+|---|---|
+| KillFeed | `$profile:KillFeed\killfeed_settings.json` — 4 options |
+| SpawnWithAmmoAndMagazine | `serverDZ.cfg`: `BRDisableSpawnWithAmmo`, `BRMinSpawnAmmo`, `BRMaxSpawnAmmo` |
+| LimitUnconsciousTime | `serverDZ.cfg`: `BRDisableUnconsciousness`, or `-br-disable-unconsciousness` on the command line |
+| SafeZone | none — controlled entirely through its API |
+
+## Compile-time defines
+
+Only three addons declare a `defines[]`, which is what lets the mod guard its call sites with
+`#ifdef`:
+
+| Define | Addon | Used by the mod? |
+|---|---|---|
+| `KILLFEED` | KillFeed | yes — 5 call sites |
+| `VIGRID_SAFEZONE` | SafeZone | yes — 2 call sites |
+| `RANDOM_MENU_GEAR` | RandomMenuGear | no — declared for consistency only |
+
+The other eleven declare none, so nothing can `#ifdef`-guard against them.

--- a/Extra/RandomMenuGear/README.md
+++ b/Extra/RandomMenuGear/README.md
@@ -1,0 +1,75 @@
+# Random Menu Gear
+
+Re-dresses the main-menu intro character in a random outfit, with a slung rifle and a melee weapon,
+re-rolled every time the menu is shown. Purely cosmetic — it makes the menu look like the mod rather
+than like a default DayZ install.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_randommenugear.pbo`                              |
+| **Side**        | client-local — no guards; gated at runtime by `IsDedicatedServer()` |
+| **Stages**      | `4_World`, `5_Mission`                                  |
+| **`defines[]`** | `RANDOM_MENU_GEAR` — declared for consistency, nothing consumes it today |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+No assets, no layouts, no stringtable, no settings, no RPC. Nothing outside the addon calls it.
+
+## What it is not
+
+**This is not a fix for the broken character save that makes the menu character render naked.** It only
+decorates whatever object was spawned. If your menu character appears nude without this addon, that is
+a separate problem and this does not address the cause.
+
+## How it works
+
+`RandomMenuGear.Apply(Man player)` clears every managed slot and re-rolls it. It is safe to call
+repeatedly. Two hooks call it, and both are needed:
+
+| Hook | Covers |
+|---|---|
+| `IntroSceneCharacter.CreateNewCharacterById` | every character *creation* — initial menu load, the prev/next arrows, returning from character creation |
+| `MainMenu.OnShow` | simply re-showing the menu, which calls `OnChangeCharacter(false)` and never recreates the character |
+
+Per slot, `Apply` finds any existing attachment and deletes it (clearing leftovers from both the
+character save and the previous roll), picks a random entry from that slot's pool, and attaches it with
+`GameInventory.CreateAttachmentEx`.
+
+Twelve slots, ordered so nothing is attached before the layer under it:
+
+`BODY`, `LEGS`, `FEET`, `VEST`, `BACK`, `HEADGEAR`, `MASK`, `EYEWEAR`, `GLOVES`, `ARMBAND`,
+`SHOULDER` (9 rifles), `MELEE`.
+
+An **empty-string entry in a pool means "leave this slot bare"** — the same trick vanilla's
+`GenerateRandomEquip` uses. `MASK` carries two empty entries so a face-covering mask is the exception
+rather than the rule; `VEST`, `EYEWEAR` and `ARMBAND` carry one each.
+
+## The load-bearing design decision
+
+Gear is applied straight to the spawned object and is **deliberately never written into
+`MenuDefaultCharacterData`**. That map is serialized to the server on connect and saved locally, so
+writing to it would leak random menu gear into the player's real spawn loadout.
+
+If you extend this addon, keep that rule.
+
+## Notes
+
+- Pool construction is **lazily initialised** on first use, not at static-initializer time:
+  `InventorySlots` constants are populated by the engine from `CfgSlots`, so they are only safe to read
+  once the game is up.
+- A rifle renders slung because `Rifle_Base` declares `inventorySlot[] = {"Shoulder","Melee"}`, which
+  makes it a proper slung proxy on the static menu idle pose.
+- This addon's `modded class MainMenu` chains cleanly onto the mod's own `modded class MainMenu`,
+  because that one does not override `OnShow()`.
+- The `CfgPatches` class is `Random_Menu_Gear` (underscored) so the config class never collides with
+  the script class `RandomMenuGear`. The PBO name comes from the folder, not from that class.
+
+## Changing the gear
+
+The pools are hardcoded parallel arrays in `BuildPools()` (`Scripts/4_World/RandomMenuGear.c`). Add or
+remove classnames there; every classname currently in the file was verified against the vanilla
+configs.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely and the
+menu character reverts to vanilla behaviour.

--- a/Extra/SafeZone/README.md
+++ b/Extra/SafeZone/README.md
@@ -1,0 +1,100 @@
+# Vigrid Safe Zone
+
+A lobby truce: while active, players cannot shoot each other and cannot damage each other. It exists so
+the pre-match lobby is not a free-for-all, and it replaces DayZ Expansion's Safe Zone for that purpose.
+
+It hooks vanilla `PlayerBase` and `WeaponManager` directly, so it works on **any** DayZ server — Battle
+Royale is not required.
+
+|                 |                                                            |
+|-----------------|------------------------------------------------------------|
+| **PBO**         | `extra_safezone.pbo`                                        |
+| **Side**        | both — deliberately, see below                              |
+| **Stages**      | `3_Game`, `4_World` (no `5_Mission` — it needs no bootstrap) |
+| **`defines[]`** | `VIGRID_SAFEZONE`                                           |
+| **Requires**    | `DZ_Data`, `DZ_Scripts` (no CF — it uses no RPC)             |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced                   |
+
+It ships **no assets, no settings file, no stringtable and no RPC namespace.** It defaults to off, so
+dropping the PBO on a server that never calls the API changes nothing.
+
+## What it actually changes
+
+Exactly two things, and the narrowness is the entire point:
+
+1. **`WeaponManager.CanFire` returns false.** Pulling the trigger does nothing — no shot, no round
+   consumed, no noise.
+2. **`PlayerBase.EEOnDamageCalculated` returns false** for damage another player inflicted, so the hit
+   is discarded before it is applied.
+
+Everything else is deliberately left alone. Weapon raise, ADS, melee swings, reloading and user actions
+all behave normally — players can still aim and still punch each other in the lobby.
+
+Falls, drowning, infected, animals and the mod's own scripted zone damage all still land, because the
+predicate resolves the damage source to a player (directly, via `GetHierarchyRootPlayer()` for a held
+weapon, or by explosive type) and returns false for anything else — **including the victim as their own
+source**, which is exactly how the mod's `DecreaseHealthCoef` zone damage surfaces.
+
+## Why not Expansion's safezone
+
+Expansion calls `hic.OverrideRaise(true, false)`, which kills ADS for every item including melee; hard
+-returns false from `DayZPlayerMeleeFightLogic_LightHeavy.HandleFightLogic`, so melee swings do not even
+play; and its `EEOnDamageCalculated` cancels *all* damage, not just PvP.
+
+**If Expansion's safezone is left enabled it stacks on top of this addon and all those restrictions come
+back.** Set `"Enabled": 0` in your mission's `Expansion/Settings/SafeZoneSettings.json`.
+
+## Public API
+
+```c
+static void VigridSafeZoneAPI.SetActive(bool active)   // idempotent
+static bool VigridSafeZoneAPI.IsActive()
+```
+
+Two call sites in the mod, both wrapped in `#ifdef VIGRID_SAFEZONE`:
+
+| State | Call |
+|---|---|
+| `1_BattleRoyaleDebug.Activate()` | `SetActive(true)` — truce on for the lobby |
+| `5_BattleRoyaleStartMatch.HandleUnlock()` | `SetActive(false)` — truce off |
+
+The lift point is `HandleUnlock` rather than `Activate` because input stays locked through the warm-up
+countdown — `HandleUnlock` is the first instant a player could actually shoot back.
+
+## Design notes
+
+**State is global, not geographic.** There is no zone module, no actor list and no per-tick
+point-in-shape test. The server owns one static flag and mirrors it onto each player as the netsync
+bool `m_VigridSafeZoneActive`.
+
+**Netsync rather than an RPC broadcast**, specifically so a player joining an already-running lobby is
+disarmed too; `OnConnect` / `OnReconnect` re-assert it unconditionally, because a rejoining player must
+never end up armed because a sync was missed.
+
+**`PlayerBase.c` and `WeaponManager.c` are deliberately unguarded** so both sides compile them:
+
+- The client needs the flag locally so `CanFire` can refuse the trigger without a round trip.
+- `RegisterNetSyncVariableBool` sits in the shared `Init()` override precisely so registration order is
+  byte-identical on both sides — mandatory for netsync.
+- Defence in depth: a client that patches out `CanFire` still lands zero damage, because
+  `EEOnDamageCalculated` runs server-side.
+
+## Caveats
+
+- **A discarded hit produces no hit reaction.** A punch lands visually for the attacker but the target
+  does not flinch. `TotalDamageResult` is getter-only, so scaling damage to zero is not available —
+  cancelling is the only clean route.
+- Expansion's safezone stacking, above. This is the one that bites in practice.
+- `VIGRID_SAFEZONE_VERSION` is declared but never read — unlike KillFeed, this addon has no
+  `MissionServer` boot line to log it.
+
+## Logging
+
+`-safezone-trace` / `-safezone-debug` / `-safezone-info` / `-safezone-warn` / `-safezone-none` on the
+command line, or `SafeZoneLogLevel` in `serverDZ.cfg`. Diag builds default to trace. This is the only
+external tuning knob the addon has.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the mod's two call sites are `#ifdef
+VIGRID_SAFEZONE`, so it still builds without this addon — the lobby simply becomes a free-for-all.

--- a/Extra/SpawnCarFull/README.md
+++ b/Extra/SpawnCarFull/README.md
@@ -1,0 +1,51 @@
+# Spawn Car Full
+
+Vehicles spawn ready to drive. Vanilla gives a freshly spawned car 0–35 % fuel and nothing else, so a
+found vehicle usually needs parts and jerrycans before it moves — too slow to matter inside a single
+battle royale match.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_spawncarfull.pbo`                                |
+| **Side**        | server (`#ifdef SERVER`)                                |
+| **Stages**      | `4_World`                                               |
+| **`defines[]`** | none                                                    |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+## How it works
+
+Two classes, each overriding `EEOnCECreate()`.
+
+**`CarScript`** — fuel is randomised, coolant and oil are filled completely:
+
+```c
+Fill( CarFluid.FUEL,    GetFluidCapacity( CarFluid.FUEL ) * Math.RandomFloatInclusive(0.30, 1) );
+Fill( CarFluid.COOLANT, GetFluidCapacity( CarFluid.COOLANT ) );
+Fill( CarFluid.OIL,     GetFluidCapacity( CarFluid.OIL ) );
+```
+
+**`BoatScript`** — boats only have a fuel fluid, so that is all there is to fill:
+
+```c
+Fill( BoatFluid.FUEL, GetFluidCapacity( BoatFluid.FUEL ) * Math.RandomFloatInclusive(0.30, 1) );
+```
+
+Net effect versus vanilla: **30–100 % fuel** instead of 0–35 %, plus full coolant and oil on cars.
+
+Because this hooks `EEOnCECreate`, it applies **only to Central-Economy vehicle spawns** — not to
+admin-spawned or scripted vehicles.
+
+## Caveats
+
+- Despite the in-file comment "Fill the car to max", **fuel is random 30–100 %**, not full. Only
+  coolant and oil are maxed.
+- Neither override calls `super.EEOnCECreate()`. That drops the vanilla base implementation and any
+  other mod's CE-spawn initialisation further along the chain, DayZ-Expansion included. Tracked in
+  `TODO.md`.
+- Attachments — battery, spark plug, radiator, wheels — are untouched. Whether a vehicle is actually
+  driveable still depends on your loot configuration. (`Extra/SpawnWithBattery` covers items with an
+  energy manager, not vehicle battery slots.)
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely.

--- a/Extra/SpawnWeaponChambered/README.md
+++ b/Extra/SpawnWeaponChambered/README.md
@@ -1,0 +1,43 @@
+# Spawn Weapon Chambered
+
+Weapons arrive with a round in the chamber and, where possible, a magazine attached — so a gun picked
+up mid-fight can be fired immediately rather than needing to be loaded and racked first.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_spawnweaponchambered.pbo`                        |
+| **Side**        | server (`#ifdef SERVER`)                                |
+| **Stages**      | `4_World`                                               |
+| **`defines[]`** | none                                                    |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+## How it works
+
+`modded class Weapon_Base` overrides `EEInit()`, calls `super.EEInit()` first, then:
+
+```c
+FillChamber( "", WeaponWithAmmoFlags.CHAMBER );   // "" = pick a valid ammo type at random
+
+Magazine mag = GetMagazine(0);
+if ( mag == NULL )
+    SpawnAmmo();                                  // vanilla: fill internal mag, else attach one, else fill chamber
+```
+
+Unlike the CE-only spawn addons in this folder, this hooks `EEInit`, so it fires for **every**
+`Weapon_Base` created server-side — loot spawns, admin-spawned weapons, scripted spawns and player
+loadouts alike.
+
+## Caveats
+
+- The magazine check uses muzzle index `0`, so on a double-barrel or other multi-muzzle weapon only the
+  first muzzle is inspected.
+- It runs immediately after `super.EEInit()`, which itself only *queues* `AssembleGun` on the game call
+  queue — chambering therefore happens before that queued assembly runs.
+- `Extra/DefaultFullAuto` also does `modded class Weapon_Base { override void EEInit() }`. The two are
+  compatible: both call `super` first and touch disjoint state (chamber vs. fire mode).
+- Stacks with `Extra/SpawnWithAmmoAndMagazine`, which drops **loose** magazines on the ground next to
+  CE-spawned weapons. This addon loads the gun itself; that one supplies the reloads.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely.

--- a/Extra/SpawnWithAmmoAndMagazine/README.md
+++ b/Extra/SpawnWithAmmoAndMagazine/README.md
@@ -1,0 +1,63 @@
+# Spawn With Ammo And Magazine
+
+Loot firearms come with ammunition next to them. Without this, a rifle found in a building is dead
+weight until a magazine turns up somewhere else — a poor fit for a mode where the first minutes decide
+the match.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_spawnwithammoandmagazine.pbo`                    |
+| **Side**        | server (`#ifdef SERVER`)                                |
+| **Stages**      | `4_World`                                               |
+| **`defines[]`** | none                                                    |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+## How it works
+
+`modded class ItemBase` overrides `EEOnCECreate()` and calls `super` first, so vanilla's own
+CE-spawn initialisation still runs. It then acts only when `IsWeapon()` is true — real firearms.
+
+**If the weapon takes magazines**, it rolls a count between `min_spawn` and `max_spawn` (default 1–2)
+and creates that many magazines:
+
+```c
+GetGame().CreateObjectEx(magazineType, GetPosition(), ECE_CREATEPHYSICS|ECE_UPDATEPATHGRAPH);
+```
+
+**If it takes none** (a break-action or bolt gun with no detachable mag), it reads the weapon's own
+`chamberableFrom` config array and drops loose ammo piles instead, deleting any pile that has no
+economy profile.
+
+Note both paths use `GetPosition()` — the ammunition lands **on the ground at the weapon**, not inside
+its inventory. If you want the gun itself loaded, that is `Extra/SpawnWeaponChambered`'s job; the two
+stack fine.
+
+Because this hooks `EEOnCECreate`, it applies **only to Central-Economy loot spawns** — not to
+admin-spawned or scripted weapons.
+
+## Configuration
+
+Three `serverDZ.cfg` keys, read only by this addon:
+
+| Key | Effect |
+|---|---|
+| `BRDisableSpawnWithAmmo` | `1` disables the addon entirely |
+| `BRMinSpawnAmmo` | above `0` overrides the minimum; below `0` forces the minimum to `0`; `0` keeps the default of 1 |
+| `BRMaxSpawnAmmo` | above `0` overrides the maximum; `0` or below keeps the default of 2. Raised to the minimum if it ends up lower |
+
+## Caveats
+
+- **Magazines over 100 rounds are skipped** — drums and other high-capacity magazines never spawn. The
+  loop retries a different type, up to `spawnCount * 10` attempts.
+- The addon uses raw `Print()` rather than the project's logging helpers, so it writes to the log on
+  every CE weapon spawn. One of those calls also wraps the real `CreateObjectEx` call inside a
+  `Print()` argument.
+- In the no-magazine branch the loop bound `Math.RandomIntInclusive(min_spawn, max_spawn)` is
+  **re-rolled on every iteration**, which biases the number of ammo piles toward the minimum.
+- Shares `modded class ItemBase { override void EEOnCECreate() }` with `Extra/SpawnWithBattery`; both
+  call `super`, so they chain safely.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely. To keep
+the addon but turn it off at runtime, set `BRDisableSpawnWithAmmo = 1;` in `serverDZ.cfg` instead.

--- a/Extra/SpawnWithBattery/README.md
+++ b/Extra/SpawnWithBattery/README.md
@@ -1,0 +1,53 @@
+# Spawn With Battery
+
+Battery-powered loot spawns with a battery already fitted, so a found radio, flashlight or scope works
+the moment you pick it up instead of needing a separate scavenger hunt.
+
+|                 |                                                        |
+|-----------------|--------------------------------------------------------|
+| **PBO**         | `extra_spawnwithbattery.pbo`                            |
+| **Side**        | server (`#ifdef SERVER`)                                |
+| **Stages**      | `4_World`                                               |
+| **`defines[]`** | none                                                    |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced              |
+
+## How it works
+
+`modded class ItemBase` overrides `EEOnCECreate()`, calls `super` first, then acts on any item with an
+energy manager:
+
+```c
+if( HasEnergyManager() )
+{
+    ItemBase item;
+    item = ItemBase.Cast( GetInventory().CreateInInventory( "Battery9V" ) );
+    ApplyRandomHealthAndEnergy(item);
+    item = ItemBase.Cast( GetInventory().CreateInInventory( "CarBattery" ) );
+    ApplyRandomHealthAndEnergy(item);
+}
+```
+
+Both battery types are attempted on every such item; whichever the item cannot accept simply returns
+null and is skipped by the null check inside the helper. The battery is then randomised:
+
+| Property | Range |
+|---|---|
+| Health | 66–100 % of max (`HEALTH_MIN_FACTOR = 0.66`) |
+| Charge | 50–90 % (`ENERGY_MIN = 0.5`, `ENERGY_MAX = 0.9`) |
+
+Because this hooks `EEOnCECreate`, it applies **only to Central-Economy loot spawns** — not to
+admin-spawned items, and not to a vehicle's `CarBattery` attachment.
+
+## Caveats
+
+- Battery classnames `Battery9V` and `CarBattery` are hardcoded, so modded battery types are not
+  covered.
+- The helper `ApplyRandomHealthAndEnergy` and its three `static const` fields are declared on
+  `ItemBase` itself, not inside the override — they are added to **every** `ItemBase` in the game while
+  this PBO is loaded. Worth knowing if another mod ever declares the same names.
+- Shares `modded class ItemBase { override void EEOnCECreate() }` with
+  `Extra/SpawnWithAmmoAndMagazine`; both call `super`, so they chain safely.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely.

--- a/Extra/Vehicle3PPDefaultFix/README.md
+++ b/Extra/Vehicle3PPDefaultFix/README.md
@@ -1,0 +1,62 @@
+# Vehicle 3PP Default Fix
+
+Guarantees that the common vanilla cars and boats are always allowed a third-person camera under the
+third-party **Vehicle3PP** mod, regardless of what its own whitelist happens to contain.
+
+|                 |                                                                        |
+|-----------------|------------------------------------------------------------------------|
+| **PBO**         | `extra_vehicle3ppdefaultfix.pbo`                                        |
+| **Side**        | compiles on both — the body is fenced at runtime by `IsDedicatedServer()` |
+| **Stages**      | `4_World`                                                               |
+| **`defines[]`** | none — but the code is gated on `Vehicle3PP` (see below)                 |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced                               |
+
+## Requires the Vehicle3PP mod
+
+Both source files open with `#ifdef Vehicle3PP` rather than the usual `#ifdef SERVER`. That define is
+supplied by the external Vehicle3PP mod's own `defines[]`, so **without that mod loaded this addon
+compiles to nothing** and is harmless. It is the only consumer of that define in this repository.
+
+## How it works
+
+`modded class CarScript` and `modded class BoatScript` each override `EEInit()`, run their body first
+and call `super.EEInit()` last. On a dedicated server they inject a hardcoded list into Vehicle3PP's
+whitelist if it is not already there, then re-run that mod's whitelist evaluation:
+
+```c
+array<string> vehicles = GetVehicle3PPConfig().GetWhitelist();
+foreach (string forced_vehicle : ForcedWhitelist)
+{
+    if (vehicles.Find(forced_vehicle) == -1)
+        vehicles.Insert(forced_vehicle);
+}
+```
+
+Forced entries:
+
+| File | Vehicles |
+|---|---|
+| `CarScript.c` | `OffroadHatchback`, `CivilianSedan`, `Hatchback_02`, `Sedan_02`, `Truck_01_Covered`, `Offroad_02` |
+| `BoatScript.c` | `Boat_01_Black`, `Boat_01_Blue`, `Boat_01_Orange`, `Boat_01_Camo` |
+
+If the whitelist ends up empty, 3PP is allowed for everything.
+
+## Caveats
+
+- **Vehicle3PP is not listed in `requiredAddons[]`** — only `DZ_Scripts` is, even though the code
+  depends on that mod's `GetVehicle3PPConfig()`.
+- The two files are byte-identical apart from the class name and the vehicle list, and each is a ~45
+  line copy of Vehicle3PP's own `EEInit`. If that mod changes its implementation, this copy will
+  silently diverge. Tracked in `TODO.md`.
+- The whitelist is dereferenced (`Find` / `Insert`) *before* the code's own `if (!vehicles || ...)`
+  null check, so a null return from `GetWhitelist()` would crash before reaching the guard.
+  `GetVehicle3PPConfig()` is likewise unchecked.
+- Only vanilla classnames are forced — modded vehicles are not covered.
+- `m_Allow3PPCamera` and `m_DriverOnly` are redeclared here while the upstream mod also declares them
+  on the same class. If you upgrade Vehicle3PP, verify these still resolve to the upstream netsync
+  fields rather than becoming shadow copies.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild; the folder is then skipped entirely. Removing
+the Vehicle3PP mod also neutralises it without any change here.

--- a/Workbench/Batchfiles/CI1.bat
+++ b/Workbench/Batchfiles/CI1.bat
@@ -172,12 +172,6 @@ IF EXIST "%~dp1IGNORE" IF %noIgnore%==0 (
 	exit /B
 )
 
-echo "%~dp1..\..\..\config.cpp"
-echo "%~dp1..\..\config.cpp"
-echo "%~dp1..\config.cpp"
-echo "%date% %time% ERROR: dp1 %~dp1"
-echo "%~1">>"%workDrive%Temp\%modName%-configpaths.list"
-
 IF NOT EXIST "%~dp1..\config.cpp" (
 	IF NOT EXIST "%~dp1..\..\config.cpp" (
 		IF NOT EXIST "%~dp1..\..\..\config.cpp" (


### PR DESCRIPTION
One README per Extra/ addon, indexed by Extra/README.md: what it does, how it
hooks in, its caveats, and how to disable it.

Also corrects the stale Extra/ PBO counts in CLAUDE.md, and fixes CI1.bat
double-building every PBO.

Squashed from 3 commits:
  eed5192  Merge branch 'extra-readmes' - document every Extra/ sub-addon with a README
  fd873e0  Merge branch 'claudemd-counts' - correct stale Extra/ PBO counts in CLAUDE.md
  0795ad9  Merge branch 'worktree-fix-ci1-double-build' - fix CI1.bat double-building every PBO

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 16 of 31 replaying the local history onto `main`.
