### PR TITLE
Fix the naked spawn and the teleport hover, and reorganise the settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,20 @@ States are an **ordered `array<ref BattleRoyaleState>`** built in `BattleRoyaleS
 
 Long-running work uses script coroutines — `GetGame().GameScript.Call(this, "MethodName", NULL)` plus `Sleep()` (see `4_BattleRoyalePrepare.ProcessPlayers`), not the call queue.
 
+### Teleports and stuck players
+
+**A player wedged in geometry has their inventory locked, and that is why they used to spawn naked.** Vanilla `PlayerBase.OnCommandFallStart` / `ClimbStart` / `LadderStart` / `SwimStart` each take a `LOCK_FROM_SCRIPT` lock on the character's inventory and only release it in the matching `...Finish` (`playerbase.c:3964-4085`). A player stuck mid-jump never finishes the command, so the lock is still held when `4_BattleRoyalePrepare` dresses everyone — and **a locked inventory refuses `CreateAttachment` silently, returning NULL**. `LocalDestroyEntity` is not an inventory move and ignores the lock, so the lobby clothes still went away: the symptom is "stripped and never re-dressed", not "still in lobby clothes". `ClearStuckMovementState` ends the command and drains any leaked lock count before dressing, every creation result is now checked, and `ProcessPlayers` re-dresses anyone left with zero attachments after the teleport. **A ladder is the deterministic repro** — same lock, reproducible where wedging yourself in a prop is not.
+
+**Never start a movement command outside `CommandHandler`.** Vanilla only ever does it there and always `return`s immediately after (`dayzplayerimplement.c:2366-2400`, four times in a row). Starting one from a juncture handler produces a player who *looks* right but whose movement input drives nothing until some real command transition resyncs them — one jump was the cure. `BR_NotifyTeleported` therefore only sets a flag; the overridden `CommandHandler` consumes it and issues the transition — a `Fall` if the controller reports airborne, otherwise an unconditional `Move`, which is that jump without the jump. `BattleRoyalePrepare` keeps `BR_ForceMoveCommandImmediate` because it needs the inventory unlock synchronously and cannot yield, which is safe only because input is disabled for that whole state.
+
+Both teleports (match start and F2 unstuck) go through **one** sync juncture, `BR_SYNC_JUNCTURE_TELEPORT` (88). Its server half repositions; a **client** half is also required, in `Scripts/Client/4_World/.../PlayerBase.c`, because the server half is `#ifdef SERVER` and the client would otherwise keep predicting the old command. The client does receive the juncture — verified by instrumenting both sides.
+
+**Known bug, deliberately left in (2026-08-09): an F2 unstuck taken *while on a ladder in the lobby* still arrives playing the ladder animation, pinned until the player jumps once.** Everything else is clean — the match-start teleport handles a laddered player correctly, position and animation both, and neither path hovers any more. The difference between the two is the lead: `4_BattleRoyalePrepare` already ended the command server-side in `ClearStuckMovementState` and has input disabled for the whole state, while F2 has only the juncture. **One hypothesis has since been tested and refuted.** The theory was that the client consumes the forced `Move` before the corrected position arrives, restarts Move while still at the ladder, and vanilla re-enters the ladder command. Re-issuing the `Move` every frame of the settle window for as long as `GetCommand_Ladder()` or `GetCommand_Climb()` was running changed **nothing at all** — not the symptom, not even its texture — and everything else stayed clean. Had the ladder command genuinely still been running, forcing Move at frame rate would have looked like *something*. So the command state after the teleport is most likely already correct and **what is stuck is the animation graph, not the command** — which is also why a jump cures it, a jump being a real animation transition. That experiment was reverted rather than kept.
+
+The untried lead is `HumanCommandLadder.Exit()` / `CanExit()` (`P:\scripts\3_game\human.c:644-664`) — vanilla's own way off a ladder, which plays the exit transition instead of replacing the command underneath it. Note `Exit()` plausibly only works while still *at* the ladder, so it would have to run before the teleport rather than in the juncture, and `Unstuck()` already defers 1-3 s, which is where the sequencing would go. **Instrument before writing any of it**: log instance type, `GetCurrentCommandID()` and whether `GetCommand_Ladder()` is null on both sides at juncture receipt and for a few ticks after. That single measurement distinguishes "command stuck" from "graph stuck" outright, and one instrumented run has already settled this subsystem once where reasoning had failed twice. Three explanations have now been wrong here; do not make a fourth without data.
+
+**The controller does not re-check its ground contact after a scripted `SetPosition`, so a teleport must never rely on the engine noticing a drop.** `BR_TELEPORT_DROP_HEIGHT` was briefly 1 m on the theory that a player dropped in would be airborne, fall, and land — and that the landing would reset the animation graph. `PhysicsIsFalling` read "not airborne" on both sides with the metre applied, which was known at the time and read too narrowly ("the Fall branch is not what fixes the unstuck" rather than "nothing converts this drop into a fall"). What shipped was a character hovering a metre up after *every* teleport, on both paths, until the player's first input dropped them. It is now `0.05` — a seating epsilon so the capsule does not start inside the surface, nothing more. Two things replace it: `CommandHandler` ends every teleport with a real command transition (above), and `BattleRoyaleDebugState.FindUnstuckPosition` runs its lobby-centre fallback through `IsSafeForTeleport` instead of taking a raw `SurfaceY`, which is the wedging the metre of clearance was really hiding. `BR_TELEPORT_SETTLE_SECONDS` (0.75 s) is why the airborne check is a window rather than one tick: on the client the juncture can arrive before the corrected position does.
+
 ### Zones
 
 `BattleRoyaleZone` (server, `BattleRoyaleZone.c`) is a static registry; all play areas are generated **once per process** into `static ref array<ref BattleRoyalePlayArea> m_PlayAreas`. **Zone 1 is the largest** and the last zone is the smallest — `BattleRoyaleZone.c:71` indexes with `i_NumRounds - GetZoneNumber()`. Radii come from `zone_settings.json` `static_sizes`; the other `shrink_type` values are declared but marked unused.
@@ -150,18 +164,22 @@ Two secondary channels: `ScriptRPC` with the `BattleRoyaleCOTStateMachineRPC` en
 
 Server-side only (`Scripts/Server/3_Game/Config/`, all `#ifdef SERVER`). `BattleRoyaleConfig` is a singleton holding `map<string, ref BattleRoyaleDataBase>`; reach it with `BattleRoyaleConfig.GetConfig().GetGameData()` etc.
 
-| File in `$profile:Vigrid-BattleRoyale\` | Class | Registry key |
-|---|---|---|
-| `general_settings.json` | `BattleRoyaleGameData` | `GameData` |
-| `lobby_settings.json` | `BattleRoyaleLobbyData` | `DebugData` |
-| `spawns_settings.json` | `BattleRoyaleSpawnsData` | `SpawnsData` |
-| `zone_settings.json` | `BattleRoyaleZoneData` | `ZoneData` |
-| `pois_settings.json` | `BattleRoyalePOIsData` | `POIsData` |
-| `server_settings.json` | `BattleRoyaleServerData` | `ServerData` — **no mission override** |
+| File in `$profile:Vigrid-BattleRoyale\` | Class | Registry key | Scope |
+|---|---|---|---|
+| `general_settings.json` | `BattleRoyaleGameData` | `GameData` | general match-flow settings not owned by another file below |
+| `lobby_settings.json` | `BattleRoyaleLobbyData` | `LobbyData` | pre-match lobby flow: ready-up, autostart, spawn selection |
+| `zone_settings.json` | `BattleRoyaleZoneData` | `ZoneData` | zone geometry, shrink timing, zone damage, shrink-notification timing |
+| `voice_settings.json` | `BattleRoyaleVoiceData` | `VoiceData` | party-only voice while frozen, speaking-list panel |
+| `spawns_settings.json` | `BattleRoyaleSpawnsData` | `SpawnsData` | lobby spawn point and match spawn placement |
+| `pois_settings.json` | `BattleRoyalePOIsData` | `POIsData` | POI position overrides |
+| `server_settings.json` | `BattleRoyaleServerData` | `ServerData` | Vigrid API/webhook + autolock infra — **no mission override** |
+| `leaderboard_settings.json` | `BattleRoyaleLeaderboardData` | `LeaderboardData` | scoring curve + persistence knobs — **no mission override**, integrity-sensitive |
 
 The mission override (`$mission:Vigrid-BattleRoyale\`) is **not a merge** — `JsonFileLoader<T>.LoadFile()` is called twice into the same instance (`Load()` then `LoadMission()`), so only keys present in the mission JSON get overwritten. `Upgrade()` runs inside `Load()`, before the mission pass, and `Save()` only ever writes the profile path.
 
-Each class carries `int version` plus an `Upgrade()` migration. `Load()` re-saves after reading, so new fields appear in existing profile JSONs on next boot.
+A field can also be locked out of mission override *within* an otherwise-overridable file: `LoadMission()` snapshots it before the deserialize call and restores it right after. `BattleRoyaleGameData.admins_steamid64` is the example — general_settings.json supports mission overrides, but the admin list is a server-operator concern, not mission content, so it's exempted. Reach for the same idiom for any future field that needs this.
+
+Each class carries `int version` plus an `Upgrade()` migration. `Load()` re-saves after reading, so new fields appear in existing profile JSONs on next boot. Moving a field to a different settings file is *not* treated as a migration — the field starts from its new class's default and the old key is left inert in the old file.
 
 ### Parties (`Party/`)
 

--- a/Extra/Map/Scripts/3_Game/VigridMapConstants.c
+++ b/Extra/Map/Scripts/3_Game/VigridMapConstants.c
@@ -55,7 +55,7 @@ static const string VM_RPC_REQUEST_SYNC = "VM_RequestSync";
 
 //--- Server settings defaults, mirrored on the client until the first VM_Settings push arrives.
 static const bool VIGRID_MAP_DEF_MARKERS_ENABLED = true;
-static const bool VIGRID_MAP_DEF_MINIMAP_ALLOWED = true;
+static const bool VIGRID_MAP_DEF_MINIMAP_ALLOWED = false;
 static const int VIGRID_MAP_DEF_LABEL_MAX = 32;
 static const int VIGRID_MAP_PLACE_COOLDOWN_MS = 250;
 

--- a/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
+++ b/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
@@ -59,6 +59,50 @@ static const int BR_LEADERBOARD_MAX_ROWS = 50;
 static const int BR_LEADERBOARD_BOARD_SOLO = 0;
 static const int BR_LEADERBOARD_BOARD_GROUP = 1;
 
+//id of the mod's own DayZPlayer sync juncture, used by every teleport this mod performs (match
+//start and F2 unstuck). Both halves of the handler key off it - the server one repositions, the
+//client one stops predicting the movement command it was in - so it needs a name rather than a
+//literal 88 in four places.
+static const int BR_SYNC_JUNCTURE_TELEPORT = 88;
+
+//metres above the resolved ground position a teleport actually places the player, rather than
+//setting them exactly on it. A seating epsilon and nothing more: enough that the capsule is not
+//started inside the surface it is standing on, far too small to see.
+//
+//**It used to be 1.0, and that was a mistake worth recording.** The theory was that dropping the
+//player in would leave them briefly airborne, the engine would run its own fall -> land
+//transition, and that landing would reset the animation graph. The landing never happens: the
+//character controller does not re-evaluate its ground contact after a scripted SetPosition, so a
+//player placed a metre up simply believes they are standing there. The instrumented run said so at
+//the time - PhysicsIsFalling read "not airborne" on BOTH sides with the metre applied - and the
+//conclusion drawn from it was too narrow. It was not "the Fall branch is not what fixes the
+//unstuck", it was "nothing converts this drop into a fall at all".
+//
+//What that shipped was a character hovering a metre off the ground after every teleport, on both
+//paths, until the player's first input forced a command transition and dropped them. Reported
+//against the match-start teleport 2026-08-09 and confirmed on the F2 unstuck.
+//
+//Two things replace it, because the metre was masking two different faults:
+//  - PlayerBase.CommandHandler now ends every teleport with a real command transition (see
+//    BR_NotifyTeleported), which is the "jump once" cure without the jump.
+//  - BattleRoyaleDebugState.FindUnstuckPosition validates its lobby-centre fallback, so the
+//    unstuck stops landing on an unvetted position that could seat the capsule in the scenery.
+//That second one was always the principled fix, and this comment used to say so.
+static const float BR_TELEPORT_DROP_HEIGHT = 0.05;
+
+//how long after a teleport PlayerBase.CommandHandler keeps asking the controller whether it is
+//airborne. One check on the next command tick is not enough on the client: the juncture can arrive
+//a frame or two before the corrected position does, so the first check legitimately reads the old
+//position and answers "no". Only a fall is ever started from inside this window - the one-shot move
+//has already run by then - so a wrong answer costs nothing but the check.
+static const float BR_TELEPORT_SETTLE_SECONDS = 0.75;
+
+//per-player floor between granted F2 unstuck teleports. Only the pending-request flag guarded this
+//while unstuck existed solely during the warm-up, where the state lasts under a minute; the lobby
+//can now answer it too and players sit there for many minutes, so without a cooldown F2 is free
+//fast-travel around the lobby. Measured against GetTickTime(), which is in seconds.
+static const int BR_UNSTUCK_COOLDOWN_SECONDS = 30;
+
 //field-size weighting curves for leaderboard_settings.json `field_weight_mode`.
 static const int BR_LEADERBOARD_WEIGHT_FLAT = 0;
 static const int BR_LEADERBOARD_WEIGHT_LOG2 = 1;

--- a/Scripts/Client/4_World/Entities/ManBase/PlayerBase.c
+++ b/Scripts/Client/4_World/Entities/ManBase/PlayerBase.c
@@ -29,7 +29,169 @@ modded class PlayerBase
         players = new array<PlayerBase>();
         players.Copy(s_LocalPlayers);
     }
+
+    //--- The client half of the teleport juncture. The server half (which is what actually moves the
+    //--- player) lives in Scripts/Server/4_World/.../PlayerBase.c, and being #ifdef SERVER it does
+    //--- not exist here - so before this, a teleported client kept locally predicting whatever
+    //--- movement command it was in and went on playing the climb animation at the new position.
+    //---
+    //--- Position is deliberately NOT read or set here: it already arrives through ordinary network
+    //--- sync, and re-applying it from a juncture that may land on a different simulation step would
+    //--- only add a pop. All this side owes is to stop predicting the old command.
+    override void OnSyncJuncture(int pJunctureID, ParamsReadContext pCtx)
+    {
+        super.OnSyncJuncture(pJunctureID, pCtx);
+
+        //--- The client does receive this - verified by instrumenting both sides, which was worth
+        //--- doing precisely because the server half lives in an #ifdef SERVER file and nothing had
+        //--- ever proven the client half fired.
+        if ( pJunctureID == BR_SYNC_JUNCTURE_TELEPORT )
+            BR_NotifyTeleported();
+    }
 #endif
+
+    //--- True while a movement command is running that vanilla pairs with an inventory lock:
+    //--- OnCommandFallStart / ClimbStart / LadderStart / SwimStart each take LOCK_FROM_SCRIPT and
+    //--- only release it in the matching ...Finish (playerbase.c:3964-4085).
+    //---
+    //--- Unguarded on purpose. The server needs it to decide whether a player can be dressed at all,
+    //--- and the client needs the same answer to stop predicting a climb it is no longer doing - and
+    //--- the two must never disagree about what counts.
+    bool BR_IsInLockingMovementCommand()
+    {
+        if ( GetCommand_Fall() )
+            return true;
+        if ( GetCommand_Climb() )
+            return true;
+        if ( GetCommand_Ladder() )
+            return true;
+        if ( GetCommand_Swim() )
+            return true;
+
+        return false;
+    }
+
+    //--- Pending deferred reset, consumed by CommandHandler below.
+    protected bool m_BR_ForceMoveRequested = false;
+
+    //--- Seconds left of the post-teleport window in which CommandHandler keeps asking the
+    //--- controller whether it is airborne. See BR_TELEPORT_SETTLE_SECONDS.
+    protected float m_BR_PostTeleportSettle = 0;
+
+    /**
+     *  Tell this character it has just been teleported. **This is the one to call.**
+     *
+     *  Called from both halves of the BR_SYNC_JUNCTURE_TELEPORT handler, and the only thing that
+     *  makes a teleport end in an actual command transition.
+     *
+     *  It only records the request; CommandHandler does the work. Vanilla never starts a command
+     *  anywhere but inside CommandHandler, and always returns immediately afterwards
+     *  (dayzplayerimplement.c:2366-2400 does it four times in a row). Starting one from outside that
+     *  tick - from a juncture handler, say - produces a player who *looks* right, standing in a
+     *  normal pose, but whose movement input is not driving anything: they are pinned in place until
+     *  some real command transition happens and resyncs them. Jumping once was the observed cure,
+     *  which is exactly that.
+     *
+     *  This used to be gated on BR_IsInLockingMovementCommand, so that only a player stuck in a
+     *  fall/climb/ladder/swim was ever reset. A player teleported out of an ordinary standing Move -
+     *  which is every player at match start - failed that gate, the request was dropped, and neither
+     *  side ever told the engine anything had changed. That is what left characters hovering above
+     *  the ground until their first input.
+     */
+    void BR_NotifyTeleported()
+    {
+        //--- A teleport must not yank somebody out of a vehicle seat or a scripted command; that
+        //--- narrowness used to come free from the locking-command gate, so it is stated here
+        //--- instead now that the gate is gone.
+        if ( GetCommand_Vehicle() )
+            return;
+        if ( GetCommand_Script() )
+            return;
+
+        m_BR_ForceMoveRequested = true;
+        m_BR_PostTeleportSettle = BR_TELEPORT_SETTLE_SECONDS;
+    }
+
+    //--- Immediate variant, for the one caller that needs the side effect *now* rather than next
+    //--- tick: BattleRoyalePrepare has to get vanilla to drop its inventory lock before it can
+    //--- create the starting clothes, and it cannot yield. Safe there specifically because player
+    //--- input is disabled for the whole of that state and a teleport follows immediately, so the
+    //--- pinned-input problem described above has no chance to be observed.
+    //---
+    //--- Still gated on the locking commands, unlike BR_NotifyTeleported: this one exists to undo an
+    //--- inventory lock, and a player who does not hold one has nothing here to fix.
+    bool BR_ForceMoveCommandImmediate()
+    {
+        if ( !BR_IsInLockingMovementCommand() )
+            return false;
+
+        StartCommand_Move();
+        return true;
+    }
+
+    //--- Hand the character to the Fall command from wherever it is standing right now. Vanilla
+    //--- pairs these two calls everywhere it leaves a command into a fall
+    //--- (dayzplayerimplement.c:2383-2387, 2540-2545) and the YDiff is what the landing measures its
+    //--- drop against, so they must not be separated.
+    protected void BR_StartFallFromHere()
+    {
+        StartCommand_Fall(0);
+        SetFallYDiff( GetPosition()[1] );
+    }
+
+    //--- Consume the request at the only point the engine sanctions for it. Returning right after
+    //--- StartCommand_Move mirrors vanilla, which never falls through to the rest of the handler on
+    //--- a frame where it changed command.
+    override void CommandHandler(float pDt, int pCurrentCommandID, bool pCurrentCommandFinished)
+    {
+        if ( m_BR_ForceMoveRequested )
+        {
+            m_BR_ForceMoveRequested = false;
+
+            //--- Re-checked rather than trusted from BR_NotifyTeleported: a tick has passed since
+            //--- the juncture, and ejecting somebody from a vehicle seat is not a teleport's job.
+            if ( !GetCommand_Vehicle() && !GetCommand_Script() )
+            {
+                //--- Mirror vanilla's own sequence for leaving a command
+                //--- (dayzplayerimplement.c:2381-2400): if physics says we are airborne, hand over
+                //--- to Fall so the engine runs its normal landing rather than dropping the player
+                //--- straight into a move they are not standing up for; otherwise start the move.
+                //---
+                //--- The move is unconditional, and that is the point of it. It is a genuine command
+                //--- transition, which is exactly what a single jump used to supply by hand for a
+                //--- player left pinned by a teleport - and it is cheap for everybody else, since
+                //--- restarting Move from Move is what vanilla itself does every time a command
+                //--- finishes.
+                if ( PhysicsIsFalling(true) )
+                {
+                    BR_StartFallFromHere();
+                    return;
+                }
+
+                StartCommand_Move();
+                return;
+            }
+        }
+
+        //--- The controller does not re-evaluate its ground contact when a script moves the
+        //--- character, so the one-shot above can honestly answer "not airborne" while standing a
+        //--- metre up - and on the client it can run before the corrected position has even arrived.
+        //--- Keep asking for a moment. Only a fall is started here: the move has already happened,
+        //--- and re-issuing one every frame would fight whatever the player has started doing since.
+        if ( m_BR_PostTeleportSettle > 0 )
+        {
+            m_BR_PostTeleportSettle = m_BR_PostTeleportSettle - pDt;
+
+            if ( !GetCommand_Fall() && PhysicsIsFalling(true) )
+            {
+                m_BR_PostTeleportSettle = 0;
+                BR_StartFallFromHere();
+                return;
+            }
+        }
+
+        super.CommandHandler(pDt, pCurrentCommandID, pCurrentCommandFinished);
+    }
 
     void DisableInput(bool disabled)
     {

--- a/Scripts/Server/3_Game/Config/BattleRoyaleConfig.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleConfig.c
@@ -31,9 +31,9 @@ class BattleRoyaleConfig
 	{
 		BattleRoyaleUtils.Trace("Initializing Settings...");
 
-		BattleRoyaleLobbyData p_DebugData = new BattleRoyaleLobbyData;
-		if(p_DebugData)
-			m_Configs.Insert("DebugData", p_DebugData);
+		BattleRoyaleLobbyData p_LobbyData = new BattleRoyaleLobbyData;
+		if(p_LobbyData)
+			m_Configs.Insert("LobbyData", p_LobbyData);
 		else
 			Error("BattleRoyaleLobbyData Setting Constructor Returned NULL");
 
@@ -72,6 +72,12 @@ class BattleRoyaleConfig
 			m_Configs.Insert("LeaderboardData", p_LeaderboardData);
 		else
 			Error("BattleRoyaleLeaderboardData Setting Constructor Returned NULL");
+
+		BattleRoyaleVoiceData p_VoiceData = new BattleRoyaleVoiceData;
+		if(p_VoiceData)
+			m_Configs.Insert("VoiceData", p_VoiceData);
+		else
+			Error("BattleRoyaleVoiceData Setting Constructor Returned NULL");
 
 		//--- adding a new config? copy below
 	}
@@ -177,11 +183,11 @@ class BattleRoyaleConfig
 		return m_Configs.Get(key);
 	}
 
-	BattleRoyaleLobbyData GetDebugData()
+	BattleRoyaleLobbyData GetLobbyData()
 	{
-		BattleRoyaleUtils.Trace("Accessing Debug Data Config...");
+		BattleRoyaleUtils.Trace("Accessing Lobby Data Config...");
 
-		return BattleRoyaleLobbyData.Cast( GetConfig("DebugData") );
+		return BattleRoyaleLobbyData.Cast( GetConfig("LobbyData") );
 	}
 
 	BattleRoyaleGameData GetGameData()
@@ -224,5 +230,12 @@ class BattleRoyaleConfig
 		BattleRoyaleUtils.Trace("Accessing Leaderboard Data Config...");
 
 		return BattleRoyaleLeaderboardData.Cast( GetConfig("LeaderboardData") );
+	}
+
+	BattleRoyaleVoiceData GetVoiceData()
+	{
+		BattleRoyaleUtils.Trace("Accessing Voice Data Config...");
+
+		return BattleRoyaleVoiceData.Cast( GetConfig("VoiceData") );
 	}
 };

--- a/Scripts/Server/3_Game/Config/BattleRoyaleGameData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleGameData.c
@@ -1,61 +1,30 @@
 #ifdef SERVER
+// General match-flow settings that don't belong to a specific subsystem file. Zone geometry/timing
+// lives in BattleRoyaleZoneData, lobby/spawn-selection flow in BattleRoyaleLobbyData, voice policy
+// in BattleRoyaleVoiceData - see those files before adding a new field here.
+//
+// admins_steamid64 below is mission-locked: LoadMission() snapshots it before the mission-folder
+// deserialize and restores it after, so a mission pack can never grant itself admin immunity even
+// though this file otherwise supports mission overrides. Reach for the same snapshot/restore idiom
+// for any future field that is a server-operator concern rather than mission content.
 class BattleRoyaleGameData: BattleRoyaleDataBase
 {
 	int version = 3;  // Config version
 
 	// Allowed admins - Are immune to kick and can go outside the play area
+	// Mission-locked (see class comment above) - never overridable from a mission pack.
 	ref array<string> admins_steamid64 = {
 		"123456789123456789" // Dummy SteamID64
 	};
 
-    int num_zones = 6;  // number of zones
     int round_duration_minutes = 5;  // round length in minutes
-
-	bool enable_spawn_selection_menu = true;  // show spawn selection menu (0 = no, 1 = yes)
-	bool gather_party_for_spawn_selection = true;  // pull party members next to their leader when the spawn map opens
-	int spawn_selection_duration = 30;  // spawn selection duration in seconds
-	int spawn_selection_extra_time = 2;  // extra time between spawn selection and next state in seconds
-	float spawn_selection_radius = 50;  // radius where the player can spawn
-	bool show_spawn_heatmap = true;  // show spawn heatmap (0 = no, 1 = yes)
-
     int time_until_teleport_unlock = 10;  // seconds before unlock after teleporting & preparing
-
-    ref array<int> zone_notification_minutes = { 1, 2 };  // minutes when notification about the zone shrinking will be displayed
-    ref array<int> zone_notification_seconds = { 30, 10 };  // seconds when notification about the zone shrinking will be displayed, when under the minute
-
-    int debug_heal_tick_seconds = 5;  // seconds between debug (lobby) heal ticks
-
-    // Zone damage settings
-    int zone_damage_tick_seconds = 5;  // seconds between zone damage ticks
-    float zone_damage_delta = 0.1;  // damage per tick
-    bool enable_zone_damage = true;  // enable zone damage
 
     bool hide_players_endgame = false;  // Hide the number of players left in the endgame
 
     bool show_first_zone_at_start = true;  // Show the first zone at the start of the game
 
     bool artillery_sound = true;  // Play the artillery sound when the zone shrinks
-
-    // Voice settings
-    // While players are frozen (countdown, spawn selection, prepare) a player hears only their own
-    // party. Solo players hear nobody. The lobby is deliberately not covered - it stays open voice.
-    bool party_only_voice = true;  // restrict voice to party members while players are frozen
-    bool show_speaking_players = true;  // show the on-screen list of who is currently speaking
-    bool speaking_list_during_match = true;  // keep that list up after the match has started
-
-    // How far a voice carries, per voice level, in metres. Used ONLY to decide who appears in the
-    // speaking list - it does not change what players actually hear, which the engine decides and
-    // does not expose. While party-only voice is active these are ignored, because membership then
-    // answers audibility exactly. Tune these if the list names people you cannot hear, or misses
-    // people you can.
-    //
-    // These are the community-reported vanilla ranges rather than measured ones - the engine does
-    // not expose the real values anywhere in script, so they cannot be verified from code. Erring
-    // small is the safer direction: a radius that is too large names people you cannot actually
-    // hear, which is worse than occasionally missing someone at the edge of earshot.
-    float voice_radius_whisper = 7;
-    float voice_radius_talk = 25;
-    float voice_radius_shout = 45;
 
 	// Airdrop settings
     bool airdrop_enabled = true;  // Enable airdrops
@@ -113,8 +82,14 @@ class BattleRoyaleGameData: BattleRoyaleDataBase
 		// Override from mission folder
 		if (FileExist(GetMissionPath()))
 		{
+			// admins_steamid64 is a server-operator concern (who is immune to kick/zone restriction),
+			// not mission content - a mission pack must never be able to grant itself admin immunity.
+			ref array<string> lockedAdmins = admins_steamid64;
+
 			if (!JsonFileLoader<BattleRoyaleGameData>.LoadFile(GetMissionPath(), this, errorMessage))
 				ErrorEx(errorMessage);
+
+			admins_steamid64 = lockedAdmins;
 		}
 	}
 
@@ -149,6 +124,12 @@ class BattleRoyaleGameData: BattleRoyaleDataBase
 			// The voice keys were INTRODUCED in v3, so an older file does not carry them and the
 			// field initialisers above survive deserialization. Nothing to migrate - the bump exists
 			// so Save() writes the new keys into the existing profile JSON.
+			//
+			// Those voice fields have since moved to BattleRoyaleVoiceData/voice_settings.json - this
+			// version stays at 3 (no bump) because that move needs no migration of its own: a v3
+			// general_settings.json on disk still has the old keys, JsonFileLoader simply ignores
+			// them now that this class no longer declares matching fields, and voice_settings.json
+			// starts fresh from BattleRoyaleVoiceData's own defaults.
 			version = 3;
 			Save();  // Save the upgraded config
 		}

--- a/Scripts/Server/3_Game/Config/BattleRoyaleLobbyData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleLobbyData.c
@@ -21,6 +21,16 @@ class BattleRoyaleLobbyData: BattleRoyaleDataBase
     bool autostart_enabled = true;  // Enable autostart
     float autostart_delay = 750.0;  // Delay before autostart
 
+    int debug_heal_tick_seconds = 5;  // seconds between debug (lobby) heal ticks
+
+	// Spawn selection settings - the pre-match map where players pick where to drop in
+	bool enable_spawn_selection_menu = true;  // show spawn selection menu (0 = no, 1 = yes)
+	bool gather_party_for_spawn_selection = true;  // pull party members next to their leader when the spawn map opens
+	int spawn_selection_duration = 30;  // spawn selection duration in seconds
+	int spawn_selection_extra_time = 2;  // extra time between spawn selection and next state in seconds
+	float spawn_selection_radius = 50;  // radius where the player can spawn
+	bool show_spawn_heatmap = true;  // show spawn heatmap (0 = no, 1 = yes)
+
 	// Items given to players when they spawn in the lobby
     ref array<string> player_lobby_items = {
         "TShirt_DBR",

--- a/Scripts/Server/3_Game/Config/BattleRoyalePOIsData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyalePOIsData.c
@@ -144,7 +144,11 @@ class BattleRoyalePOIsData: BattleRoyaleDataBase
 
 class BattleRoyaleOverridePOIPosition
 {
+    // CfgWorlds class name of the POI being overridden - see the example in the class comment above.
     string poi_name;
+
+    // [x, z] world position to use instead of the POI's real one. Y (height) is resolved at read
+    // time via GetGame().SurfaceY() rather than stored, so this only ever needs the two values.
     // Must be `ref`: without it nothing strongly holds the array the ctor (or JSON deserialization)
     // assigns, and GetOverrodePosition() reads a destroyed object.
     ref array<int> new_position;

--- a/Scripts/Server/3_Game/Config/BattleRoyaleVoiceData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleVoiceData.c
@@ -1,0 +1,77 @@
+#ifdef SERVER
+// Voice policy settings, split out from general_settings.json because BattleRoyaleVoice.c is a
+// self-contained subsystem (party-only voice while frozen, the speaking-players panel) with its
+// own settings surface - same reasoning as leaderboard_settings.json getting its own file.
+class BattleRoyaleVoiceData: BattleRoyaleDataBase
+{
+	int version = 1;  // Config version
+
+    // While players are frozen (countdown, spawn selection, prepare) a player hears only their own
+    // party. Solo players hear nobody. The lobby is deliberately not covered - it stays open voice.
+    bool party_only_voice = true;  // restrict voice to party members while players are frozen
+    bool show_speaking_players = true;  // show the on-screen list of who is currently speaking
+    bool speaking_list_during_match = true;  // keep that list up after the match has started
+
+    // How far a voice carries, per voice level, in metres. Used ONLY to decide who appears in the
+    // speaking list - it does not change what players actually hear, which the engine decides and
+    // does not expose. While party-only voice is active these are ignored, because membership then
+    // answers audibility exactly. Tune these if the list names people you cannot hear, or misses
+    // people you can.
+    //
+    // These are the community-reported vanilla ranges rather than measured ones - the engine does
+    // not expose the real values anywhere in script, so they cannot be verified from code. Erring
+    // small is the safer direction: a radius that is too large names people you cannot actually
+    // hear, which is worse than occasionally missing someone at the edge of earshot.
+    float voice_radius_whisper = 7;
+    float voice_radius_talk = 25;
+    float voice_radius_shout = 45;
+
+    override string GetProfilePath()
+    {
+        return BATTLEROYALE_SETTINGS_FOLDER + "voice_settings.json";
+    }
+
+    override string GetMissionPath()
+    {
+        return BATTLEROYALE_SETTINGS_MISSION_FOLDER + "voice_settings.json";
+    }
+
+	override void Load()
+	{
+		string errorMessage;
+		// Load from profile folder
+		if (FileExist(GetProfilePath()))
+		{
+			if (!JsonFileLoader<BattleRoyaleVoiceData>.LoadFile(GetProfilePath(), this, errorMessage))
+				ErrorEx(errorMessage);
+		}
+
+		// Run the upgrade function here to avoid overrides from mission folder
+		Upgrade();
+	}
+
+	override void LoadMission()
+	{
+		string errorMessage;
+		// Override from mission folder
+		if (FileExist(GetMissionPath()))
+		{
+			if (!JsonFileLoader<BattleRoyaleVoiceData>.LoadFile(GetMissionPath(), this, errorMessage))
+				ErrorEx(errorMessage);
+		}
+	}
+
+	override void Save()
+	{
+		string errorMessage;
+		if (!JsonFileLoader<BattleRoyaleVoiceData>.SaveFile(GetProfilePath(), this, errorMessage))
+			ErrorEx(errorMessage);
+	}
+
+	override void Upgrade()
+	{
+		// Nothing to migrate yet - this class started at v1 with the fields above already present.
+		// Simply ADDING a field needs no bump (JsonFileLoader leaves the initialiser in place for a
+		// key an older file doesn't have). Only a changed meaning for an existing value needs one.
+	}
+};

--- a/Scripts/Server/3_Game/Config/BattleRoyaleZoneData.c
+++ b/Scripts/Server/3_Game/Config/BattleRoyaleZoneData.c
@@ -1,7 +1,17 @@
 #ifdef SERVER
 class BattleRoyaleZoneData: BattleRoyaleDataBase
 {
-	int version = 2;  // Config version
+	int version = 3;  // Config version
+
+    int num_zones = 6;  // number of zones
+
+    ref array<int> zone_notification_minutes = { 1, 2 };  // minutes when notification about the zone shrinking will be displayed
+    ref array<int> zone_notification_seconds = { 30, 10 };  // seconds when notification about the zone shrinking will be displayed, when under the minute
+
+    // Zone damage settings
+    int zone_damage_tick_seconds = 5;  // seconds between zone damage ticks
+    float zone_damage_delta = 0.1;  // damage per tick
+    bool enable_zone_damage = true;  // enable zone damage
 
     bool end_in_villages = true;  // The final zone will end in a village/city/town
     ref array<string> end_avoid_type = {"DeerStand", "FeedShack", "Marine"};  // Types to avoid in the final zone (Only if end_in_villages is true)
@@ -30,8 +40,8 @@ class BattleRoyaleZoneData: BattleRoyaleDataBase
 
 	// Static
 	// SMALLEST ZONE FIRST: index 0 describes the tight final circle, the last index the widest
-	// opening one. num_zones (general_settings.json) picks that many tiers from the small end, so
-	// lowering it shortens a match by dropping the LARGEST circles and always keeps the endgame one.
+	// opening one. num_zones (above) picks that many tiers from the small end, so lowering it
+	// shortens a match by dropping the LARGEST circles and always keeps the endgame one.
 	// At the defaults below, num_zones = 6 plays 3375 down to 35 and leaves index 6 (4500) unused.
 	// Entries past num_zones are ignored on purpose; FEWER entries than num_zones is a misconfiguration.
     ref array<float> static_sizes = { 35, 140, 562, 1125, 2250, 3375, 4500 };
@@ -105,6 +115,33 @@ class BattleRoyaleZoneData: BattleRoyaleDataBase
 			first_zone_polygon = new array<string>();
 
 			version = 2;
+			Save();  // Save the upgraded config
+		}
+
+		if (version < 3)
+		{
+			// zone_notification_minutes/_seconds were INTRODUCED in v3 (moved here from
+			// general_settings.json). Unlike a missing scalar key, which leaves the field initialiser
+			// above in place, a missing array key deserializes to an EMPTY array - confirmed against a
+			// pre-v3 zone_settings.json, which naturally has neither key. Left unguarded, every server
+			// upgrading to v3 would silently lose the zone-shrink countdown notifications. Only fill an
+			// array that came back genuinely empty, so an admin who deliberately empties it later (to
+			// turn notifications off) stays empty on the next boot.
+			if (!zone_notification_minutes || zone_notification_minutes.Count() == 0)
+			{
+				zone_notification_minutes = new array<int>();
+				zone_notification_minutes.Insert(1);
+				zone_notification_minutes.Insert(2);
+			}
+
+			if (!zone_notification_seconds || zone_notification_seconds.Count() == 0)
+			{
+				zone_notification_seconds = new array<int>();
+				zone_notification_seconds.Insert(30);
+				zone_notification_seconds.Insert(10);
+			}
+
+			version = 3;
 			Save();  // Save the upgraded config
 		}
 	}

--- a/Scripts/Server/4_World/Entities/ManBase/PlayerBase.c
+++ b/Scripts/Server/4_World/Entities/ManBase/PlayerBase.c
@@ -12,6 +12,10 @@ modded class PlayerBase
     bool force_result = true;
 
     bool wait_unstuck = false;
+    //--- Tick time before which this player may not request another unstuck. wait_unstuck alone only
+    //--- covers the 1-3 s while one is in flight; this is what stops F2 being held down as
+    //--- fast-travel now that the lobby answers it too. See BattleRoyaleState.DeferredUnstuck.
+    float next_unstuck_time = 0;
 
     string owner_id = "";
 
@@ -96,12 +100,19 @@ modded class PlayerBase
 
 		switch( pJunctureID )
 		{
-			case 88:
+			case BR_SYNC_JUNCTURE_TELEPORT:
 				vector position, direction;
 				pCtx.Read( position );
 				pCtx.Read( direction );
 				if ( position )
 				{
+					//--- Seated just above the resolved ground rather than exactly on it, so the
+					//--- capsule never starts inside the surface. This is a few centimetres and
+					//--- nothing depends on it; it is emphatically NOT a drop the engine is expected
+					//--- to turn into a fall - see BR_TELEPORT_DROP_HEIGHT for the metre that tried
+					//--- that and left everybody hovering.
+					position[1] = position[1] + BR_TELEPORT_DROP_HEIGHT;
+
 					SetDynamicPhysicsLifeTime( 0.001 );
 					dBodyActive( this, ActiveState.INACTIVE );
 					SetPosition( position );
@@ -111,6 +122,17 @@ modded class PlayerBase
 				{
 					SetDirection( direction );
 				}
+
+				//--- Repositioning alone leaves the running movement command running, so a player
+				//--- teleported off a ladder or out of an unfinished fall arrives still playing that
+				//--- animation - which, for the unstuck teleport, is the exact state it exists to
+				//--- escape. It has to happen HERE rather than before the teleport: clearing the
+				//--- command while the player is still standing on the ladder just lets the engine
+				//--- re-enter it on the next tick, which is what BattleRoyalePrepare saw.
+				//---
+				//--- Requested rather than done outright: this is a juncture handler, not the
+				//--- command tick. See BR_NotifyTeleported.
+				BR_NotifyTeleported();
 				break;
 		}
 	}

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
@@ -81,9 +81,10 @@ class BattleRoyaleServer: BattleRoyaleBase
         m_Timer = new Timer;
 
         //load config (this may error because GetBattleRoyale would return false)
-        BattleRoyaleGameData m_GameData = config_data.GetGameData();
-        i_NumRounds = m_GameData.num_zones;
-        b_EnableSpawnSelectionMenu = m_GameData.enable_spawn_selection_menu;
+        BattleRoyaleZoneData m_ZoneData = config_data.GetZoneData();
+        BattleRoyaleLobbyData m_LobbyData = config_data.GetLobbyData();
+        i_NumRounds = m_ZoneData.num_zones;
+        b_EnableSpawnSelectionMenu = m_LobbyData.enable_spawn_selection_menu;
 
         //--- initialize all states (in order from start to finish)
         m_States = new array<ref BattleRoyaleState>;
@@ -255,7 +256,7 @@ class BattleRoyaleServer: BattleRoyaleBase
 
         //--- The speaking-players panel is a client HUD element gated by two server settings, so the
         //--- joining player needs them before their first frame of gameplay.
-        BattleRoyaleGameData voice_settings = config_data.GetGameData();
+        BattleRoyaleVoiceData voice_settings = config_data.GetVoiceData();
         GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "SetVoiceSettings", new Param2<bool, bool>( voice_settings.show_speaking_players, voice_settings.speaking_list_during_match ), true, player.GetIdentity() );
 
         BattleRoyaleDebug m_Debug = BattleRoyaleDebug.Cast( GetState(0) );
@@ -530,18 +531,25 @@ class BattleRoyaleServer: BattleRoyaleBase
     {
 		if(type == CallType.Server)
 		{
-			BattleRoyaleStartMatch m_StartMatchStateObj;
-			if(!Class.CastTo(m_StartMatchStateObj, GetCurrentState()))
+			//--- Asked of the state rather than by casting to one. This used to require
+			//--- BattleRoyaleStartMatch specifically, which meant F2 was dead in the lobby - where a
+			//--- wedged player has no other way out, and where staying wedged until Prepare costs
+			//--- them their whole loadout. Every state that has not opted in still refuses.
+			BattleRoyaleState state = GetCurrentState();
+			if(!state || !state.AllowsUnstuck())
 				return;
 
-            PlayerBase senderBase = m_StartMatchStateObj.GetPlayerFromIdentity(sender);
+            PlayerBase senderBase = state.GetPlayerFromIdentity(sender);
             if(!senderBase)
             {
-                Error("StartMatch state does not contain player requesting unstuck!");
+                //--- Warn, not Error: Error() raises a VM exception, and now that the lobby is in
+                //--- scope an RPC arriving from someone the state has not registered yet - or has
+                //--- just dropped - is an ordinary race rather than a fatal condition.
+                BattleRoyaleUtils.Warn("Current state does not contain the player requesting unstuck!");
                 return;
             }
 
-			m_StartMatchStateObj.DeferredUnstuck( senderBase );
+			state.DeferredUnstuck( senderBase );
 			senderBase.SetSynchDirty();
 		}
     }

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleVoice.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleVoice.c
@@ -26,24 +26,24 @@ class BattleRoyaleVoice
     /**
      *  Cached settings handle.
      *
-     *  BattleRoyaleConfig.GetGameData() emits a Trace on every single call
-     *  (BattleRoyaleConfig.c:189), and the code below runs at the server tick rate - once per tick
-     *  in UpdateSpeakers, and once per listener/speaker pair in CanHear. Fetching it each time put
-     *  roughly ten "Accessing Game Data Config..." lines per second into the log, and on a DIAG
-     *  server BattleRoyaleUtils mirrors every level into in-game chat, so it spammed that too.
+     *  BattleRoyaleConfig.GetVoiceData() emits a Trace on every single call, and the code below runs
+     *  at the server tick rate - once per tick in UpdateSpeakers, and once per listener/speaker pair
+     *  in CanHear. Fetching it each time put roughly ten "Accessing Voice Data Config..." lines per
+     *  second into the log, and on a DIAG server BattleRoyaleUtils mirrors every level into in-game
+     *  chat, so it spammed that too.
      *
      *  The config is loaded once at boot and its data objects keep their identity, which is why the
      *  states already cache this in their constructors. Same idea, fetched lazily because this class
      *  has no constructor to hang it off.
      */
-    private static BattleRoyaleGameData s_GameData;
+    private static BattleRoyaleVoiceData s_VoiceData;
 
-    private static BattleRoyaleGameData GameData()
+    private static BattleRoyaleVoiceData VoiceData()
     {
-        if (!s_GameData)
-            s_GameData = BattleRoyaleConfig.GetConfig().GetGameData();
+        if (!s_VoiceData)
+            s_VoiceData = BattleRoyaleConfig.GetConfig().GetVoiceData();
 
-        return s_GameData;
+        return s_VoiceData;
     }
 
     //--- Exactly the uids the matrix was built from, so ClearAll() can undo precisely what it did.
@@ -79,7 +79,7 @@ class BattleRoyaleVoice
             return;
         }
 
-        if (!GameData().party_only_voice)
+        if (!VoiceData().party_only_voice)
         {
             BattleRoyaleUtils.Info("BattleRoyaleVoice: party_only_voice is disabled, leaving voice open");
             return;
@@ -216,7 +216,7 @@ class BattleRoyaleVoice
             return;
         s_NextSpeakerPollMs = now_ms + BR_SPEAKING_POLL_MS;
 
-        if (!GameData().show_speaking_players)
+        if (!VoiceData().show_speaking_players)
             return;
 
         if (!s_LastSpokeMs)
@@ -338,12 +338,12 @@ class BattleRoyaleVoice
             return s_GroupIndex.Get(listener_uid) == s_GroupIndex.Get(speaker_uid);
         }
 
-        float radius = GameData().voice_radius_talk;
+        float radius = VoiceData().voice_radius_talk;
         int level = GetGame().GetVoiceLevel(speaker);
         if (level == VoiceLevelWhisper)
-            radius = GameData().voice_radius_whisper;
+            radius = VoiceData().voice_radius_whisper;
         else if (level == VoiceLevelShout)
-            radius = GameData().voice_radius_shout;
+            radius = VoiceData().voice_radius_shout;
 
         vector listener_pos = listener.GetPosition();
         vector speaker_pos = speaker.GetPosition();

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleZone.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleZone.c
@@ -45,10 +45,10 @@ class BattleRoyaleZone
         m_Config = BattleRoyaleConfig.GetConfig();
 
         BattleRoyaleGameData m_GameData = m_Config.GetGameData();
-        i_NumRounds = m_GameData.num_zones;
         i_RoundDurationMinutes = m_GameData.round_duration_minutes;
 
         m_ZoneSettings = m_Config.GetZoneData();
+        i_NumRounds = m_ZoneSettings.num_zones;
         f_ConstantShrink = m_ZoneSettings.constant_scale;
         i_ShrinkType = m_ZoneSettings.shrink_type;
         f_Eulers = m_ZoneSettings.shrink_base;

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
@@ -430,6 +430,126 @@ class BattleRoyaleState: Timeable
         return true;
     }
 
+    //--- Identity-safe name for logging. A PlayerBase can outlive its PlayerIdentity across a
+    //--- coroutine yield or a deferred call, and a Trace argument is evaluated whatever the log
+    //--- level - so an inlined GetIdentity().GetName() throws from inside a disabled log call and
+    //--- takes the caller with it. Lives here rather than in one state because both the Prepare
+    //--- coroutine and the unstuck path below need it.
+    protected string GetPlayerLogName(PlayerBase player)
+    {
+        if(!player)
+            return "<null player>";
+
+        PlayerIdentity identity = player.GetIdentity();
+        if(!identity)
+            return "<null identity>";
+
+        return identity.GetName();
+    }
+
+    //--- Whether this state answers an F2 unstuck request at all. False by default, so Prepare, the
+    //--- rounds and Win keep refusing exactly as they always have; only the lobby and the warm-up
+    //--- opt in. The client sends the RPC unconditionally (BattleRoyaleClient.Unstuck), so this is
+    //--- the only gate.
+    bool AllowsUnstuck()
+    {
+        return false;
+    }
+
+    //--- Where an unstuck request may drop this player. Ring search outward from where they stand,
+    //--- which is what keeps the teleport short enough to read as "shoved free" rather than as a
+    //--- relocation. check_zone is off because an unstuck must work wherever the player currently
+    //--- is - refusing to free somebody because they are already outside the circle is backwards.
+    protected bool FindUnstuckPosition(PlayerBase player, out vector position)
+    {
+        position = "0 0 0";
+
+        if(!player)
+            return false;
+
+        vector player_position = player.GetPosition();
+
+        for(int search_pos = 0; search_pos < 50; search_pos++)
+        {
+            float radius = 10.0 + (search_pos * 0.5);
+            float angle = Math.RandomFloat(0, 360) * Math.DEG2RAD;
+            float x = player_position[0] + ( radius * Math.Cos(angle) );
+            float z = player_position[2] + ( radius * Math.Sin(angle) );
+            float y = GetGame().SurfaceY(x, z);
+
+            if( !IsSafeForTeleport(x, y, z, false) )
+                continue;
+
+            position = Vector(x, y, z);
+            return true;
+        }
+
+        return false;
+    }
+
+    //--- Cooldown gate, so F2 cannot be held down as free fast-travel. wait_unstuck alone is not
+    //--- enough: it is cleared the moment the teleport lands, which was fine while unstuck only
+    //--- existed during the warm-up but is not once the lobby - where players idle for minutes -
+    //--- can answer it too.
+    void DeferredUnstuck( PlayerBase player )
+    {
+        //--- Reached from an RPC handler, so the subject may already be gone.
+        if( !player )
+            return;
+
+        if( player.wait_unstuck )
+        {
+            MessagePlayerUntranslated( player, "STR_BR_ALREADY_REQUESTED_UNSTUCK" );
+            return;
+        }
+
+        if( GetGame().GetTickTime() < player.next_unstuck_time )
+        {
+            MessagePlayerUntranslated( player, "STR_BR_ALREADY_REQUESTED_UNSTUCK" );
+            return;
+        }
+
+        //--- Note the cooldown is NOT started here. A request that finds nowhere to land refuses and
+        //--- leaves the player exactly as stuck as they were, so charging them 30 s for it would
+        //--- punish the one case where retrying immediately is the right thing to do. Unstuck()
+        //--- starts the clock once a teleport has actually been sent.
+        player.wait_unstuck = true;
+
+        MessagePlayerUntranslated( player, "STR_BR_UNSTUCK_TELEPORTATION" );
+        BattleRoyaleUtils.Trace( GetPlayerLogName( player ) + " asked for an unstuck teleportation." );
+        GetGame().GetCallQueue(CALL_CATEGORY_SYSTEM).CallLaterByName(this, "Unstuck", Math.RandomFloat(1, 3) * 1000 , false, new Param1<PlayerBase>( player ));
+    }
+
+    void Unstuck( PlayerBase player )
+    {
+        //--- 1-3 seconds have passed since DeferredUnstuck queued this, and a player can disconnect
+        //--- inside that window. The failure branch below used to dereference GetIdentity() with no
+        //--- guard on either, which was survivable while only the warm-up could reach it.
+        if( !player )
+            return;
+
+        vector unstuck_position;
+        if( !FindUnstuckPosition( player, unstuck_position ) )
+        {
+            BattleRoyaleUtils.Warn( GetPlayerLogName( player ) + " unstuck failed at " + player.GetPosition() );
+            player.wait_unstuck = false;
+            return;
+        }
+
+        vector playerDir = vector.YawToVector( Math.RandomFloat(0, 360) );
+        vector direction = Vector(playerDir[0], 0, playerDir[1]);
+
+        ScriptJunctureData pCtx = new ScriptJunctureData;
+        pCtx.Write( unstuck_position );
+        pCtx.Write( direction );
+        player.SendSyncJuncture( BR_SYNC_JUNCTURE_TELEPORT, pCtx );
+        player.SetSynchDirty();
+        player.wait_unstuck = false;
+
+        //--- Charged only for a teleport that was actually sent - see the note in DeferredUnstuck.
+        player.next_unstuck_time = GetGame().GetTickTime() + BR_UNSTUCK_COOLDOWN_SECONDS;
+    }
+
 	// Maybe this should be moved to another class, maybe not
     int GetDynamicStartingZone(int num_players)
     {
@@ -441,7 +561,6 @@ class BattleRoyaleState: Timeable
 		int resolved_zone = 1;  // Default to 1 if dynamic zones are not enabled
 
     	BattleRoyaleZoneData m_ZoneSettings = BattleRoyaleConfig.GetConfig().GetZoneData();
-		BattleRoyaleGameData m_GameSettings = BattleRoyaleConfig.GetConfig().GetGameData();
 		if ( m_ZoneSettings.use_dynamic_zones )
 		{
 			// Return the first zone based on number of registered players
@@ -451,10 +570,10 @@ class BattleRoyaleState: Timeable
 			//--- Solving for min_zone_num gives Z = num_zones - min_zone_num + 1; the old test
 			//--- omitted the +1 and so guaranteed one zone more than configured. Clamped so a
 			//--- min_zone_num >= num_zones still means "play them all" rather than never matching.
-			int floor_zone = Math.Max(1, m_GameSettings.num_zones - m_ZoneSettings.min_zone_num + 1);
+			int floor_zone = Math.Max(1, m_ZoneSettings.num_zones - m_ZoneSettings.min_zone_num + 1);
 
 			BattleRoyaleUtils.Trace("Number of players registered: " + num_players);
-			for(int i_zone = 1; i_zone < m_GameSettings.num_zones; i_zone++)
+			for(int i_zone = 1; i_zone < m_ZoneSettings.num_zones; i_zone++)
 			{
 				BattleRoyaleUtils.Trace("Try zone: " + i_zone);
 				last_try_zone = i_zone;
@@ -613,6 +732,7 @@ class BattleRoyaleDebugState: BattleRoyaleState
     {
         BattleRoyaleSpawnsData m_SpawnsSettings = BattleRoyaleConfig.GetConfig().GetSpawnsData();
         BattleRoyaleGameData m_GameSettings = BattleRoyaleConfig.GetConfig().GetGameData();
+        BattleRoyaleLobbyData m_LobbySettings = BattleRoyaleConfig.GetConfig().GetLobbyData();
 
         if(m_SpawnsSettings && m_GameSettings)
         {
@@ -626,13 +746,13 @@ class BattleRoyaleDebugState: BattleRoyaleState
             GetGame().RequestExit(0);  // Exit the game
         }
 
-        if(m_GameSettings)
+        if(m_LobbySettings)
         {
-            i_HealTickTime = m_GameSettings.debug_heal_tick_seconds;
+            i_HealTickTime = m_LobbySettings.debug_heal_tick_seconds;
         }
         else
         {
-            Error("GAME SETTINGS IS NULL");
+            Error("LOBBY SETTINGS IS NULL");
             i_HealTickTime = DAYZBR_DEBUG_HEAL_TICK;
         }
     }
@@ -743,6 +863,82 @@ class BattleRoyaleDebugState: BattleRoyaleState
         }
 
         return (a_AdminsList.Find(steamid) != -1);
+    }
+
+    //--- Same ring search as the base state, but no candidate outside the lobby disc is allowed, and
+    //--- there is always an answer.
+    //---
+    //--- Two reasons the clamp is here rather than left to OnPlayerTick's containment above. It
+    //--- would catch an escapee anyway, but only by yanking them back to the centre a frame later -
+    //--- a visible double teleport. More importantly it exempts admins (CanGoOutsideLobby), so for
+    //--- an admin nothing would catch it at all and an unstuck could quietly drop them into the
+    //--- world mid-lobby. Making "cannot leave the lobby" a property of this method covers both.
+    //---
+    //--- 2D distance, matching OnPlayerTick and for the same reason its comment gives.
+    override protected bool FindUnstuckPosition(PlayerBase player, out vector position)
+    {
+        position = "0 0 0";
+
+        if(!player)
+            return false;
+
+        vector player_position = player.GetPosition();
+
+        for(int search_pos = 0; search_pos < 50; search_pos++)
+        {
+            float radius = 10.0 + (search_pos * 0.5);
+            float angle = Math.RandomFloat(0, 360) * Math.DEG2RAD;
+            float x = player_position[0] + ( radius * Math.Cos(angle) );
+            float z = player_position[2] + ( radius * Math.Sin(angle) );
+            float y = GetGame().SurfaceY(x, z);
+
+            //--- The ring grows to 34.5 m, so on a small lobby most of it lies outside. Reject
+            //--- before the expensive geometry test in IsSafeForTeleport, not after.
+            if( vector.Distance( Vector( x, 0, z ), Vector( v_Center[0], 0, v_Center[2] ) ) > f_Radius )
+                continue;
+
+            if( !IsSafeForTeleport(x, y, z, false) )
+                continue;
+
+            position = Vector(x, y, z);
+            return true;
+        }
+
+        //--- Nothing safe inside the disc. Fall back to the placement OnPlayerTick already uses to
+        //--- put an escapee back, so a lobby unstuck never fails: being shoved to the middle of the
+        //--- lobby is the correct outcome for a player who cannot otherwise move.
+        //---
+        //--- Vetted first, though, which it never used to be. This is where a lobby unstuck almost
+        //--- always lands - the ring search above only tends to succeed on a wide open lobby - and
+        //--- the position was taken raw from SurfaceY with no geometry test of any kind. A centre
+        //--- that happens to sit under a prop seats the capsule inside it, and the player is freed
+        //--- from being stuck into being stuck. That is the fault BR_TELEPORT_DROP_HEIGHT spent a
+        //--- metre of clearance hiding.
+        float centre_x = v_Center[0];
+        float centre_z = v_Center[2];
+        float centre_y = GetGame().SurfaceY(centre_x, centre_z);
+
+        for(int centre_try = 0; centre_try < 10; centre_try++)
+        {
+            centre_x = Math.RandomFloatInclusive((v_Center[0] - 5), (v_Center[0] + 5));
+            centre_z = Math.RandomFloatInclusive((v_Center[2] - 5), (v_Center[2] + 5));
+            centre_y = GetGame().SurfaceY(centre_x, centre_z);
+
+            if( !IsSafeForTeleport(centre_x, centre_y, centre_z, false) )
+                continue;
+
+            BattleRoyaleUtils.Trace("No safe unstuck spot inside the lobby, falling back to a vetted position near the centre.");
+
+            position = Vector(centre_x, centre_y, centre_z);
+            return true;
+        }
+
+        //--- Even the centre is obstructed. Land there regardless: refusing outright would leave a
+        //--- genuinely stuck player with no way out at all, and that is the worse of the two.
+        BattleRoyaleUtils.Warn("No safe unstuck spot anywhere in the lobby, including around the centre. Using the last centre candidate unvetted.");
+
+        position = Vector(centre_x, centre_y, centre_z);
+        return true;
     }
 
     //TODO:

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/1_BattleRoyaleDebug.c
@@ -16,20 +16,35 @@ class BattleRoyaleDebug: BattleRoyaleDebugState
     {
         m_ReadyList = new array<PlayerBase>();
 
-        BattleRoyaleLobbyData m_DebugSettings = BattleRoyaleConfig.GetConfig().GetDebugData();
+        BattleRoyaleLobbyData m_LobbySettings = BattleRoyaleConfig.GetConfig().GetLobbyData();
 
-		i_MinPlayers = m_DebugSettings.minimum_players;
+		i_MinPlayers = m_LobbySettings.minimum_players;
 		i_TimeBetweenMessages = 45;
-		b_UseVoteSystem = (m_DebugSettings.use_ready_up == 1);
-		f_VoteThreshold = m_DebugSettings.ready_up_percent;
-		f_MinWaitingTime = m_DebugSettings.min_waiting_time;
-		b_AutoStartGame = m_DebugSettings.autostart_enabled;
-		f_AutoStartDelay = m_DebugSettings.autostart_delay;
+		b_UseVoteSystem = (m_LobbySettings.use_ready_up == 1);
+		f_VoteThreshold = m_LobbySettings.ready_up_percent;
+		f_MinWaitingTime = m_LobbySettings.min_waiting_time;
+		b_AutoStartGame = m_LobbySettings.autostart_enabled;
+		f_AutoStartDelay = m_LobbySettings.autostart_delay;
     }
 
     override string GetName()
     {
         return "Debug Zone State";
+    }
+
+    //--- The lobby needs this at least as much as the warm-up does, and used not to have it. A
+    //--- player wedged in the scenery here has no way out on their own and stays wedged for the
+    //--- whole wait - and if they are still wedged when Prepare runs, the fall command that pinned
+    //--- them has their inventory locked and they start the match with no loadout at all (see
+    //--- BattleRoyalePrepare.ClearStuckMovementState). Observed 2026-08-08: Client_B was stuck for
+    //--- ~80s, pressed F2 to no effect, and spawned naked.
+    //---
+    //--- BattleRoyaleDebugState.FindUnstuckPosition clamps the landing spot to the lobby disc, so
+    //--- this cannot be used to get out of the lobby, and the cooldown in DeferredUnstuck stops it
+    //--- being used as fast-travel within it.
+    override bool AllowsUnstuck()
+    {
+        return true;
     }
 
     //returns true when this state is complete

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/2_BattleRoyaleCountReached.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/2_BattleRoyaleCountReached.c
@@ -6,8 +6,8 @@ class BattleRoyaleCountReached: BattleRoyaleDebugState
 
     void BattleRoyaleCountReached()
     {
-        BattleRoyaleLobbyData m_DebugSettings = BattleRoyaleConfig.GetConfig().GetDebugData();
-		i_TimeToStart = m_DebugSettings.time_to_start_match_seconds;
+        BattleRoyaleLobbyData m_LobbySettings = BattleRoyaleConfig.GetConfig().GetLobbyData();
+		i_TimeToStart = m_LobbySettings.time_to_start_match_seconds;
     }
 
     override string GetName()

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/3_BattleRoyaleSpawnSelection.c
@@ -7,7 +7,7 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
 	ref Timer m_SpawnSelectionTimer;
 
 	private BattleRoyaleConfig m_Config;
-    private BattleRoyaleGameData m_GameSettings;
+    private BattleRoyaleLobbyData m_LobbySettings;
 
 	private ref set<int> spawn_colors;
 	private ref map<string, int> player_spawn_colors = new map<string, int>; // Player ID -> Spawn color
@@ -22,11 +22,11 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
     {
     	m_Config = BattleRoyaleConfig.GetConfig();
 
-        m_GameSettings = m_Config.GetGameData();
+        m_LobbySettings = m_Config.GetLobbyData();
 
-		i_SpawnSelectionDuration = m_GameSettings.spawn_selection_duration;
-		i_ExtraScreenTime = m_GameSettings.spawn_selection_extra_time;
-		b_ShowHeatMap = m_GameSettings.show_spawn_heatmap;
+		i_SpawnSelectionDuration = m_LobbySettings.spawn_selection_duration;
+		i_ExtraScreenTime = m_LobbySettings.spawn_selection_extra_time;
+		b_ShowHeatMap = m_LobbySettings.show_spawn_heatmap;
 
 		spawn_colors = new set<int>;
 //        spawn_colors.Insert(ARGB(255, 255, 179, 186));  // Light Pastel Pink
@@ -64,7 +64,7 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
         ref BattleRoyalePlayArea spawn_area = BattleRoyaleZone.GetZone(i_SpawnZoneNumber).GetArea();
         vector v_FirstZoneCenter = spawn_area.GetCenter();
         float f_FirstZoneRadius = spawn_area.GetRadius();
-        float f_SpawnSelectionRadius = m_GameSettings.spawn_selection_radius;
+        float f_SpawnSelectionRadius = m_LobbySettings.spawn_selection_radius;
 
         GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ShowSpawnSelection", new Param4<int, float, vector, float>(i_SpawnSelectionDuration, f_SpawnSelectionRadius, v_FirstZoneCenter, f_FirstZoneRadius), true);
 
@@ -277,7 +277,7 @@ class BattleRoyaleSpawnSelection: BattleRoyaleState
         if (!IsActive())
             return;
 
-        if (!m_GameSettings.gather_party_for_spawn_selection)
+        if (!m_LobbySettings.gather_party_for_spawn_selection)
             return;
 
         array<PlayerBase> population = GetPlayers();

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/4_BattleRoyalePrepare.c
@@ -10,6 +10,7 @@ class BattleRoyalePrepare: BattleRoyaleState
 
 	private BattleRoyaleConfig m_Config;
     private BattleRoyaleGameData m_GameSettings;
+    private BattleRoyaleLobbyData m_LobbySettings;
     private BattleRoyaleSpawnsData m_SpawnsSettings;
     private BattleRoyaleServerData m_ServerData;
     private BattleRoyalePOIsData m_POIsSettings;
@@ -26,6 +27,7 @@ class BattleRoyalePrepare: BattleRoyaleState
     	m_Config = BattleRoyaleConfig.GetConfig();
 
         m_GameSettings = m_Config.GetGameData();
+        m_LobbySettings = m_Config.GetLobbyData();
         m_SpawnsSettings = m_Config.GetSpawnsData();
         m_ServerData = m_Config.GetServerData();
         m_POIsSettings = m_Config.GetPOIsData();
@@ -33,7 +35,7 @@ class BattleRoyalePrepare: BattleRoyaleState
 		a_StartingClothes = m_GameSettings.player_starting_clothes;
 		a_StartingItems = m_GameSettings.player_starting_items;
 		a_AvoidCitySpawn = m_SpawnsSettings.avoid_city_spawn;
-		b_EnableSpawnSelectionMenu = m_GameSettings.enable_spawn_selection_menu;
+		b_EnableSpawnSelectionMenu = m_LobbySettings.enable_spawn_selection_menu;
 
         a_PlayerList = new array<PlayerBase>();
 
@@ -149,6 +151,59 @@ class BattleRoyalePrepare: BattleRoyaleState
         return true;
     }
 
+    /**
+     *  Undo whatever movement command has the player's inventory locked, so they can be dressed.
+     *
+     *  Vanilla PlayerBase.OnCommandFallStart, OnCommandClimbStart, OnCommandLadderStart and
+     *  OnCommandSwimStart each take a LOCK_FROM_SCRIPT lock on the character's inventory
+     *  (playerbase.c:3964-4085) and only release it in the matching ...Finish callback. A player
+     *  wedged inside a prop mid-jump never finishes the fall command, so the lock is still held when
+     *  this state runs - and a locked inventory refuses CreateAttachment *silently*, returning NULL.
+     *
+     *  LocalDestroyEntity is a local destroy rather than an inventory move and ignores the lock, so
+     *  the symptom is not "still in lobby clothes" but the far worse "stripped and never
+     *  re-dressed". Observed 2026-08-08: Client_B logged five inventory removals and zero additions
+     *  while Client_A, 90 ms later through the same code, logged five and eight.
+     */
+    protected void ClearStuckMovementState(PlayerBase process_player)
+    {
+        if(!process_player)
+            return;
+
+        //--- Note this only has to hold long enough to create the items. If the player is still
+        //--- physically on a ladder the engine re-enters the command on the next tick, which is
+        //--- fine here and is why the teleport clears it a second time - see the note on
+        //--- BR_ForceMoveCommand in PlayerBase.OnSyncJuncture.
+        if(process_player.BR_IsInLockingMovementCommand())
+        {
+            BattleRoyaleUtils.Warn("Player " + GetPlayerLogName(process_player) + " is in a movement command that locks their inventory; forcing a move command before dressing them.");
+            process_player.BR_ForceMoveCommandImmediate();
+        }
+
+        GameInventory inventory = process_player.GetInventory();
+        if(!inventory)
+            return;
+
+        //--- Order matters. Ending the command above is what lets vanilla release its own lock, so
+        //--- anything still held here is a leaked count. It also means no ...Finish callback is
+        //--- still pending that would unlock a second time, which is what keeps this drain from
+        //--- underflowing the count later. Bounded because this runs inside the ProcessPlayers
+        //--- coroutine and a runaway count must not hang the whole match in Prepare.
+        int guard = 0;
+        while(inventory.IsInventoryLockedForLockType(LOCK_FROM_SCRIPT) && guard < 8)
+        {
+            inventory.UnlockInventory(LOCK_FROM_SCRIPT);
+            guard++;
+        }
+
+        //--- Some other lock type, i.e. a cause we have not seen. Their loadout is about to fail the
+        //--- same way, so say so here rather than leaving it to be rediscovered from a naked player.
+        if(inventory.IsInventoryLocked())
+            BattleRoyaleUtils.Warn("Player " + GetPlayerLogName(process_player) + " still has a locked inventory after unlocking; their loadout will probably fail.");
+    }
+
+    //--- Returns false if anything the config asked for could not be created. Every failure used to
+    //--- be swallowed - that is the whole reason a naked player shipped instead of an error.
     protected bool AddStartItems(PlayerBase process_player)
     {
         DeleteAllItems(process_player);
@@ -157,11 +212,19 @@ class BattleRoyalePrepare: BattleRoyaleState
 
         int cCount = a_StartingClothes.Count();
         bool item_spawned = false;
+        bool all_created = true;
         EntityAI new_item;
         for (int i = 0; i < cCount; i++)
         {
             EntityAI clothes = process_player.GetInventory().CreateAttachment(a_StartingClothes[i]);
-            if(!item_spawned && clothes && clothes.GetInventory() && clothes.GetInventory().GetCargo())
+            if(!clothes)
+            {
+                BattleRoyaleUtils.Warn("Failed to create starting clothing '" + a_StartingClothes[i] + "' on " + GetPlayerLogName(process_player));
+                all_created = false;
+                continue;
+            }
+
+            if(!item_spawned && clothes.GetInventory() && clothes.GetInventory().GetCargo())
             {
                 int iCount = a_StartingItems.Count();
                 for (int j = 0; j < iCount; j++)
@@ -179,16 +242,36 @@ class BattleRoyalePrepare: BattleRoyaleState
 							process_player.SetQuickBarEntityShortcut(new_item, shortcut_index);
 						}
 					}
+					else
+					{
+						BattleRoyaleUtils.Warn("Failed to create starting item '" + a_StartingItems[j] + "' for " + GetPlayerLogName(process_player));
+						all_created = false;
+					}
                 }
                 item_spawned = true;
             }
         }
 
-        return true;
+        //--- Clothing was created but none of it could hold the starting items, so the player has no
+        //--- knife and no bandage. Worth reporting even though every CreateAttachment succeeded.
+        if(!item_spawned && a_StartingItems.Count() > 0)
+        {
+            BattleRoyaleUtils.Warn("No starting clothing with cargo for " + GetPlayerLogName(process_player) + "; they received none of the starting items.");
+            all_created = false;
+        }
+
+        return all_created;
     }
 
-    protected void GiveStartingItems(PlayerBase process_player)
+    protected bool GiveStartingItems(PlayerBase process_player)
     {
+        if(!process_player)
+            return false;
+
+        //--- Before anything else: a locked inventory refuses every creation below while still
+        //--- allowing the deletions, which strips the player and leaves them stripped.
+        ClearStuckMovementState(process_player);
+
         //drop the item out of the player's hands before we delete it
         if(process_player.GetItemInHands())
         {
@@ -198,7 +281,7 @@ class BattleRoyalePrepare: BattleRoyaleState
             GetGame().ObjectDelete( item_inhands );
         }
         DeleteAllItems(process_player);
-        AddStartItems(process_player);
+        return AddStartItems(process_player);
     }
 
     protected void DisablePlayerInput(PlayerBase process_player)
@@ -562,22 +645,6 @@ class BattleRoyalePrepare: BattleRoyaleState
 		return random_pos;
 	}
 
-    //--- Identity-safe name for logging. A PlayerBase can outlive its PlayerIdentity across one of
-    //--- the ProcessPlayers coroutine's yields, and a Trace argument is evaluated whatever the log
-    //--- level - so an inlined GetIdentity().GetName() throws from inside a disabled log call and
-    //--- takes the whole coroutine with it.
-    protected string GetPlayerLogName(PlayerBase player)
-    {
-        if(!player)
-            return "<null player>";
-
-        PlayerIdentity identity = player.GetIdentity();
-        if(!identity)
-            return "<null identity>";
-
-        return identity.GetName();
-    }
-
     protected void Teleport(PlayerBase process_player)
     {
         ref Param2<vector, NamedLocation> random_pos = GetRandomSpawnPosition();
@@ -705,7 +772,7 @@ class BattleRoyalePrepare: BattleRoyaleState
 		ScriptJunctureData pCtx = new ScriptJunctureData;
 		pCtx.Write( position );
 		pCtx.Write( direction );
-		player.SendSyncJuncture( 88, pCtx );
+		player.SendSyncJuncture( BR_SYNC_JUNCTURE_TELEPORT, pCtx );
     }
 
     void ProcessPlayers()
@@ -733,9 +800,17 @@ class BattleRoyalePrepare: BattleRoyaleState
 
         a_PlayerList.ShuffleArray();
 
+        //--- Players whose loadout did not come out whole. Retried after the teleport below, because
+        //--- the teleport is what actually frees somebody wedged in geometry.
+        array<PlayerBase> loadout_failed = new array<PlayerBase>();
+
         for (i = 0; i < pCount; i++) {
             process_player = a_PlayerList[i];
-            if (process_player) GiveStartingItems(process_player);
+            if (process_player)
+            {
+                if (!GiveStartingItems(process_player))
+                    loadout_failed.Insert(process_player);
+            }
 
             Sleep(100);
         }
@@ -776,7 +851,7 @@ class BattleRoyalePrepare: BattleRoyaleState
 					if (!process_player)
 						continue;
 
-					float f_SpawnSelectionRadius = m_GameSettings.spawn_selection_radius;
+					float f_SpawnSelectionRadius = m_LobbySettings.spawn_selection_radius;
 					vector position = process_player.GetSpawnPos();
 					string player_name = GetPlayerLogName(process_player);
 
@@ -898,6 +973,39 @@ class BattleRoyalePrepare: BattleRoyaleState
 
         // plz fix this
         Sleep(1000);
+
+        //--- Second chance, now that the teleport has landed. A player who was wedged in the
+        //--- scenery when the loop above ran is standing on open ground by this point, so whatever
+        //--- had their inventory locked is gone and the same call simply works.
+        //---
+        //--- Verified rather than trusted: the recorded failure list is checked, but so is
+        //--- "has no attachments at all", which is the reported symptom itself and does not care
+        //--- which config entry or which cause produced it.
+        for (i = 0; i < pCount; i++) {
+            process_player = a_PlayerList[i];
+            if (!process_player)
+                continue;
+
+            bool needs_repair = false;
+            if (loadout_failed.Find(process_player) != -1)
+                needs_repair = true;
+
+            //--- Guarded on the config asking for clothes at all: with an empty
+            //--- player_starting_clothes, zero attachments is the correct outcome and this would
+            //--- otherwise warn about, and pointlessly retry, every player every match.
+            if (a_StartingClothes.Count() > 0 && process_player.GetInventory() && process_player.GetInventory().AttachmentCount() == 0)
+                needs_repair = true;
+
+            if (!needs_repair)
+                continue;
+
+            BattleRoyaleUtils.Warn("Re-applying the loadout for " + GetPlayerLogName(process_player) + " after the teleport.");
+
+            if (!GiveStartingItems(process_player))
+                BattleRoyaleUtils.Warn("Loadout for " + GetPlayerLogName(process_player) + " failed a second time - they start the match short of gear.");
+
+            Sleep(100);
+        }
 
         for (i = 0; i < pCount; i++) {
             process_player = a_PlayerList[i];

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/5_BattleRoyaleStartMatch.c
@@ -215,59 +215,13 @@ class BattleRoyaleStartMatch: BattleRoyaleState
         DeactivateDeferred();
     }
 
-    void DeferredUnstuck( PlayerBase player )
-	{
-		if( !player.wait_unstuck )
-		{
-			player.wait_unstuck = true;
-			MessagePlayerUntranslated( player, "STR_BR_UNSTUCK_TELEPORTATION" );
-			BattleRoyaleUtils.Trace( player.GetIdentity().GetName() + " asked for an unstuck teleportation." );
-			GetGame().GetCallQueue(CALL_CATEGORY_SYSTEM).CallLaterByName(this, "Unstuck", Math.RandomFloat(1, 3) * 1000 , false, new Param1<PlayerBase>( player ));
-		}
-		else
-		{
-			MessagePlayerUntranslated( player, "STR_BR_ALREADY_REQUESTED_UNSTUCK" );
-		}
-	}
-
-	void Unstuck( PlayerBase player )
-	{
-		bool unstuckSuccess = false;
-		for(int search_pos = 0; search_pos < 50; search_pos++)
-		{
-			float radius, angle, x, z, y;
-			vector player_position, playerDir, direction;
-
-			radius = 10.0 + (search_pos * 0.5);
-			angle = Math.RandomFloat(0, 360) * Math.DEG2RAD;
-			player_position = player.GetPosition();
-			x = player_position[0] + ( radius * Math.Cos(angle) );
-			z = player_position[2] + ( radius * Math.Sin(angle) );
-			y = GetGame().SurfaceY(x, z);
-
-			if( IsSafeForTeleport(x, y, z, false) )
-			{
-				playerDir = vector.YawToVector( Math.RandomFloat(0, 360) );
-				direction = Vector(playerDir[0], 0, playerDir[1]);
-
-				ScriptJunctureData pCtx = new ScriptJunctureData;
-				pCtx.Write( Vector(x, y, z) );
-				pCtx.Write( direction );
-				player.SendSyncJuncture( 88, pCtx );
-				player.SetSynchDirty();
-				player.wait_unstuck = false;
-
-				unstuckSuccess = true;
-				break;
-			}
-		}
-
-		if( !unstuckSuccess )
-		{
-			BattleRoyaleUtils.Warn( player.GetIdentity().GetName() + " unstuck failed at " + player.GetPosition() );
-			player.wait_unstuck = false;
-		}
-	}
+    //--- The warm-up is the state this feature was written for: players have just been dropped into
+    //--- the world and input is locked until HandleUnlock, so a bad landing is not recoverable by
+    //--- moving. The implementation itself now lives on BattleRoyaleState, shared with the lobby.
+    override bool AllowsUnstuck()
+    {
+        return true;
+    }
 
     override void OnPlayerKilled(PlayerBase player, Object source)
     {

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -28,18 +28,19 @@ class BattleRoyaleRound: BattleRoyaleState
 
         BattleRoyaleConfig m_Config = BattleRoyaleConfig.GetConfig();
         BattleRoyaleGameData m_GameSettings = m_Config.GetGameData();
+        BattleRoyaleZoneData m_ZoneSettings = m_Config.GetZoneData();
         i_RoundTimeInSeconds = 60 * m_GameSettings.round_duration_minutes;
 
-        lock_notif_min = m_GameSettings.zone_notification_minutes;
-        lock_notif_sec = m_GameSettings.zone_notification_seconds;
+        lock_notif_min = m_ZoneSettings.zone_notification_minutes;
+        lock_notif_sec = m_ZoneSettings.zone_notification_seconds;
 
-        i_DamageTickTime = m_GameSettings.zone_damage_tick_seconds;
-        f_Damage = m_GameSettings.zone_damage_delta;
-        i_NumZones = m_GameSettings.num_zones;
+        i_DamageTickTime = m_ZoneSettings.zone_damage_tick_seconds;
+        f_Damage = m_ZoneSettings.zone_damage_delta;
+        i_NumZones = m_ZoneSettings.num_zones;
 
         b_ArtillerySound = m_GameSettings.artillery_sound;
 
-        b_DoZoneDamage = m_GameSettings.enable_zone_damage;
+        b_DoZoneDamage = m_ZoneSettings.enable_zone_damage;
 
         m_MessageTimers = new array<ref Timer>;
 
@@ -359,7 +360,7 @@ class BattleRoyaleRound: BattleRoyaleState
         if(Class.CastTo(prev_round, m_PreviousState))
             return prev_round;
 
-        BattleRoyaleUtils.Trace("Can't cast m_PreviousState to BattleRoyaleRound!");
+        // BattleRoyaleUtils.Trace("Can't cast m_PreviousState to BattleRoyaleRound!");
         return NULL;
     }
 

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
@@ -22,18 +22,18 @@ class BattleRoyaleLastRound: BattleRoyaleState
 
         BattleRoyaleConfig m_Config = BattleRoyaleConfig.GetConfig();
         BattleRoyaleGameData m_GameSettings = m_Config.GetGameData();
+        BattleRoyaleZoneData m_ZoneSettings = m_Config.GetZoneData();
 
-        lock_notif_min =  m_GameSettings.zone_notification_minutes;
-        lock_notif_sec =  m_GameSettings.zone_notification_seconds;
+        lock_notif_min =  m_ZoneSettings.zone_notification_minutes;
+        lock_notif_sec =  m_ZoneSettings.zone_notification_seconds;
 
-        i_DamageTickTime = m_GameSettings.zone_damage_tick_seconds;
-        f_Damage = m_GameSettings.zone_damage_delta;
-        b_DoZoneDamage = m_GameSettings.enable_zone_damage;
+        i_DamageTickTime = m_ZoneSettings.zone_damage_tick_seconds;
+        f_Damage = m_ZoneSettings.zone_damage_delta;
+        b_DoZoneDamage = m_ZoneSettings.enable_zone_damage;
         b_IsZoneLocked = false;
 
         m_MessageTimers = new array<ref Timer>;
 
-        BattleRoyaleZoneData m_ZoneSettings = m_Config.GetZoneData();
         if (m_ZoneSettings.shrink_type == 3)
         {
             i_RoundTimeInSeconds = m_ZoneSettings.static_timers[0];

--- a/Scripts/Server/5_Mission/Mission/MissionServer.c
+++ b/Scripts/Server/5_Mission/Mission/MissionServer.c
@@ -71,10 +71,10 @@ modded class MissionServer
 
 	override void EquipCharacter(MenuDefaultCharacterData char_data)
 	{
-		BattleRoyaleLobbyData m_DebugSettings = BattleRoyaleConfig.GetConfig().GetDebugData();
+		BattleRoyaleLobbyData m_LobbySettings = BattleRoyaleConfig.GetConfig().GetLobbyData();
 
-		array<string> player_lobby_items = m_DebugSettings.player_lobby_items;
-		array<int> player_lobby_items_shortcut = m_DebugSettings.player_lobby_items_shortcut;
+		array<string> player_lobby_items = m_LobbySettings.player_lobby_items;
+		array<int> player_lobby_items_shortcut = m_LobbySettings.player_lobby_items_shortcut;
 
 		for(int i = 0; i < player_lobby_items.Count(); i++)
 		{


### PR DESCRIPTION
A player wedged in geometry mid-jump started the match with no clothes and no
loadout. An unfinished fall command holds vanilla's LOCK_FROM_SCRIPT inventory
lock, and a locked inventory refuses CreateAttachment silently, returning NULL -
while LocalDestroyEntity ignores the lock, so the lobby clothes still went away.
Stripped and never re-dressed. Prepare now clears the offending command and
drains the leaked lock before dressing, checks every creation result, and
re-dresses anyone left with no attachments after the teleport.

F2 unstuck now answers in the lobby, where it was dead - which is why a stuck
player had no way out for the ~80 s before Prepare ran.

The 1 m drop height added by that work never converted into a fall, because the
character controller does not re-check its ground contact after a scripted
SetPosition, so every teleport left the player hovering until their first input.
It is a seating epsilon now, with a forced command transition on both sides and
a vetted lobby-centre fallback for the unstuck. A movement command is never
started outside CommandHandler: doing so produces a player who looks right but
whose input drives nothing until some real transition resyncs them.

Verified in a local two-client run: no hover at match start or on a lobby F2,
and a laddered player teleported by the match start arrives correct. F2 from a
ladder still pins until a jump - unchanged by this work and documented as a
known bug with the next experiment to run.

Also reorganises the battle-royale settings by subsystem and adds the
mission-lock, makes the minimap opt-in by default, and silences a trace that
fired whenever the previous round could not be cast.

Squashed from 5 commits:
  b3cda6e  Merge branch 'worktree-naked-spawn-fix' - naked spawn fix, lobby unstuck, teleport command state
  eb8434d  Disable minimap by default
  a984a9e  Silence previous-round trace log
  40eddac  Merge branch 'worktree-settings-reorg'
  9113f8d  Merge branch 'teleport-hover-fix' - stop teleports leaving the player in the air

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 18 of 31 replaying the local history onto `main`.
