### PR TITLE
Turn the diag menu into a real developer toolbox

### DIFF
--- a/Extra/KillFeed/Scripts/4_World/KillFeedAPI.c
+++ b/Extra/KillFeed/Scripts/4_World/KillFeedAPI.c
@@ -1,10 +1,9 @@
-#ifdef SERVER
 /**
  *  KillFeed - the public API. THIS IS THE ENTIRE CONTRACT with the host game.
  *
  *  The addon needs none of it: it hooks vanilla PlayerBase.EEKilled and produces a feed on a bare
- *  DayZ server. These two calls exist so a host game that knows more than the engine does can say
- *  so - when a match is running, and why a player is losing health right now.
+ *  DayZ server. These calls exist so a host game that knows more than the engine does can say so -
+ *  when a match is running, and why a player is losing health right now.
  *
  *  Every method is safe to call at any time, including before anything is initialised, so a host
  *  game never has to null-check.
@@ -14,9 +13,13 @@
  *      #ifdef KILLFEED
  *          KillFeedAPI.SetActive(true);
  *      #endif
+ *
+ *  No file-level guard - each half is #ifdef-ed inside the class body, the shape VigridPartyAPI
+ *  uses. The server half is the match-state contract; the client half is diag-only test scaffolding.
  */
 class KillFeedAPI
 {
+#ifdef SERVER
     /**
      *  Turn the feed on or off at runtime, on top of the `enabled` setting. A host game with a
      *  lobby phase wants it off there: kills before the match are not part of the story, and a
@@ -53,5 +56,46 @@ class KillFeedAPI
         victim.m_KillFeedHintCause = cause;
         victim.m_KillFeedHintTime = GetGame().GetTime();
     }
-}
 #endif
+
+#ifndef SERVER
+#ifdef DIAG_DEVELOPER
+    /**
+     *  Queue one synthetic row. Diag builds only.
+     *
+     *  A kill feed is the one thing a single client can never produce for itself - it takes two
+     *  players and a death - so every visual defect in a row otherwise has to survive a two-client
+     *  test to be found. This lets a developer push a row and look at it.
+     *
+     *  Rows go in through the same queue the network handler fills, so a fake row is rendered by
+     *  exactly the code that renders a real one, including the ECE_LOCAL preview entity and its
+     *  attachments. Nothing here fakes the rendering.
+     *
+     *  Pass "" for weapon_type to exercise the icon-and-phrase middle cell instead of the model,
+     *  and -1 for distance to hide that field - the conventions KillFeedEntry documents.
+     */
+    static void DebugPush(string killer_name, string victim_name, string weapon_type, string attachments, int distance, int cause)
+    {
+        KillFeedRPC rpc = KillFeedRPC.GetInstance();
+        if (!rpc)
+            return;
+
+        rpc.pending.Insert(new KillFeedEntry(killer_name, victim_name, weapon_type, attachments, distance, cause));
+        KillFeedLog.Debug("DebugPush " + killer_name + " -> " + victim_name + " cause=" + cause);
+    }
+
+    //! Rows the feed can show at once. Exposed so a caller can overflow it deliberately - eviction
+    //! and the matching Release() are otherwise unreachable without four real deaths in a row.
+    static int GetMaxRows()
+    {
+        return KILLFEED_MAX_ROWS;
+    }
+
+    //! The separator DebugPush expects inside `attachments`, so a caller never hardcodes it.
+    static string GetAttachmentSeparator()
+    {
+        return KILLFEED_ATTACHMENT_SEPARATOR;
+    }
+#endif // DIAG_DEVELOPER
+#endif // !SERVER
+}

--- a/Party/Scripts/4_World/VigridPartyAPI.c
+++ b/Party/Scripts/4_World/VigridPartyAPI.c
@@ -533,6 +533,142 @@ class VigridPartyAPI
         return current;
     }
 
+    //--- debug scaffolding --------------------------------------------------------------------
+
+#ifdef DIAG_DEVELOPER
+    /**
+     *  Fabricate a party of `member_count` teammates around the local player. Diag builds only.
+     *
+     *  A party needs three real clients to exercise properly - two partied plus one solo, because a
+     *  round never advances while everyone is in one group - so every renderer that reads a roster
+     *  (the HUD panel, the world nametags, the map's team layer) is otherwise untestable alone.
+     *  This writes the same fields the VP_Roster and VP_TeamState handlers write, so every consumer
+     *  runs unmodified.
+     *
+     *  Slot 0 is always the local player, exactly as a real roster has it: consumers resolve their
+     *  own position from GetGame().GetPlayer() via GetSelfIndex(), and ClientData excludes the local
+     *  player, so a fabricated self position would be the one value that never updates.
+     *
+     *  Teammates are placed on a ring around the player so they land at different bearings and
+     *  distances - a cluster at one point would not exercise the nametag edge-clamp at all.
+     */
+    static void DebugSetRoster(int member_count)
+    {
+        VigridPartyRPC rpc = VigridPartyRPC.GetInstance();
+
+        Man local_player = GetGame().GetPlayer();
+        vector origin = vector.Zero;
+        if (local_player)
+            origin = local_player.GetPosition();
+
+        rpc.roster_uids.Clear();
+        rpc.roster_names.Clear();
+        rpc.state_positions.Clear();
+        rpc.state_prev_positions.Clear();
+        rpc.state_health_level.Clear();
+        rpc.state_blood_level.Clear();
+        rpc.state_flags.Clear();
+
+        //--- Slot 0: you.
+        rpc.roster_uids.Insert("debug-self");
+        rpc.roster_names.Insert("You");
+        rpc.state_positions.Insert(origin);
+        rpc.state_prev_positions.Insert(origin);
+        rpc.state_health_level.Insert(0);
+        rpc.state_blood_level.Insert(0);
+        rpc.state_flags.Insert(VIGRID_PARTY_FLAG_ONLINE | VIGRID_PARTY_FLAG_ALIVE);
+
+        for (int i = 0; i < member_count; i++)
+        {
+            float bearing = (i * 360.0) / member_count;
+            float distance = 25.0 + (i * 35.0);
+
+            vector offset = vector.Zero;
+            offset[0] = Math.Sin(bearing * Math.DEG2RAD) * distance;
+            offset[2] = Math.Cos(bearing * Math.DEG2RAD) * distance;
+
+            vector member_pos = origin + offset;
+            member_pos[1] = GetGame().SurfaceY(member_pos[0], member_pos[2]);
+
+            rpc.roster_uids.Insert("debug-member-" + i);
+            rpc.roster_names.Insert("Fake " + (i + 1));
+            rpc.state_positions.Insert(member_pos);
+            rpc.state_prev_positions.Insert(member_pos);
+            rpc.state_health_level.Insert(i % 5);
+            rpc.state_blood_level.Insert(i % 5);
+            rpc.state_flags.Insert(VIGRID_PARTY_FLAG_ONLINE | VIGRID_PARTY_FLAG_ALIVE);
+        }
+
+        rpc.party_id = "debug-party";
+        rpc.self_index = 0;
+        rpc.leader_index = 0;
+        rpc.roster_version = rpc.roster_version + 1;
+        rpc.roster_seq = rpc.roster_seq + 1;
+
+        //--- state_version must match roster_version or every member reads as "no usable state".
+        rpc.state_version = rpc.roster_version;
+
+        //--- Freshness. Without these IsStateStale() is true from the first frame and consumers dim
+        //--- or hide the whole fabricated party.
+        rpc.state_recv_ms = GetGame().GetTime();
+        rpc.state_prev_recv_ms = rpc.state_recv_ms;
+
+        VigridPartyLog.Debug("DebugSetRoster " + member_count + " fake members around " + origin);
+    }
+
+    //! Drop the fabricated party. Same shape as VigridPartyRPC.Reset's roster half.
+    static void DebugClearRoster()
+    {
+        VigridPartyRPC rpc = VigridPartyRPC.GetInstance();
+
+        rpc.roster_uids.Clear();
+        rpc.roster_names.Clear();
+        rpc.state_positions.Clear();
+        rpc.state_prev_positions.Clear();
+        rpc.state_health_level.Clear();
+        rpc.state_blood_level.Clear();
+        rpc.state_flags.Clear();
+
+        rpc.party_id = "";
+        rpc.self_index = -1;
+        rpc.leader_index = -1;
+        rpc.roster_version = rpc.roster_version + 1;
+        rpc.roster_seq = rpc.roster_seq + 1;
+        rpc.state_version = rpc.roster_version;
+
+        VigridPartyLog.Debug("DebugClearRoster");
+    }
+
+    /**
+     *  Drop one local ping, owned by whoever sits in slot 0 of the current roster.
+     *
+     *  Local only - the server knows nothing about it, so it disappears on the next real VP_PingSet.
+     *  That is the point: it exercises the renderers (world markers and the map's ping glyph) with
+     *  no second client and no party.
+     *
+     *  ttl_seconds of 0 means permanent, matching the real ping_ttl_seconds semantics.
+     */
+    static void DebugAddPing(vector pos, int ttl_seconds)
+    {
+        VigridPartyRPC rpc = VigridPartyRPC.GetInstance();
+
+        string owner = "debug-self";
+        if (rpc.roster_uids.Count() > 0)
+            owner = rpc.roster_uids.Get(0);
+
+        int expire_ms = 0;
+        if (ttl_seconds > 0)
+            expire_ms = GetGame().GetTime() + (ttl_seconds * 1000);
+
+        rpc.ping_owner_uids.Insert(owner);
+        rpc.ping_positions.Insert(pos);
+        rpc.ping_expire_ms.Insert(expire_ms);
+        rpc.ping_recv_ms = GetGame().GetTime();
+
+        VigridPartyLog.Debug("DebugAddPing at " + pos + " ttl=" + ttl_seconds);
+    }
+#endif // DIAG_DEVELOPER
+
     //--- internals ----------------------------------------------------------------------------
 
     /**

--- a/Scripts/Client/2_GameLib/BattleRoyaleEnums.c
+++ b/Scripts/Client/2_GameLib/BattleRoyaleEnums.c
@@ -17,6 +17,41 @@ enum BattleRoyaleCOTStateMachineRPC
 //#endif
 
 
+/**
+ *  Server-side debug actions, carried as param1 of the single "BRDiagAction" RPC.
+ *
+ *  Not guarded: an enum costs nothing in a retail build, and guarding it would mean guarding every
+ *  mention of it. The RPC registration, its handler and every sender ARE guarded on DIAG_DEVELOPER.
+ *
+ *  Append only - the value travels on the wire, so renumbering desyncs a client that was not
+ *  rebuilt alongside the server.
+ */
+enum BattleRoyaleDiagAction
+{
+    INVALID = 12000, //Do not move this
+
+    SKIP_STATE,        //!< advance one state now
+    SET_PAUSED,        //!< arg_i 0/1 - Pause()/Resume() the current state
+    GOTO_STATE,        //!< arg_i = target index; fast-forwards, running every transition on the way
+    FORCE_READY_ALL,   //!< ready-up every lobby player, so the real countdown path runs
+    LOG_STATE,         //!< dump index / name / player counts to the log and to chat
+
+    TP_ZONE_CENTER,    //!< teleport the sender to the live circle's centre
+    TP_NEXT_ZONE,      //!< ... to the incoming circle's centre
+    TP_LOBBY,          //!< ... to the lobby centre
+    FORCE_UNSTUCK,     //!< unstuck ignoring AllowsUnstuck() and the cooldown
+
+    LOG_ZONE_TABLE,    //!< dump every generated play area, in generation order
+    CLEAR_MAP_MARKERS, //!< VigridMapAPI.ClearAllMarkers()
+
+    SET_LOG_LEVEL,     //!< arg_i = BattleRoyaleUtils level, or -1 to stop overriding
+    SET_CHAT_MIRROR,   //!< arg_i 0/1 - gate the ChatLog RPC
+    SET_TRACE_TP,      //!< arg_i 0/1 = on/off, arg_f = tick budget
+
+    COUNT //Do not move this
+}
+
+
 enum BattleRoyaleMatchMakingState
 {
 	INVALID = -1, //Do not move this

--- a/Scripts/Client/3_Game/BattleRoyale/Diag/BattleRoyaleDiag.c
+++ b/Scripts/Client/3_Game/BattleRoyale/Diag/BattleRoyaleDiag.c
@@ -1,0 +1,123 @@
+#ifdef DIAG_DEVELOPER
+/**
+ *  Battle Royale - the diag menu's state bag.
+ *
+ *  A bag of plain static fields, exactly like BattleRoyaleRPC: the diag callbacks store, they never
+ *  act. Consumers poll these where they live - BattleRoyaleClient.Update for anything 5_Mission,
+ *  PlayerBase for the teleport trace, BattleRoyaleUtils for the log level.
+ *
+ *  WHY A BAG AT ALL. The modded PluginDiagMenu / PluginDiagMenuClient must stay in 4_World, because
+ *  that is where vanilla declares them and the four stages compile as separate ScriptModules. So a
+ *  diag callback cannot touch KillFeedUI or BattleRoyaleClient directly. 3_Game is the lowest stage
+ *  every party can see: the 4_World callbacks that write these, the 4_World PlayerBase that reads
+ *  the trace flags, the 5_Mission client that polls the rest, and Scripts/Server at any stage.
+ *
+ *  NOT guarded on SERVER. The server needs the same class for the trace flags, the log level and
+ *  the chat mirror - those are set by the BRDiagAction RPC handler over there. Client-only members
+ *  sit in an inner #ifndef SERVER block, the two-sided shape VigridPartyAPI already uses.
+ *
+ *  The whole file is DIAG_DEVELOPER, so none of it exists in a retail build.
+ */
+class BattleRoyaleDiag
+{
+    //=========================================================================================
+    //--- Shared. Written on the client by a callback, or on the server by the RPC handler.
+    //=========================================================================================
+
+    //! -1 means "no override, resolve normally". Otherwise one of BattleRoyaleUtils.NONE..TRACE.
+    static int log_level_override = -1;
+
+    //! Mirror server log lines into in-game chat over the ChatLog RPC. That mirror is otherwise
+    //! unconditional on a DIAG server, which at trace level is most of the chat window.
+    static bool chat_mirror = true;
+
+    //! Log command/juncture state around a teleport. See PlayerBase.BR_LogTeleportState.
+    static bool trace_teleport = false;
+
+    //! How many CommandHandler ticks to keep logging for after a teleport juncture arrives.
+    static int trace_teleport_ticks = 20;
+
+#ifndef SERVER
+    //=========================================================================================
+    //--- Client only.
+    //=========================================================================================
+
+    //--- HUD. While hud_force is on, BattleRoyaleClient.Update drives every HUD element from these
+    //--- instead of from BattleRoyaleRPC, so the whole HUD can be dressed with no match running.
+    static bool hud_force = false;
+    static int hud_players = 60;
+    static int hud_groups = 20;
+    static int hud_kills = 3;
+    static int hud_countdown = 60;
+
+    //--- Zones. Same idea: synthetic circles centred on the player, which feed the HUD distance
+    //--- arrow and - through the single VigridMapAPI.SetZones call - the map's rings.
+    static bool zones_fake = false;
+    static float zone_radius = 1500;
+    static float zone_next_radius = 600;
+
+    //--- Kill feed. Read by the "Push Fake Kill" / "Fill Feed" callbacks at the moment they fire,
+    //--- rather than mirroring the entry ids, so no id has to leave the plugin class.
+    static int kf_cause = 0;
+    static bool kf_with_weapon = true;
+
+    //--- Party roster size to fabricate.
+    static int party_size = 3;
+
+    //--- Match Flow's "Jump To State" target. Held client-side and sent only when "Jump: Go" is
+    //--- pressed: a range callback plausibly fires on every step while scrubbing, and nothing here
+    //--- should be able to fire ten RPCs on the way to state 10.
+    static int goto_state = 0;
+
+    //--- One-shot requests. Monotonic counters, not bools - the consumer diffs against its own
+    //--- last-seen value, so nobody owns the clear and two presses in one frame are not merged.
+    static int req_open_spawn_menu = 0;
+    static int req_open_leaderboard = 0;
+
+    //! Zero everything. The plugin is destroyed and recreated on every world change, so this runs
+    //! from RegisterModdedDiags() as well as from BattleRoyaleClient.Init().
+    static void Reset()
+    {
+        log_level_override = -1;
+        chat_mirror = true;
+        trace_teleport = false;
+        trace_teleport_ticks = 20;
+
+        hud_force = false;
+        hud_players = 60;
+        hud_groups = 20;
+        hud_kills = 3;
+        hud_countdown = 60;
+
+        zones_fake = false;
+        zone_radius = 1500;
+        zone_next_radius = 600;
+
+        kf_cause = 0;
+        kf_with_weapon = true;
+        party_size = 3;
+
+        goto_state = 0;
+
+        req_open_spawn_menu = 0;
+        req_open_leaderboard = 0;
+    }
+
+    /**
+     *  Fire one server-side debug action.
+     *
+     *  One RPC carrying an action id, rather than one named RPC per action: adding an action is one
+     *  enum value plus one case in the handler, with no new registration and no wire change. The
+     *  float is present from day one on purpose - widening the payload later is a silent read
+     *  failure on a client that was not rebuilt.
+     *
+     *  No target. The server resolves the subject from the RPC sender identity, the same way
+     *  PlayerReadyUp and PlayerUnstuck do.
+     */
+    static void SendServerAction(int action, int arg_i, float arg_f)
+    {
+        GetRPCManager().SendRPC( RPC_DAYZBRSERVER_NAMESPACE, "BRDiagAction", new Param3<int, int, float>( action, arg_i, arg_f ), true );
+    }
+#endif
+}
+#endif // DIAG_DEVELOPER

--- a/Scripts/Client/3_Game/BattleRoyaleUtils.c
+++ b/Scripts/Client/3_Game/BattleRoyaleUtils.c
@@ -44,7 +44,14 @@ class BattleRoyaleUtils: Managed
 
 #ifdef SERVER
 #ifdef DIAG
-			GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ChatLog", new Param2<string, string>(msg, chat_color), true);
+			//--- Gated so the diag menu can turn it off. At trace level this mirror is most of the
+			//--- chat window on a local server, which is every local run.
+			bool mirror_chat = true;
+#ifdef DIAG_DEVELOPER
+			mirror_chat = BattleRoyaleDiag.chat_mirror;
+#endif
+			if (mirror_chat)
+				GetRPCManager().SendRPC( RPC_DAYZBR_NAMESPACE, "ChatLog", new Param2<string, string>(msg, chat_color), true);
 #endif
 #else
 			if ( GetGame() )
@@ -90,6 +97,16 @@ class BattleRoyaleUtils: Managed
 
 	static bool CheckLogLevel(int level)
 	{
+#ifdef DIAG_DEVELOPER
+		// Runtime override from the diag menu's Logging submenu, so the level can be changed
+		// without relaunching with a different -br-* flag. -1 is "not overriding", which is the
+		// value until somebody touches the entry.
+		if (BattleRoyaleDiag.log_level_override >= 0)
+		{
+			return (BattleRoyaleDiag.log_level_override >= level);
+		}
+#endif
+
 		// Check command line params
 		if (IsCLIParam("br-trace")) return (TRACE >= level);
 		if (IsCLIParam("br-debug")) return (DEBUG >= level);

--- a/Scripts/Client/4_World/Entities/ManBase/PlayerBase.c
+++ b/Scripts/Client/4_World/Entities/ManBase/PlayerBase.c
@@ -71,6 +71,84 @@ modded class PlayerBase
         return false;
     }
 
+#ifdef DIAG_DEVELOPER
+    //--- Ticks of CommandHandler still to log after a teleport juncture. See BR_LogTeleportState.
+    protected int m_BR_TraceTicksLeft = 0;
+
+    /**
+     *  One line describing this character's command state, for the teleport trace.
+     *
+     *  THIS IS THE MEASUREMENT, not a convenience. Three explanations of the "F2 unstuck on a ladder
+     *  leaves the player pinned in the ladder animation" bug have been wrong, two of them refuted by
+     *  a build each, and CLAUDE.md's standing instruction is to instrument before writing a fourth.
+     *  What it distinguishes is exactly one thing: whether the LADDER COMMAND is still running after
+     *  the juncture (command stuck - HumanCommandLadder.Exit is then the lead) or whether the command
+     *  is already correct and only the animation graph is wedged (in which case every command-level
+     *  lead is dead, which is also why a jump cures it).
+     *
+     *  Lives in the UNGUARDED part of this file on purpose. Only the s_LocalPlayers / OnSyncJuncture
+     *  block above is #ifndef SERVER; everything from here down compiles and runs on both sides,
+     *  because Scripts/Server lists this addon in requiredAddons and mods over it. So this one method
+     *  and the one call in CommandHandler instrument the client AND the server.
+     *
+     *  GetGame().GetTime() is included so the two logs can be aligned afterwards - the two processes
+     *  write separate files and nothing else in the line is comparable between them.
+     */
+    void BR_LogTeleportState(string tag)
+    {
+        if ( !BattleRoyaleDiag.trace_teleport )
+            return;
+
+        string side = "client";
+        if ( GetGame().IsServer() )
+            side = "server";
+
+        string commands = "";
+        if ( GetCommand_Ladder() )
+            commands = commands + "Ladder ";
+        if ( GetCommand_Climb() )
+            commands = commands + "Climb ";
+        if ( GetCommand_Fall() )
+            commands = commands + "Fall ";
+        if ( GetCommand_Move() )
+            commands = commands + "Move ";
+        if ( GetCommand_Script() )
+            commands = commands + "Script ";
+        if ( GetCommand_Vehicle() )
+            commands = commands + "Vehicle ";
+        if ( commands == "" )
+            commands = "none";
+
+        //--- Built one statement at a time: EnfusionScript does not accept an expression continued
+        //--- across lines, the same restriction that forbids a multi-line `if` condition.
+        bool on_ladder = false;
+        if ( GetCommand_Ladder() )
+            on_ladder = true;
+
+        string line = "[TPTrace][" + side + "][" + tag + "] t=" + GetGame().GetTime();
+        line = line + " type=" + Type().ToString();
+        line = line + " cmdID=" + GetCurrentCommandID();
+        line = line + " ladder=" + on_ladder;
+        line = line + " running={" + commands + "}";
+        line = line + " falling=" + PhysicsIsFalling(true);
+        line = line + " pos=" + GetPosition();
+        line = line + " forceMove=" + m_BR_ForceMoveRequested;
+        line = line + " settle=" + m_BR_PostTeleportSettle;
+
+        BattleRoyaleUtils.Debug(line);
+    }
+
+    //! Start (or restart) the post-teleport tick window. Called from BR_NotifyTeleported, so both
+    //! halves of the juncture open the window without either having to remember to.
+    void BR_BeginTeleportTrace()
+    {
+        if ( !BattleRoyaleDiag.trace_teleport )
+            return;
+
+        m_BR_TraceTicksLeft = BattleRoyaleDiag.trace_teleport_ticks;
+    }
+#endif
+
     //--- Pending deferred reset, consumed by CommandHandler below.
     protected bool m_BR_ForceMoveRequested = false;
 
@@ -100,6 +178,14 @@ modded class PlayerBase
      */
     void BR_NotifyTeleported()
     {
+#ifdef DIAG_DEVELOPER
+        //--- Logged BEFORE the two early returns, so a teleport that this method declines to act on
+        //--- is still visible in the trace. Both halves of the juncture funnel through here, so one
+        //--- call covers client and server and the two lines are directly comparable.
+        BR_BeginTeleportTrace();
+        BR_LogTeleportState("juncture");
+#endif
+
         //--- A teleport must not yank somebody out of a vehicle seat or a scripted command; that
         //--- narrowness used to come free from the locking-command gate, so it is stated here
         //--- instead now that the gate is gone.
@@ -144,6 +230,16 @@ modded class PlayerBase
     //--- a frame where it changed command.
     override void CommandHandler(float pDt, int pCurrentCommandID, bool pCurrentCommandFinished)
     {
+#ifdef DIAG_DEVELOPER
+        //--- The "few ticks after" half of the measurement. This override is outside the
+        //--- #ifndef SERVER block above, so this single call instruments both sides.
+        if ( m_BR_TraceTicksLeft > 0 )
+        {
+            m_BR_TraceTicksLeft = m_BR_TraceTicksLeft - 1;
+            BR_LogTeleportState("tick");
+        }
+#endif
+
         if ( m_BR_ForceMoveRequested )
         {
             m_BR_ForceMoveRequested = false;

--- a/Scripts/Client/4_World/Plugins/PluginBase/PluginDiagMenu/PluginDiagMenu.c
+++ b/Scripts/Client/4_World/Plugins/PluginBase/PluginDiagMenu/PluginDiagMenu.c
@@ -1,9 +1,93 @@
 #ifndef SERVER
 #ifdef DIAG_DEVELOPER
+/**
+ *  Battle Royale - the diag menu tree.
+ *
+ *  Reached in DayZDiag_x64 through the engine's own diag window, under `Script - Modded`. This half
+ *  declares the ids and builds the tree; PluginDiagMenuClient binds the callbacks.
+ *
+ *  WHAT THIS IS FOR. Most of this mod is expensive to reach: a kill feed needs two clients, a party
+ *  needs three, and anything past the lobby needs a ready-up and a countdown first. Every entry
+ *  here exists to collapse one of those loops, and each one drives the *real* code path rather than
+ *  a lookalike - fake kill rows go through the network queue, fake zones go through the same
+ *  VigridMapAPI.SetZones call a match uses, teleports go through the sync juncture.
+ *
+ *  WHAT RUNS WHERE. Callbacks are client-side; the state machine is #ifdef SERVER. Anything that
+ *  has to happen server-side goes out as one "BRDiagAction" RPC and is refused there unless the
+ *  sender is in admins_steamid64. In an offline (LaunchOffline.bat) session no #ifdef SERVER code
+ *  is compiled at all, so Match Flow and Spawn / Teleport doing nothing there is expected.
+ *
+ *  ID BUDGET. Ids come from GetModdedDiagID(), which counts up from DiagMenuIDs.MODDED_MENU (~235)
+ *  against an engine hard cap of 512 SHARED WITH EVERY OTHER MOD LOADED. This tree spends 47. Do
+ *  not allocate an id for something a bag field can carry: an entry whose value is only ever read
+ *  when another entry fires does not need its id kept.
+ */
 modded class PluginDiagMenu
 {
 	protected int m_BRDiagRootMenuID;
 	protected int m_BRDiagDummyID;
+
+	//--- Match Flow
+	protected int m_BRDiagFlowMenuID;
+	protected int m_BRDiagSkipStateID;
+	protected int m_BRDiagPauseStateID;
+	protected int m_BRDiagGotoStateID;
+	protected int m_BRDiagGotoGoID;
+	protected int m_BRDiagForceReadyID;
+	protected int m_BRDiagLogStateID;
+
+	//--- Spawn / Teleport
+	protected int m_BRDiagTeleportMenuID;
+	protected int m_BRDiagTpZoneID;
+	protected int m_BRDiagTpNextZoneID;
+	protected int m_BRDiagTpLobbyID;
+	protected int m_BRDiagForceUnstuckID;
+
+	//--- HUD & Menus
+	protected int m_BRDiagHudMenuID;
+	protected int m_BRDiagHudForceID;
+	protected int m_BRDiagHudPlayersID;
+	protected int m_BRDiagHudGroupsID;
+	protected int m_BRDiagHudKillsID;
+	protected int m_BRDiagHudCountdownID;
+	protected int m_BRDiagOpenSpawnMenuID;
+	protected int m_BRDiagOpenLeaderboardID;
+	protected int m_BRDiagFakeLeaderboardID;
+	protected int m_BRDiagFadeID;
+
+	//--- Kill Feed
+	protected int m_BRDiagKillFeedMenuID;
+	protected int m_BRDiagKfPushID;
+	protected int m_BRDiagKfCauseID;
+	protected int m_BRDiagKfWeaponID;
+	protected int m_BRDiagKfFillID;
+
+	//--- Party
+	protected int m_BRDiagPartyMenuID;
+	protected int m_BRDiagPartySizeID;
+	protected int m_BRDiagPartyApplyID;
+	protected int m_BRDiagPartyPingID;
+	protected int m_BRDiagPartyClearID;
+
+	//--- Map & Zones
+	protected int m_BRDiagZoneMenuID;
+	protected int m_BRDiagZonesFakeID;
+	protected int m_BRDiagZoneRadiusID;
+	protected int m_BRDiagZoneNextRadiusID;
+	protected int m_BRDiagLogZoneTableID;
+	protected int m_BRDiagClearMarkersID;
+
+	//--- Teleport Trace
+	protected int m_BRDiagTraceMenuID;
+	protected int m_BRDiagTraceTpClientID;
+	protected int m_BRDiagTraceTpServerID;
+	protected int m_BRDiagTraceTicksID;
+
+	//--- Logging
+	protected int m_BRDiagLogMenuID;
+	protected int m_BRDiagLogLevelID;
+	protected int m_BRDiagLogLevelSrvID;
+	protected int m_BRDiagChatMirrorID;
 
 	override protected void RegisterModdedDiagsIDs()
 	{
@@ -11,13 +95,204 @@ modded class PluginDiagMenu
 
 		m_BRDiagRootMenuID = GetModdedDiagID();
 		m_BRDiagDummyID = GetModdedDiagID();
+
+		m_BRDiagFlowMenuID = GetModdedDiagID();
+		m_BRDiagSkipStateID = GetModdedDiagID();
+		m_BRDiagPauseStateID = GetModdedDiagID();
+		m_BRDiagGotoStateID = GetModdedDiagID();
+		m_BRDiagGotoGoID = GetModdedDiagID();
+		m_BRDiagForceReadyID = GetModdedDiagID();
+		m_BRDiagLogStateID = GetModdedDiagID();
+
+		m_BRDiagTeleportMenuID = GetModdedDiagID();
+		m_BRDiagTpZoneID = GetModdedDiagID();
+		m_BRDiagTpNextZoneID = GetModdedDiagID();
+		m_BRDiagTpLobbyID = GetModdedDiagID();
+		m_BRDiagForceUnstuckID = GetModdedDiagID();
+
+		m_BRDiagHudMenuID = GetModdedDiagID();
+		m_BRDiagHudForceID = GetModdedDiagID();
+		m_BRDiagHudPlayersID = GetModdedDiagID();
+		m_BRDiagHudGroupsID = GetModdedDiagID();
+		m_BRDiagHudKillsID = GetModdedDiagID();
+		m_BRDiagHudCountdownID = GetModdedDiagID();
+		m_BRDiagOpenSpawnMenuID = GetModdedDiagID();
+		m_BRDiagOpenLeaderboardID = GetModdedDiagID();
+		m_BRDiagFakeLeaderboardID = GetModdedDiagID();
+		m_BRDiagFadeID = GetModdedDiagID();
+
+		m_BRDiagKillFeedMenuID = GetModdedDiagID();
+		m_BRDiagKfPushID = GetModdedDiagID();
+		m_BRDiagKfCauseID = GetModdedDiagID();
+		m_BRDiagKfWeaponID = GetModdedDiagID();
+		m_BRDiagKfFillID = GetModdedDiagID();
+
+		m_BRDiagPartyMenuID = GetModdedDiagID();
+		m_BRDiagPartySizeID = GetModdedDiagID();
+		m_BRDiagPartyApplyID = GetModdedDiagID();
+		m_BRDiagPartyPingID = GetModdedDiagID();
+		m_BRDiagPartyClearID = GetModdedDiagID();
+
+		m_BRDiagZoneMenuID = GetModdedDiagID();
+		m_BRDiagZonesFakeID = GetModdedDiagID();
+		m_BRDiagZoneRadiusID = GetModdedDiagID();
+		m_BRDiagZoneNextRadiusID = GetModdedDiagID();
+		m_BRDiagLogZoneTableID = GetModdedDiagID();
+		m_BRDiagClearMarkersID = GetModdedDiagID();
+
+		m_BRDiagTraceMenuID = GetModdedDiagID();
+		m_BRDiagTraceTpClientID = GetModdedDiagID();
+		m_BRDiagTraceTpServerID = GetModdedDiagID();
+		m_BRDiagTraceTicksID = GetModdedDiagID();
+
+		m_BRDiagLogMenuID = GetModdedDiagID();
+		m_BRDiagLogLevelID = GetModdedDiagID();
+		m_BRDiagLogLevelSrvID = GetModdedDiagID();
+		m_BRDiagChatMirrorID = GetModdedDiagID();
 	}
 
 	override protected void RegisterModdedDiags()
 	{
+		//--- MANDATORY and first: vanilla registers the "Script - Modded" root here, and unregisters
+		//--- it again if no mod moved m_ModdedDiagID. Skip this and the whole branch disappears.
 		super.RegisterModdedDiags();
 
+		//--- The plugin is recreated on every world change, so this is also the per-session reset.
+		BattleRoyaleDiag.Reset();
+
 		DiagMenu.RegisterMenu(m_BRDiagRootMenuID, "BattleRoyale - Myst", GetModdedRootMenu());
-		DiagMenu.RegisterBool(m_BRDiagDummyID, "", "Dummy Option", m_BRDiagRootMenuID);
+		{
+			DiagMenu.RegisterBool(m_BRDiagDummyID, "", "Dummy Option", m_BRDiagRootMenuID);
+
+			//--- Match Flow. Server-side; every entry is refused unless you are in admins_steamid64,
+			//--- and none of them exist at all in an offline session.
+			DiagMenu.RegisterMenu(m_BRDiagFlowMenuID, "Match Flow", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterBool(m_BRDiagSkipStateID, "", "Skip State", m_BRDiagFlowMenuID);
+				DiagMenu.RegisterBool(m_BRDiagPauseStateID, "", "Pause State", m_BRDiagFlowMenuID);
+				//--- Target and trigger are two entries on purpose: a range callback fires while the
+				//--- value is being scrubbed, which would send one RPC per step on the way to 10.
+				DiagMenu.RegisterRange(m_BRDiagGotoStateID, "", "Jump To State", m_BRDiagFlowMenuID, "0, 16, 0, 1");
+				DiagMenu.RegisterBool(m_BRDiagGotoGoID, "", "Jump: Go", m_BRDiagFlowMenuID);
+				DiagMenu.RegisterBool(m_BRDiagForceReadyID, "", "Force Ready All", m_BRDiagFlowMenuID);
+				DiagMenu.RegisterBool(m_BRDiagLogStateID, "", "Log State", m_BRDiagFlowMenuID);
+			}
+
+			//--- Spawn / Teleport. All four go through BR_SYNC_JUNCTURE_TELEPORT, never a raw
+			//--- SetPosition, so they exercise the path under test rather than a parallel one.
+			DiagMenu.RegisterMenu(m_BRDiagTeleportMenuID, "Spawn / Teleport", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterBool(m_BRDiagTpZoneID, "", "TP: Zone Centre", m_BRDiagTeleportMenuID);
+				DiagMenu.RegisterBool(m_BRDiagTpNextZoneID, "", "TP: Next Zone", m_BRDiagTeleportMenuID);
+				DiagMenu.RegisterBool(m_BRDiagTpLobbyID, "", "TP: Lobby", m_BRDiagTeleportMenuID);
+				//--- Ignores the 30 s cooldown, which is what makes the ladder repro iterable.
+				DiagMenu.RegisterBool(m_BRDiagForceUnstuckID, "", "Force Unstuck", m_BRDiagTeleportMenuID);
+			}
+
+			//--- HUD & Menus. Client only - works with no server at all.
+			DiagMenu.RegisterMenu(m_BRDiagHudMenuID, "HUD & Menus", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterBool(m_BRDiagHudForceID, "", "Force HUD", m_BRDiagHudMenuID);
+				DiagMenu.RegisterRange(m_BRDiagHudPlayersID, "", "Fake Players", m_BRDiagHudMenuID, "0, 100, 60, 1");
+				DiagMenu.RegisterRange(m_BRDiagHudGroupsID, "", "Fake Groups", m_BRDiagHudMenuID, "0, 40, 20, 1");
+				DiagMenu.RegisterRange(m_BRDiagHudKillsID, "", "Fake Kills", m_BRDiagHudMenuID, "0, 20, 3, 1");
+				DiagMenu.RegisterRange(m_BRDiagHudCountdownID, "", "Fake Countdown", m_BRDiagHudMenuID, "0, 300, 60, 1");
+				DiagMenu.RegisterBool(m_BRDiagOpenSpawnMenuID, "", "Open Spawn Menu", m_BRDiagHudMenuID);
+				DiagMenu.RegisterBool(m_BRDiagOpenLeaderboardID, "", "Open Leaderboard", m_BRDiagHudMenuID);
+				DiagMenu.RegisterBool(m_BRDiagFakeLeaderboardID, "", "Fake Leaderboard", m_BRDiagHudMenuID);
+				DiagMenu.RegisterBool(m_BRDiagFadeID, "", "Fade", m_BRDiagHudMenuID);
+			}
+
+#ifdef KILLFEED
+			//--- Kill Feed. A kill needs two players, so this is the submenu that replaces a whole
+			//--- second client. Rows go in through the network queue, so what renders them is the
+			//--- production path - preview entity, attachments and all.
+			DiagMenu.RegisterMenu(m_BRDiagKillFeedMenuID, "Kill Feed", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterBool(m_BRDiagKfPushID, "", "Push Fake Kill", m_BRDiagKillFeedMenuID);
+				DiagMenu.RegisterItem(m_BRDiagKfCauseID, "", "Kill Cause", m_BRDiagKillFeedMenuID, "Weapon,Melee,Barehands,Explosive,Zone,Infected,Animal,Environment");
+				DiagMenu.RegisterBool(m_BRDiagKfWeaponID, "", "With Weapon", m_BRDiagKillFeedMenuID);
+				DiagMenu.SetValue(m_BRDiagKfWeaponID, true);
+				//--- Overflows the row pool deliberately: eviction and the matching Release() are
+				//--- otherwise unreachable without four real deaths in a row.
+				DiagMenu.RegisterBool(m_BRDiagKfFillID, "", "Fill Feed", m_BRDiagKillFeedMenuID);
+			}
+#endif
+
+#ifdef VIGRID_PARTY
+			//--- Party. Normally three clients: two partied plus one solo, because a round never
+			//--- advances while everyone is in one group.
+			DiagMenu.RegisterMenu(m_BRDiagPartyMenuID, "Party", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterRange(m_BRDiagPartySizeID, "", "Fake Party Size", m_BRDiagPartyMenuID, "1, 6, 3, 1");
+				DiagMenu.RegisterBool(m_BRDiagPartyApplyID, "", "Apply Fake Party", m_BRDiagPartyMenuID);
+				DiagMenu.RegisterBool(m_BRDiagPartyPingID, "", "Add Fake Ping", m_BRDiagPartyMenuID);
+				DiagMenu.RegisterBool(m_BRDiagPartyClearID, "", "Clear Fake Party", m_BRDiagPartyMenuID);
+			}
+#endif
+
+			//--- Map & Zones.
+			DiagMenu.RegisterMenu(m_BRDiagZoneMenuID, "Map & Zones", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterBool(m_BRDiagZonesFakeID, "", "Fake Zones", m_BRDiagZoneMenuID);
+				DiagMenu.RegisterRange(m_BRDiagZoneRadiusID, "", "Zone Radius", m_BRDiagZoneMenuID, "50, 5000, 1500, 50");
+				DiagMenu.RegisterRange(m_BRDiagZoneNextRadiusID, "", "Next Radius", m_BRDiagZoneMenuID, "25, 2500, 600, 25");
+				//--- Generation runs smallest-first, so m_PlayAreas[0] is the FINAL circle. One dump
+				//--- settles that argument permanently, which is why it earns an id.
+				DiagMenu.RegisterBool(m_BRDiagLogZoneTableID, "", "Log Zone Table", m_BRDiagZoneMenuID);
+#ifdef VIGRID_MAP
+				DiagMenu.RegisterBool(m_BRDiagClearMarkersID, "", "Clear Map Markers", m_BRDiagZoneMenuID);
+#endif
+			}
+
+			//--- Teleport Trace. The measurement CLAUDE.md asks for before any more code goes near
+			//--- the ladder / F2-unstuck bug: command id and ladder-command state, both sides, at
+			//--- juncture receipt and for a few ticks after.
+			DiagMenu.RegisterMenu(m_BRDiagTraceMenuID, "Teleport Trace", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterBool(m_BRDiagTraceTpClientID, "", "Trace TP (Client)", m_BRDiagTraceMenuID);
+				DiagMenu.RegisterBool(m_BRDiagTraceTpServerID, "", "Trace TP (Server)", m_BRDiagTraceMenuID);
+				DiagMenu.RegisterRange(m_BRDiagTraceTicksID, "", "Trace Ticks", m_BRDiagTraceMenuID, "0, 60, 20, 1");
+			}
+
+			//--- Logging. Index 0 is "Default", i.e. resolve from the -br-* flags and serverDZ.cfg
+			//--- as usual; that is also the initial value, so no override is in force until touched.
+			DiagMenu.RegisterMenu(m_BRDiagLogMenuID, "Logging", m_BRDiagRootMenuID);
+			{
+				DiagMenu.RegisterItem(m_BRDiagLogLevelID, "", "Log Level", m_BRDiagLogMenuID, "Default,Error,Warn,Info,Debug,Trace");
+				DiagMenu.RegisterItem(m_BRDiagLogLevelSrvID, "", "Log Level (Srv)", m_BRDiagLogMenuID, "Default,Error,Warn,Info,Debug,Trace");
+				DiagMenu.RegisterBool(m_BRDiagChatMirrorID, "", "Chat Mirror", m_BRDiagLogMenuID);
+				DiagMenu.SetValue(m_BRDiagChatMirrorID, true);
+			}
+		}
+
+		BRDiagVerifyRegistration();
+	}
+
+	/**
+	 *  Confirm the tree actually landed, and say what it cost.
+	 *
+	 *  This is the id-budget canary. Script diag ids are capped at 512 across every mod on the
+	 *  machine, and the behaviour at the cap is not documented anywhere - a silently dropped tail is
+	 *  a plausible failure mode, and it would look exactly like "the last submenu does nothing".
+	 *  Checking the LAST id allocated is what catches that; the first would still be fine.
+	 *
+	 *  IsRegistered is used because it is the only reliable signal here. BindCallback also returns a
+	 *  bool, but it is NOT a success flag: measured 2026-08-09, it returns false for a valid, freshly
+	 *  registered id with a documented-valid callback signature, twice in a row on the same id. That
+	 *  is why vanilla discards it at all ~100 of its own call sites. Do not re-add a check on it -
+	 *  it produces one false alarm per entry and hides nothing.
+	 */
+	protected void BRDiagVerifyRegistration()
+	{
+		if ( !DiagMenu.IsRegistered(m_BRDiagChatMirrorID) )
+		{
+			BattleRoyaleUtils.Warn("Diag: entry " + m_BRDiagChatMirrorID + " did not register - the 512 script diag id cap is the first thing to suspect");
+			return;
+		}
+
+		BattleRoyaleUtils.Info("Diag: menu registered, ids " + m_BRDiagRootMenuID + "-" + m_BRDiagChatMirrorID + " (" + (m_BRDiagChatMirrorID - m_BRDiagRootMenuID + 1) + " of the 512 shared script diag ids)");
 	}
 }
+#endif // DIAG_DEVELOPER
+#endif // SERVER

--- a/Scripts/Client/4_World/Plugins/PluginBase/PluginDiagMenu/PluginDiagMenuClient.c
+++ b/Scripts/Client/4_World/Plugins/PluginBase/PluginDiagMenu/PluginDiagMenuClient.c
@@ -1,12 +1,523 @@
 #ifndef SERVER
 #ifdef DIAG_DEVELOPER
+/**
+ *  Battle Royale - the diag menu's callbacks. See PluginDiagMenu.c for the tree and the rationale.
+ *
+ *  THREE RULES EVERY CALLBACK HERE OBEYS.
+ *
+ *  1. Callbacks must be `static void` with one of the signatures vanilla documents - () , (int),
+ *     (int,int), (bool), (bool,int), or for a range (float) / (float,int). A wrong signature binds
+ *     NOTHING, with no error anywhere and an entry that simply does not respond - so a new entry is
+ *     only proven by pressing it.
+ *
+ *     BindCallback's bool return is NOT that proof and must not be checked. Measured 2026-08-09: it
+ *     returns false for a valid, freshly registered id whose IsRegistered() is true and whose
+ *     callback signature is one of the documented ones, twice in a row on the same id. A wrapper
+ *     that warned on false produced one false alarm for every entry in the tree and caught nothing.
+ *     Vanilla discards the return at all ~100 of its own call sites, which is now explained.
+ *
+ *  2. A callback either writes BattleRoyaleDiag or calls an addon API - it does not reach into
+ *     5_Mission, because this class is compiled in 4_World and cannot see it. Consumers poll.
+ *
+ *  3. Never BattleRoyaleUtils.Error() - it raises a VM exception. Warn, Info or Debug only.
+ *
+ *  A momentary button is a RegisterBool taking (bool, int): it acts on the rising edge and then
+ *  resets its own entry with DiagMenu.SetValue(id, false), the idiom vanilla's DiagButtonAction uses.
+ */
 modded class PluginDiagMenuClient
 {
+	//! Rotates the fake kill feed rows through different weapons and distances, so repeated presses
+	//! exercise the preview path with varied input rather than re-rendering one identical row.
+	static int s_BRDiagKfCounter = 0;
+
 	override protected void BindCallbacks()
 	{
 		super.BindCallbacks();
 
 		DiagMenu.BindCallback(m_BRDiagDummyID, CBBRDiagDummy);
+
+		DiagMenu.BindCallback(m_BRDiagSkipStateID, CBBRDiagSkipState);
+		DiagMenu.BindCallback(m_BRDiagPauseStateID, CBBRDiagPauseState);
+		DiagMenu.BindCallback(m_BRDiagGotoStateID, CBBRDiagGotoState);
+		DiagMenu.BindCallback(m_BRDiagGotoGoID, CBBRDiagGotoGo);
+		DiagMenu.BindCallback(m_BRDiagForceReadyID, CBBRDiagForceReady);
+		DiagMenu.BindCallback(m_BRDiagLogStateID, CBBRDiagLogState);
+
+		DiagMenu.BindCallback(m_BRDiagTpZoneID, CBBRDiagTpZone);
+		DiagMenu.BindCallback(m_BRDiagTpNextZoneID, CBBRDiagTpNextZone);
+		DiagMenu.BindCallback(m_BRDiagTpLobbyID, CBBRDiagTpLobby);
+		DiagMenu.BindCallback(m_BRDiagForceUnstuckID, CBBRDiagForceUnstuck);
+
+		DiagMenu.BindCallback(m_BRDiagHudForceID, CBBRDiagHudForce);
+		DiagMenu.BindCallback(m_BRDiagHudPlayersID, CBBRDiagHudPlayers);
+		DiagMenu.BindCallback(m_BRDiagHudGroupsID, CBBRDiagHudGroups);
+		DiagMenu.BindCallback(m_BRDiagHudKillsID, CBBRDiagHudKills);
+		DiagMenu.BindCallback(m_BRDiagHudCountdownID, CBBRDiagHudCountdown);
+		DiagMenu.BindCallback(m_BRDiagOpenSpawnMenuID, CBBRDiagOpenSpawnMenu);
+		DiagMenu.BindCallback(m_BRDiagOpenLeaderboardID, CBBRDiagOpenLeaderboard);
+		DiagMenu.BindCallback(m_BRDiagFakeLeaderboardID, CBBRDiagFakeLeaderboard);
+		DiagMenu.BindCallback(m_BRDiagFadeID, CBBRDiagFade);
+
+#ifdef KILLFEED
+		DiagMenu.BindCallback(m_BRDiagKfPushID, CBBRDiagKfPush);
+		DiagMenu.BindCallback(m_BRDiagKfCauseID, CBBRDiagKfCause);
+		DiagMenu.BindCallback(m_BRDiagKfWeaponID, CBBRDiagKfWeapon);
+		DiagMenu.BindCallback(m_BRDiagKfFillID, CBBRDiagKfFill);
+#endif
+
+#ifdef VIGRID_PARTY
+		DiagMenu.BindCallback(m_BRDiagPartySizeID, CBBRDiagPartySize);
+		DiagMenu.BindCallback(m_BRDiagPartyApplyID, CBBRDiagPartyApply);
+		DiagMenu.BindCallback(m_BRDiagPartyPingID, CBBRDiagPartyPing);
+		DiagMenu.BindCallback(m_BRDiagPartyClearID, CBBRDiagPartyClear);
+#endif
+
+		DiagMenu.BindCallback(m_BRDiagZonesFakeID, CBBRDiagZonesFake);
+		DiagMenu.BindCallback(m_BRDiagZoneRadiusID, CBBRDiagZoneRadius);
+		DiagMenu.BindCallback(m_BRDiagZoneNextRadiusID, CBBRDiagZoneNextRadius);
+		DiagMenu.BindCallback(m_BRDiagLogZoneTableID, CBBRDiagLogZoneTable);
+#ifdef VIGRID_MAP
+		DiagMenu.BindCallback(m_BRDiagClearMarkersID, CBBRDiagClearMarkers);
+#endif
+
+		DiagMenu.BindCallback(m_BRDiagTraceTpClientID, CBBRDiagTraceTpClient);
+		DiagMenu.BindCallback(m_BRDiagTraceTpServerID, CBBRDiagTraceTpServer);
+		DiagMenu.BindCallback(m_BRDiagTraceTicksID, CBBRDiagTraceTicks);
+
+		DiagMenu.BindCallback(m_BRDiagLogLevelID, CBBRDiagLogLevel);
+		DiagMenu.BindCallback(m_BRDiagLogLevelSrvID, CBBRDiagLogLevelSrv);
+		DiagMenu.BindCallback(m_BRDiagChatMirrorID, CBBRDiagChatMirror);
+	}
+
+	//=============================================================================================
+	//--- Match Flow. Every one of these is a no-op offline: there is no server to refuse it.
+	//=============================================================================================
+
+	static void CBBRDiagSkipState(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.SKIP_STATE, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagPauseState(bool enabled)
+	{
+		int paused = 0;
+		if ( enabled )
+			paused = 1;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.SET_PAUSED, paused, 0);
+	}
+
+	static void CBBRDiagGotoState(float value)
+	{
+		//--- Stored only. "Jump: Go" is what sends, so scrubbing this cannot fire an RPC per step.
+		BattleRoyaleDiag.goto_state = (int)value;
+	}
+
+	static void CBBRDiagGotoGo(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.GOTO_STATE, BattleRoyaleDiag.goto_state, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagForceReady(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.FORCE_READY_ALL, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagLogState(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.LOG_STATE, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	//=============================================================================================
+	//--- Spawn / Teleport
+	//=============================================================================================
+
+	static void CBBRDiagTpZone(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.TP_ZONE_CENTER, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagTpNextZone(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.TP_NEXT_ZONE, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagTpLobby(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.TP_LOBBY, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagForceUnstuck(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.FORCE_UNSTUCK, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+	//=============================================================================================
+	//--- HUD & Menus. Client only.
+	//=============================================================================================
+
+	static void CBBRDiagHudForce(bool enabled)
+	{
+		BattleRoyaleDiag.hud_force = enabled;
+	}
+
+	static void CBBRDiagHudPlayers(float value)
+	{
+		BattleRoyaleDiag.hud_players = (int)value;
+	}
+
+	static void CBBRDiagHudGroups(float value)
+	{
+		BattleRoyaleDiag.hud_groups = (int)value;
+	}
+
+	static void CBBRDiagHudKills(float value)
+	{
+		BattleRoyaleDiag.hud_kills = (int)value;
+	}
+
+	static void CBBRDiagHudCountdown(float value)
+	{
+		BattleRoyaleDiag.hud_countdown = (int)value;
+	}
+
+	static void CBBRDiagOpenSpawnMenu(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		//--- A counter, not a flag: BattleRoyaleClient.Update owns the actual opening, because the
+		//--- menu class is 5_Mission and this is 4_World.
+		BattleRoyaleDiag.req_open_spawn_menu = BattleRoyaleDiag.req_open_spawn_menu + 1;
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagOpenLeaderboard(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.req_open_leaderboard = BattleRoyaleDiag.req_open_leaderboard + 1;
+		DiagMenu.SetValue(id, false);
+	}
+
+	/**
+	 *  Fill both ladders with plausible rows, so the leaderboard menu can be laid out without a
+	 *  server that has ever finished a match.
+	 *
+	 *  Writes BattleRoyaleRPC exactly as the SetLeaderboard handler does, including the sequence
+	 *  bump the menu repaints on - it is the same data by the time anything reads it.
+	 */
+	static void CBBRDiagFakeLeaderboard(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleRPC br_rpc = BattleRoyaleRPC.GetInstance();
+		BRDiagFillBoard( br_rpc.GetLeaderboardBoard(BR_LEADERBOARD_BOARD_SOLO), 12 );
+		BRDiagFillBoard( br_rpc.GetLeaderboardBoard(BR_LEADERBOARD_BOARD_GROUP), 8 );
+
+		br_rpc.lb_season = 1;
+		br_rpc.leaderboard_seq = br_rpc.leaderboard_seq + 1;
+
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void BRDiagFillBoard(BattleRoyaleLeaderboardBoard board, int rows)
+	{
+		if ( !board )
+			return;
+
+		board.Clear();
+
+		for ( int i = 0; i < rows; i++ )
+		{
+			board.names.Insert("Fake Player " + (i + 1));
+			board.matches.Insert(40 - i);
+			board.wins.Insert(12 - i);
+			board.kills.Insert(180 - (i * 11));
+			board.points.Insert(2400 - (i * 137));
+		}
+
+		//--- Mid-table on purpose: a self rank of 1 hides every bug in how the row is highlighted.
+		board.self_rank = 5;
+		board.self_wins = 3;
+		board.self_points = 900;
+		board.valid = true;
+	}
+
+	static void CBBRDiagFade(bool enabled)
+	{
+		//--- Sets the same field the wire sets, so the real FadeIn / FadeOut edge in
+		//--- BattleRoyaleClient.Update runs. Nothing here duplicates the effect.
+		BattleRoyaleRPC.GetInstance().fade_state = enabled;
+	}
+
+#ifdef KILLFEED
+	//=============================================================================================
+	//--- Kill Feed
+	//=============================================================================================
+
+	static void CBBRDiagKfPush(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BRDiagPushFakeKill();
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagKfCause(int value)
+	{
+		BattleRoyaleDiag.kf_cause = value;
+	}
+
+	static void CBBRDiagKfWeapon(bool enabled)
+	{
+		BattleRoyaleDiag.kf_with_weapon = enabled;
+	}
+
+	static void CBBRDiagKfFill(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		//--- Two more than fit, so eviction and the Release() that goes with it actually happen.
+		int rows = KillFeedAPI.GetMaxRows() + 2;
+		for ( int i = 0; i < rows; i++ )
+			BRDiagPushFakeKill();
+
+		DiagMenu.SetValue(id, false);
+	}
+
+	/**
+	 *  One synthetic row, varied by a rolling counter.
+	 *
+	 *  The weapon rotates because the middle cell spawns a client-local copy of the classname and
+	 *  re-attaches accessories onto it - the part of a row most likely to break - and pushing the
+	 *  same gun four times would never notice a classname-specific failure.
+	 */
+	static void BRDiagPushFakeKill()
+	{
+		s_BRDiagKfCounter = s_BRDiagKfCounter + 1;
+
+		int cause = BattleRoyaleDiag.kf_cause;
+		string sep = KillFeedAPI.GetAttachmentSeparator();
+
+		string weapon = "";
+		string attachments = "";
+
+		//--- Only the two player-weapon causes render a model at all; anything else falls back to
+		//--- an icon and a phrase, and handing those a classname would test nothing.
+		bool wants_weapon = BattleRoyaleDiag.kf_with_weapon;
+		if ( cause != KillFeedCause.WEAPON && cause != KillFeedCause.MELEE )
+			wants_weapon = false;
+
+		if ( wants_weapon && cause == KillFeedCause.MELEE )
+		{
+			weapon = "Machete";
+		}
+		else if ( wants_weapon )
+		{
+			int pick = s_BRDiagKfCounter % 3;
+			if ( pick == 0 )
+			{
+				weapon = "M4A1";
+				attachments = "M4_RISHndgrd" + sep + "M4_MPBttstck" + sep + "ACOGOptic";
+			}
+			else if ( pick == 1 )
+			{
+				weapon = "AKM";
+				attachments = "AK_WoodBttstck" + sep + "AK_WoodHndgrd";
+			}
+			else
+			{
+				weapon = "Mosin9130";
+				attachments = "PUScopeOptic";
+			}
+		}
+
+		//--- Distance is only meaningful for a shot; -1 hides the field, as KillFeedEntry documents.
+		int distance = -1;
+		if ( cause == KillFeedCause.WEAPON )
+			distance = 25 + ((s_BRDiagKfCounter * 37) % 400);
+
+		//--- No killer for the causes nobody is credited with - a zone death, a fall, an animal.
+		string killer = "Fake Killer " + s_BRDiagKfCounter;
+		if ( cause == KillFeedCause.ZONE || cause == KillFeedCause.ENVIRONMENT )
+			killer = "";
+
+		KillFeedAPI.DebugPush( killer, "Fake Victim " + s_BRDiagKfCounter, weapon, attachments, distance, cause );
+	}
+#endif
+
+#ifdef VIGRID_PARTY
+	//=============================================================================================
+	//--- Party
+	//=============================================================================================
+
+	static void CBBRDiagPartySize(float value)
+	{
+		BattleRoyaleDiag.party_size = (int)value;
+	}
+
+	static void CBBRDiagPartyApply(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		VigridPartyAPI.DebugSetRoster( BattleRoyaleDiag.party_size );
+		DiagMenu.SetValue(id, false);
+	}
+
+	static void CBBRDiagPartyClear(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		VigridPartyAPI.DebugClearRoster();
+		DiagMenu.SetValue(id, false);
+	}
+
+	/**
+	 *  Drop a ping roughly where the player is looking.
+	 *
+	 *  A straight projection down the camera rather than a raycast: a debug marker only has to land
+	 *  somewhere plausible and visible, and a miss is obvious the moment it is drawn.
+	 */
+	static void CBBRDiagPartyPing(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		vector camera_pos = GetGame().GetCurrentCameraPosition();
+		vector camera_dir = GetGame().GetCurrentCameraDirection();
+
+		vector ping_pos = camera_pos + (camera_dir * 150);
+		ping_pos[1] = GetGame().SurfaceY(ping_pos[0], ping_pos[2]);
+
+		VigridPartyAPI.DebugAddPing( ping_pos, 0 );
+		DiagMenu.SetValue(id, false);
+	}
+#endif
+
+	//=============================================================================================
+	//--- Map & Zones
+	//=============================================================================================
+
+	static void CBBRDiagZonesFake(bool enabled)
+	{
+		BattleRoyaleDiag.zones_fake = enabled;
+	}
+
+	static void CBBRDiagZoneRadius(float value)
+	{
+		BattleRoyaleDiag.zone_radius = value;
+	}
+
+	static void CBBRDiagZoneNextRadius(float value)
+	{
+		BattleRoyaleDiag.zone_next_radius = value;
+	}
+
+	static void CBBRDiagLogZoneTable(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.LOG_ZONE_TABLE, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+
+#ifdef VIGRID_MAP
+	static void CBBRDiagClearMarkers(bool enabled, int id)
+	{
+		if ( !enabled )
+			return;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.CLEAR_MAP_MARKERS, 0, 0);
+		DiagMenu.SetValue(id, false);
+	}
+#endif
+
+	//=============================================================================================
+	//--- Teleport Trace
+	//=============================================================================================
+
+	static void CBBRDiagTraceTpClient(bool enabled)
+	{
+		BattleRoyaleDiag.trace_teleport = enabled;
+	}
+
+	static void CBBRDiagTraceTpServer(bool enabled)
+	{
+		int on = 0;
+		if ( enabled )
+			on = 1;
+
+		//--- Tick budget rides along, so both sides always agree on the window without a second
+		//--- entry that could be set on one side only.
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.SET_TRACE_TP, on, BattleRoyaleDiag.trace_teleport_ticks);
+	}
+
+	static void CBBRDiagTraceTicks(float value)
+	{
+		BattleRoyaleDiag.trace_teleport_ticks = (int)value;
+	}
+
+	//=============================================================================================
+	//--- Logging. Index 0 is "Default", which maps to -1: resolve normally.
+	//=============================================================================================
+
+	static void CBBRDiagLogLevel(int value)
+	{
+		BattleRoyaleDiag.log_level_override = value - 1;
+	}
+
+	static void CBBRDiagLogLevelSrv(int value)
+	{
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.SET_LOG_LEVEL, value - 1, 0);
+	}
+
+	static void CBBRDiagChatMirror(bool enabled)
+	{
+		int on = 0;
+		if ( enabled )
+			on = 1;
+
+		BattleRoyaleDiag.SendServerAction(BattleRoyaleDiagAction.SET_CHAT_MIRROR, on, 0);
 	}
 
 	static void CBBRDiagDummy(int value)
@@ -14,3 +525,5 @@ modded class PluginDiagMenuClient
 		BattleRoyaleUtils.Trace("CBBRDiagDummy: " + value);
 	}
 }
+#endif // DIAG_DEVELOPER
+#endif // SERVER

--- a/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleClient.c
+++ b/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleClient.c
@@ -48,6 +48,11 @@ class BattleRoyaleClient: BattleRoyaleBase
 		BattleRoyaleRPC br_rpc = BattleRoyaleRPC.GetInstance();
 		br_rpc.Reset();
 
+#ifdef DIAG_DEVELOPER
+		//--- The diag bag is static and outlives a server change, exactly like br_rpc.
+		BattleRoyaleDiag.Reset();
+#endif
+
 		m_SpeakingList = new BattleRoyaleSpeakingList();
 
 		BattleRoyaleUtils.Trace("BattleRoyaleClient::Init - Done");
@@ -63,6 +68,88 @@ class BattleRoyaleClient: BattleRoyaleBase
     {
         return m_FuturePlayArea;
     }
+
+#ifdef DIAG_DEVELOPER
+    //--- Diag menu bookkeeping. Counters are compared against BattleRoyaleDiag's monotonic request
+    //--- counters; the zone values exist so the fake circles are rebuilt on an edge rather than
+    //--- allocated fresh every frame.
+    protected float br_diag_zone_radius = -1;
+    protected float br_diag_zone_next_radius = -1;
+    protected vector br_diag_zone_origin;
+    protected int br_diag_req_spawn_menu = 0;
+    protected int br_diag_req_leaderboard = 0;
+
+    /**
+     *  Replace the live play areas with synthetic circles pinned near the player.
+     *
+     *  Feeds the HUD distance arrow and, through the single VigridMapAPI.SetZones call below, the
+     *  map's rings - so both can be looked at in an offline session with no match running.
+     *
+     *  The centre is captured once, on the frame the toggle goes on, and not updated afterwards. A
+     *  circle that follows the player would read "distance 0" for ever and test nothing.
+     */
+    protected void BR_DiagApplyZones()
+    {
+        if ( !BattleRoyaleDiag.zones_fake )
+        {
+            //--- Marks "not currently faking", which is also what makes the next enable re-centre.
+            br_diag_zone_radius = -1;
+            return;
+        }
+
+        bool rebuild = false;
+        if ( br_diag_zone_radius != BattleRoyaleDiag.zone_radius )
+            rebuild = true;
+        if ( br_diag_zone_next_radius != BattleRoyaleDiag.zone_next_radius )
+            rebuild = true;
+
+        if ( !rebuild )
+            return;
+
+        if ( br_diag_zone_radius < 0 )
+        {
+            PlayerBase local_player = PlayerBase.Cast( GetGame().GetPlayer() );
+            if ( local_player )
+                br_diag_zone_origin = local_player.GetPosition();
+        }
+
+        //--- Next circle offset inside the current one rather than concentric: two circles sharing a
+        //--- centre hide every bug in how the pair is drawn and how the arrow picks between them.
+        vector diag_next_center = br_diag_zone_origin;
+        diag_next_center[0] = diag_next_center[0] + (BattleRoyaleDiag.zone_radius * 0.4);
+
+        m_CurrentPlayArea = new BattleRoyalePlayArea( br_diag_zone_origin, BattleRoyaleDiag.zone_radius );
+        m_FuturePlayArea = new BattleRoyalePlayArea( diag_next_center, BattleRoyaleDiag.zone_next_radius );
+
+        br_diag_zone_radius = BattleRoyaleDiag.zone_radius;
+        br_diag_zone_next_radius = BattleRoyaleDiag.zone_next_radius;
+    }
+
+    //! Drain the diag menu's one-shot requests. Counters, so a press is never lost or double-fired.
+    protected void BR_DiagHandleRequests()
+    {
+        if ( br_diag_req_spawn_menu != BattleRoyaleDiag.req_open_spawn_menu )
+        {
+            br_diag_req_spawn_menu = BattleRoyaleDiag.req_open_spawn_menu;
+#ifdef DIAG
+            MissionGameplay diag_gameplay = MissionGameplay.Cast( GetGame().GetMission() );
+            if ( diag_gameplay )
+                diag_gameplay.BR_DiagOpenSpawnSelection();
+#endif
+        }
+
+        if ( br_diag_req_leaderboard != BattleRoyaleDiag.req_open_leaderboard )
+        {
+            br_diag_req_leaderboard = BattleRoyaleDiag.req_open_leaderboard;
+
+            //--- Parentless, on a cleared stack, for the same reason ShowSpawnSelection is.
+            //--- Qualified: the bare GetUIManager() that MissionGameplay uses is a method on
+            //--- Mission, and this class is not one.
+            GetGame().GetUIManager().CloseAll();
+            GetGame().GetUIManager().EnterScriptedMenu( MENU_BR_LEADERBOARD, NULL );
+        }
+    }
+#endif
 
 	// To track changes
     bool br_previous_fade_state = false;
@@ -83,6 +170,12 @@ class BattleRoyaleClient: BattleRoyaleBase
 		float distInt;
 		float angle;
 		bool isInsideZone;
+
+#ifdef DIAG_DEVELOPER
+		// Diag menu, drained first so a forced value cannot be overwritten later in the same frame.
+		BR_DiagApplyZones();
+		BR_DiagHandleRequests();
+#endif
 
 		// First check if player is outside current play area
 		if (m_CurrentPlayArea)
@@ -136,8 +229,25 @@ class BattleRoyaleClient: BattleRoyaleBase
 
 		if( br_rpc )
 		{
+			//--- Everything the HUD shows, taken from the wire unless the diag menu is forcing it.
+			//--- Resolved once, up front, so there is exactly one place the two sources meet.
+			int hud_players = br_rpc.nb_players;
+			int hud_groups = br_rpc.nb_groups;
+			int hud_kills = br_rpc.player_kills;
+			int hud_countdown = br_rpc.countdown_seconds;
+
+#ifdef DIAG_DEVELOPER
+			if ( BattleRoyaleDiag.hud_force )
+			{
+				hud_players = BattleRoyaleDiag.hud_players;
+				hud_groups = BattleRoyaleDiag.hud_groups;
+				hud_kills = BattleRoyaleDiag.hud_kills;
+				hud_countdown = BattleRoyaleDiag.hud_countdown;
+			}
+#endif
+
 			// Update player and group remaining count
-			PlayerCountChanged( br_rpc.nb_players, br_rpc.nb_groups );
+			PlayerCountChanged( hud_players, hud_groups );
 
 			// Fade in/out effect
 			if( br_previous_fade_state != br_rpc.fade_state )
@@ -161,7 +271,7 @@ class BattleRoyaleClient: BattleRoyaleBase
 			}
 
 			// Update player kill count
-			gameplay.UpdateKillCount( br_rpc.player_kills );
+			gameplay.UpdateKillCount( hud_kills );
 
 			// Update match start state
 			if( br_rpc.match_started && !b_MatchStarted )
@@ -170,17 +280,32 @@ class BattleRoyaleClient: BattleRoyaleBase
 			}
 
 			// Update countdown timer and zone distance
-			if ( br_previous_countdown != br_rpc.countdown_seconds )
+			bool countdown_changed = ( br_previous_countdown != hud_countdown );
+#ifdef DIAG_DEVELOPER
+			//--- Re-assert every frame while forcing, or OnSecond ticks the forced value down to
+			//--- zero and hides the widget a minute after it was set.
+			if ( BattleRoyaleDiag.hud_force )
+				countdown_changed = true;
+#endif
+
+			if ( countdown_changed )
 			{
-				i_SecondsRemaining = br_rpc.countdown_seconds;
+				i_SecondsRemaining = hud_countdown;
 				gameplay.UpdateCountdownTimer( i_SecondsRemaining );
-				br_previous_countdown = br_rpc.countdown_seconds;
+				br_previous_countdown = hud_countdown;
 			}
+
+			//--- False while the diag menu owns the circles, so the wire cannot overwrite them.
+			bool zones_from_server = true;
+#ifdef DIAG_DEVELOPER
+			if ( BattleRoyaleDiag.zones_fake )
+				zones_from_server = false;
+#endif
 
 			// Update current play area. Diffed like the future area below, and for the same
 			// reason: without the diff this allocated a fresh BattleRoyalePlayArea every frame
 			// for the entire match.
-			if ( br_previous_current_play_area_center != br_rpc.current_play_area_center || br_previous_current_play_area_radius != br_rpc.current_play_area_radius )
+			if ( zones_from_server && ( br_previous_current_play_area_center != br_rpc.current_play_area_center || br_previous_current_play_area_radius != br_rpc.current_play_area_radius ) )
 			{
 				// "0 0 0" with a zero radius is the server deliberately clearing the area, not an
 				// absent update - 7_BattleRoyaleLastRound sends exactly that. Treating it as
@@ -195,7 +320,7 @@ class BattleRoyaleClient: BattleRoyaleBase
 			}
 
 			// Update future play area
-			if ( br_previous_future_play_area_center != br_rpc.future_play_area_center || br_previous_future_play_area_radius != br_rpc.future_play_area_radius )
+			if ( zones_from_server && ( br_previous_future_play_area_center != br_rpc.future_play_area_center || br_previous_future_play_area_radius != br_rpc.future_play_area_radius ) )
 			{
 				if ( br_rpc.future_play_area_center && br_rpc.future_play_area_radius )
 				{

--- a/Scripts/Client/5_Mission/COT/GUI/BRMasterControlsForm.c
+++ b/Scripts/Client/5_Mission/COT/GUI/BRMasterControlsForm.c
@@ -29,12 +29,10 @@ class BRMasterControlsForm: JMFormBase
             UIActionManager.CreateButton( wrapper, "Spawn Airdrop", this, "SpawnAirdrop" );
 #endif
 
-#ifdef DIAG
-        wrapper = UIActionManager.CreateGridSpacer( m_ActionsWrapper, 1, 4 );
-            UIActionManager.CreateText( wrapper, "DIAG DEBUG" );
-            UIActionManager.CreateButton( wrapper, "Add Player", this, "AddFakePlayer" );
-            UIActionManager.CreateButton( wrapper, "Add Group", this, "AddFakeGroup" );
-#endif
+        //--- No DIAG block here on purpose. "Add Player" / "Add Group" used to live here, but
+        //--- BattleRoyaleCOTStateMachineRPC.AddFakePlayer / .AddFakeGroup have no case in the
+        //--- server switch, so both buttons sent an RPC into the void. Fake players and fake
+        //--- parties now come from the diag menu instead - see PluginDiagMenu.c.
 
         m_sclr_MainActions.UpdateScroller();
     }
@@ -60,16 +58,6 @@ class BRMasterControlsForm: JMFormBase
     void StateMachine_Resume(UIEvent eid, UIActionBase action)
     {
         m_Module.StateMachine_Resume();
-    }
-
-    void AddFakePlayer(UIEvent eid, UIActionBase action)
-    {
-        m_Module.AddFakePlayer();
-    }
-
-    void AddFakeGroup(UIEvent eid, UIActionBase action)
-    {
-        m_Module.AddFakeGroup();
     }
 
     void SpawnAirdrop(UIEvent eid, UIActionBase action)

--- a/Scripts/Client/5_Mission/COT/GUI/BRMasterControlsModule.c
+++ b/Scripts/Client/5_Mission/COT/GUI/BRMasterControlsModule.c
@@ -72,18 +72,6 @@ class BRMasterControlsModule: JMRenderableModuleBase
         rpc.Send( NULL, BattleRoyaleCOTStateMachineRPC.Resume, true, NULL );
     }
 
-    void AddFakePlayer()
-    {
-        ScriptRPC rpc = new ScriptRPC();
-        rpc.Send( GetGame().GetPlayer(), BattleRoyaleCOTStateMachineRPC.AddFakePlayer, true, NULL );
-    }
-
-    void AddFakeGroup()
-    {
-        ScriptRPC rpc = new ScriptRPC();
-        rpc.Send( GetGame().GetPlayer(), BattleRoyaleCOTStateMachineRPC.AddFakeGroup, true, NULL );
-    }
-
     void SpawnAirdrop()
     {
         ScriptRPC rpc = new ScriptRPC();

--- a/Scripts/Client/5_Mission/Mission/MissionGameplay.c
+++ b/Scripts/Client/5_Mission/Mission/MissionGameplay.c
@@ -275,17 +275,10 @@ modded class MissionGameplay
 				}
 			}
 #ifdef DIAG
-			// Debug key
+			// Debug key. Shares its implementation with the diag menu's "Open Spawn Menu" entry -
+			// two copies of the same hardcoded fake data is how they drift apart.
 			if (GetUApi().GetInputByID(UADayZBRDebug).LocalPress()) {
-				//--- Parentless, same as the real opener - see ShowSpawnSelection for why.
-				GetUIManager().CloseAll();
-				SpawnSelectionMenu m = SpawnSelectionMenu.Cast(GetUIManager().EnterScriptedMenu(MENU_SPAWN_SELECTION, NULL));
-				if (m)
-				{
-					m.SetInitialCountdown(45);
-					m.SetSpawnSize(50);
-					m.SetFirstZone(Vector(6000, 0, 7777), 1500);
-				}
+				BR_DiagOpenSpawnSelection();
 			}
 #endif
 #ifdef BR_MINIMAP
@@ -305,6 +298,31 @@ modded class MissionGameplay
 #endif
 		}
 	}
+
+#ifdef DIAG
+	/**
+	 *  Open spawn selection with plausible made-up data, with no server involved.
+	 *
+	 *  Reached from the F3 key and from the diag menu's "Open Spawn Menu" entry. It is the same
+	 *  opening sequence ShowSpawnSelection uses - parentless, on a cleared stack, for the reason
+	 *  spelled out there - so what is exercised is the real menu, not a lookalike.
+	 */
+	void BR_DiagOpenSpawnSelection()
+	{
+		GetUIManager().CloseAll();
+
+		SpawnSelectionMenu diag_menu = SpawnSelectionMenu.Cast(GetUIManager().EnterScriptedMenu(MENU_SPAWN_SELECTION, NULL));
+		if (!diag_menu)
+		{
+			BattleRoyaleUtils.Warn("BR_DiagOpenSpawnSelection: could not open the spawn selection menu");
+			return;
+		}
+
+		diag_menu.SetInitialCountdown(45);
+		diag_menu.SetSpawnSize(50);
+		diag_menu.SetFirstZone(Vector(6000, 0, 7777), 1500);
+	}
+#endif
 
 	void ShowSpawnSelection(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
 	{

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/BattleRoyaleServer.c
@@ -22,6 +22,12 @@ class BattleRoyaleServer: BattleRoyaleBase
 #ifdef VPPADMINTOOLS
         GetRPCManager().AddRPC( RPC_DAYZBRSERVER_NAMESPACE, "NextState", this, SingleplayerExecutionType.Server);
 #endif
+#ifdef DIAG_DEVELOPER
+        //--- Guarded on the same define as its handler, unlike NextState above, whose registration
+        //--- is VPPADMINTOOLS while its only caller is JM_COT - a COT-without-VPP build has a live
+        //--- button and nothing listening.
+        GetRPCManager().AddRPC( RPC_DAYZBRSERVER_NAMESPACE, "BRDiagAction", this );
+#endif
 
         Init();
     }
@@ -182,6 +188,11 @@ class BattleRoyaleServer: BattleRoyaleBase
 	const float CHECK_IS_COMPLETE = 0.1;  //seconds
 	float m_TimeSinceLastTick = CHECK_IS_COMPLETE + 1;
 
+#ifdef DIAG_DEVELOPER
+	//! Diag "Jump To State" target, or -1. See the fast-forward block in Update().
+	int m_DiagTargetState = -1;
+#endif
+
     override void Update(float delta)
     {
         float timeslice = delta; //Legacy
@@ -219,6 +230,21 @@ class BattleRoyaleServer: BattleRoyaleBase
 			//--- this is a single bool test per tick.
 			if ( BattleRoyaleNameService.ConsumePartyRefresh() )
 				VigridPartyAPI.RefreshRosterNames();
+#endif
+
+#ifdef DIAG_DEVELOPER
+			//--- Diag fast-forward. Deliberately a fast-forward and not a seek: it deactivates the
+			//--- current state once per tick and lets the transition below run normally, so every
+			//--- state on the way still gets its Activate() and nothing is left half-initialised.
+			//--- Ten states cost one second. Clearing the target on arrival is what stops it from
+			//--- driving the machine off the end.
+			if ( m_DiagTargetState >= 0 )
+			{
+				if ( i_CurrentStateIndex >= m_DiagTargetState )
+					m_DiagTargetState = -1;
+				else if ( GetCurrentState().IsActive() )
+					GetCurrentState().Deactivate();
+			}
 #endif
 
 			if (GetCurrentState().IsComplete()) //current state is complete
@@ -632,6 +658,253 @@ class BattleRoyaleServer: BattleRoyaleBase
 			weather.GetFog().Set( Math.RandomFloatInclusive(0.0, 0.1), 0, 0);
         }
     }
+
+#ifdef DIAG_DEVELOPER
+    /**
+     *  Every server-side debug action, behind one RPC.
+     *
+     *  One RPC carrying an action id rather than one named RPC per action: adding an action is one
+     *  enum value plus one case here, with no new registration and no wire change to keep in sync
+     *  between the two sides.
+     *
+     *  The refusal path logs. A silently-refused button and a broken button look identical from the
+     *  diag menu, and the usual cause is simply that the tester is not in admins_steamid64 - which
+     *  is read from the PROFILE general_settings.json, since that field is exempt from the mission
+     *  override.
+     */
+    void BRDiagAction(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
+    {
+        if(type != CallType.Server)
+            return;
+
+        Param3<int, int, float> data;
+        if(!ctx.Read(data))
+        {
+            BattleRoyaleUtils.Warn("Failed to read BRDiagAction RPC");
+            return;
+        }
+
+        if(!IsAdminIdentity(sender))
+        {
+            BattleRoyaleUtils.Warn("Rejected unauthorized BRDiagAction " + data.param1 + " from " + GetIdentityLogName(sender));
+            return;
+        }
+
+        BattleRoyaleUtils.Info("[Diag] action " + data.param1 + " (" + data.param2 + ", " + data.param3 + ") from " + GetIdentityLogName(sender));
+
+        BattleRoyaleState state = GetCurrentState();
+
+        //--- Asked of the state rather than of the game: a player the current state does not hold
+        //--- is one OnPlayerTick would be force-logging-out anyway, so "not in this state" is the
+        //--- right answer to "who sent this".
+        PlayerBase sender_player;
+        if(state)
+            sender_player = state.GetPlayerFromIdentity(sender);
+
+        switch(data.param1)
+        {
+            case BattleRoyaleDiagAction.SKIP_STATE:
+            {
+                //--- Same one-liner the COT and VPP paths use: a state signals "done" by
+                //--- deactivating itself, and Update() picks the transition up at 10 Hz.
+                if(state)
+                    state.Deactivate();
+                break;
+            }
+
+            case BattleRoyaleDiagAction.SET_PAUSED:
+            {
+                if(!state)
+                    break;
+
+                if(data.param2 != 0)
+                    state.Pause();
+                else
+                    state.Resume();
+                break;
+            }
+
+            case BattleRoyaleDiagAction.GOTO_STATE:
+            {
+                //--- Clamped, and this is not a nicety: the last state is BattleRoyaleRestart, whose
+                //--- Activate() calls RequestExit. A fat-fingered target would kill the server.
+                //--- Not named `target`: this handler already has an Object parameter by that name,
+                //--- and EnfusionScript allows one declaration per name per method scope.
+                int max_target = m_States.Count() - 2;
+                int goto_target = data.param2;
+                if(goto_target > max_target)
+                    goto_target = max_target;
+                if(goto_target < 0)
+                    goto_target = 0;
+
+                if(goto_target <= i_CurrentStateIndex)
+                {
+                    BattleRoyaleUtils.Warn("[Diag] cannot jump back to state " + goto_target + ", already at " + i_CurrentStateIndex);
+                    break;
+                }
+
+                BattleRoyaleUtils.Info("[Diag] fast-forwarding from state " + i_CurrentStateIndex + " to " + goto_target);
+                m_DiagTargetState = goto_target;
+                break;
+            }
+
+            case BattleRoyaleDiagAction.FORCE_READY_ALL:
+            {
+                //--- BattleRoyaleDebug specifically, not BattleRoyaleDebugState: ReadyUp and the
+                //--- ready list live on the lobby state, while CountReached shares the base class.
+                BattleRoyaleDebug lobby;
+                if(!Class.CastTo(lobby, state))
+                {
+                    BattleRoyaleUtils.Warn("[Diag] Force Ready All only works in the lobby state");
+                    break;
+                }
+
+                //--- Readies everyone through the real ReadyUp path, so the countdown, the messages
+                //--- and the vote threshold all behave exactly as they would with real players.
+                ref array<PlayerBase> lobby_players = lobby.GetPlayers();
+                for(int r = 0; r < lobby_players.Count(); r++)
+                {
+                    if(lobby_players[r])
+                        lobby.ReadyUp(lobby_players[r]);
+                }
+                break;
+            }
+
+            case BattleRoyaleDiagAction.LOG_STATE:
+            {
+                if(!state)
+                    break;
+
+                //--- Info rather than Debug: on a DIAG server this mirrors into in-game chat, so the
+                //--- answer lands where the tester is looking instead of only in the log.
+                BattleRoyaleUtils.Info("[Diag] state " + i_CurrentStateIndex + "/" + (m_States.Count() - 1) + " `" + state.GetName() + "` players=" + state.GetPlayers().Count() + " active=" + state.IsActive());
+                break;
+            }
+
+            case BattleRoyaleDiagAction.TP_ZONE_CENTER:
+            {
+                BattleRoyaleRound round_current;
+                if(!Class.CastTo(round_current, state))
+                {
+                    BattleRoyaleUtils.Warn("[Diag] TP: Zone Centre needs a round state, not `" + state.GetName() + "`");
+                    break;
+                }
+
+                //--- GetActiveZone is the circle that is actually damaging right now, which before
+                //--- the 80% lock is the PREVIOUS one - that is the circle a tester means.
+                BattleRoyaleZone active_zone = round_current.GetActiveZone();
+                if(!active_zone)
+                    active_zone = round_current.GetZone();
+
+                if(active_zone && active_zone.GetArea())
+                    state.BR_DiagTeleport(sender_player, active_zone.GetArea().GetCenter());
+                break;
+            }
+
+            case BattleRoyaleDiagAction.TP_NEXT_ZONE:
+            {
+                BattleRoyaleRound round_next;
+                if(!Class.CastTo(round_next, state))
+                {
+                    BattleRoyaleUtils.Warn("[Diag] TP: Next Zone needs a round state, not `" + state.GetName() + "`");
+                    break;
+                }
+
+                if(round_next.GetZone() && round_next.GetZone().GetArea())
+                    state.BR_DiagTeleport(sender_player, round_next.GetZone().GetArea().GetCenter());
+                break;
+            }
+
+            case BattleRoyaleDiagAction.TP_LOBBY:
+            {
+                //--- State 0 is always the lobby, whatever the rest of the machine looks like.
+                BattleRoyaleDebugState lobby_state;
+                if(Class.CastTo(lobby_state, GetState(0)) && state)
+                    state.BR_DiagTeleport(sender_player, lobby_state.GetCenter());
+                break;
+            }
+
+            case BattleRoyaleDiagAction.FORCE_UNSTUCK:
+            {
+                if(!state || !sender_player)
+                    break;
+
+                //--- Clear the gates rather than going around DeferredUnstuck: the 1-3 s defer and
+                //--- the position search are the parts worth exercising, and the 30 s cooldown is
+                //--- the only thing that makes the ladder repro slow to iterate on.
+                sender_player.wait_unstuck = false;
+                sender_player.next_unstuck_time = 0;
+                state.DeferredUnstuck(sender_player);
+                break;
+            }
+
+            case BattleRoyaleDiagAction.LOG_ZONE_TABLE:
+            {
+                //--- Generation runs smallest-first, so index 0 is the FINAL circle and each later
+                //--- index contains the one before it. This dump is the cheapest way to see that.
+                if(!BattleRoyaleZone.m_PlayAreas)
+                {
+                    BattleRoyaleUtils.Warn("[Diag] no play areas generated");
+                    break;
+                }
+
+                BattleRoyaleUtils.Info("[Diag] play areas, generation order (index 0 is the FINAL circle):");
+                for(int z = 0; z < BattleRoyaleZone.m_PlayAreas.Count(); z++)
+                {
+                    BattleRoyalePlayArea area = BattleRoyaleZone.m_PlayAreas[z];
+                    if(!area)
+                        continue;
+
+                    float offset = 0;
+                    if(BattleRoyaleZone.s_PlayAreaDurationOffsets && z < BattleRoyaleZone.s_PlayAreaDurationOffsets.Count())
+                        offset = BattleRoyaleZone.s_PlayAreaDurationOffsets[z];
+
+                    BattleRoyaleUtils.Info("[Diag]   [" + z + "] center=" + area.GetCenter() + " radius=" + area.GetRadius() + " duration_offset=" + offset);
+                }
+                break;
+            }
+
+            case BattleRoyaleDiagAction.CLEAR_MAP_MARKERS:
+            {
+#ifdef VIGRID_MAP
+                VigridMapAPI.ClearAllMarkers();
+                BattleRoyaleUtils.Info("[Diag] cleared every map marker");
+#endif
+                break;
+            }
+
+            case BattleRoyaleDiagAction.SET_LOG_LEVEL:
+            {
+                BattleRoyaleDiag.log_level_override = data.param2;
+                //--- Printed unconditionally through Print, because the new level may well be one
+                //--- that swallows this very line.
+                Print("[DayZ-BattleRoyale][Diag] server log level override -> " + data.param2);
+                break;
+            }
+
+            case BattleRoyaleDiagAction.SET_CHAT_MIRROR:
+            {
+                BattleRoyaleDiag.chat_mirror = (data.param2 != 0);
+                Print("[DayZ-BattleRoyale][Diag] chat mirror -> " + BattleRoyaleDiag.chat_mirror);
+                break;
+            }
+
+            case BattleRoyaleDiagAction.SET_TRACE_TP:
+            {
+                BattleRoyaleDiag.trace_teleport = (data.param2 != 0);
+                BattleRoyaleDiag.trace_teleport_ticks = (int)data.param3;
+                BattleRoyaleUtils.Info("[Diag] teleport trace -> " + BattleRoyaleDiag.trace_teleport + " for " + BattleRoyaleDiag.trace_teleport_ticks + " ticks");
+                break;
+            }
+
+            default:
+            {
+                BattleRoyaleUtils.Warn("[Diag] unknown action " + data.param1);
+                break;
+            }
+        }
+    }
+#endif
 
     void NextState(CallType type, ParamsReadContext ctx, PlayerIdentity sender, Object target)
     {

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/0_BattleRoyaleState.c
@@ -536,6 +536,13 @@ class BattleRoyaleState: Timeable
             return;
         }
 
+#ifdef DIAG_DEVELOPER
+        //--- The one sample the juncture cannot give: what the command state was while the player
+        //--- was still AT the ladder. If it reads Ladder here and not at "juncture", the command was
+        //--- replaced underneath the animation, which is the case HumanCommandLadder.Exit exists for.
+        player.BR_LogTeleportState("pre-unstuck");
+#endif
+
         vector playerDir = vector.YawToVector( Math.RandomFloat(0, 360) );
         vector direction = Vector(playerDir[0], 0, playerDir[1]);
 
@@ -549,6 +556,37 @@ class BattleRoyaleState: Timeable
         //--- Charged only for a teleport that was actually sent - see the note in DeferredUnstuck.
         player.next_unstuck_time = GetGame().GetTickTime() + BR_UNSTUCK_COOLDOWN_SECONDS;
     }
+
+#ifdef DIAG_DEVELOPER
+    /**
+     *  Diag only: put `player` at `position` down the same sync juncture the unstuck path uses.
+     *
+     *  Deliberately NOT a SetPosition. The juncture is what carries the teleport to the client half
+     *  as well, and it is the code path the mod's own teleport bugs live in - a debug teleport that
+     *  went around it would be testing something nobody ships.
+     *
+     *  The height is left alone: the juncture's server half applies BR_TELEPORT_DROP_HEIGHT itself,
+     *  and adding it here as well would stack two seating epsilons.
+     */
+    void BR_DiagTeleport( PlayerBase player, vector position )
+    {
+        if( !player )
+            return;
+
+        position[1] = GetGame().SurfaceY( position[0], position[2] );
+
+        vector playerDir = vector.YawToVector( Math.RandomFloat(0, 360) );
+        vector direction = Vector(playerDir[0], 0, playerDir[1]);
+
+        ScriptJunctureData pCtx = new ScriptJunctureData;
+        pCtx.Write( position );
+        pCtx.Write( direction );
+        player.SendSyncJuncture( BR_SYNC_JUNCTURE_TELEPORT, pCtx );
+        player.SetSynchDirty();
+
+        BattleRoyaleUtils.Info( "[Diag] teleported " + GetPlayerLogName( player ) + " to " + position );
+    }
+#endif
 
 	// Maybe this should be moved to another class, maybe not
     int GetDynamicStartingZone(int num_players)


### PR DESCRIPTION
PluginDiagMenu was a placeholder: one root menu and a "Dummy Option" whose
callback only traced. Both files were also missing their #endifs and had been
since the feature landed, working only because an unterminated conditional runs
to EOF.

It now carries 38 entries in 8 submenus, each one collapsing a dev loop that was
expensive to reach: a kill feed needs two clients, a party needs three, and
anything past the lobby needs a ready-up and a countdown first.

Callbacks live in 4_World and cannot see 5_Mission, so they write a two-sided
BattleRoyaleDiag in 3_Game and consumers poll it - the same shape
BattleRoyaleRPC -> BattleRoyaleClient.Update already uses. One-shots are
monotonic counters rather than flags, so nobody owns the clear. Server-side
actions go out as a single RPC and are refused unless the sender is in
admins_steamid64, with the refusal logged, because a silently-refused button and
a broken button look identical from the menu.

Entries drive production code paths, never lookalikes: fake kill rows go through
the network queue so the ECE_LOCAL preview and its attachments run, fake zones
go through the one VigridMapAPI.SetZones call a match uses, and every teleport
goes through the real sync juncture rather than SetPosition.

Two things were measured rather than assumed. Enfusion rejects an expression
continued across lines, the same restriction that forbids a multi-line if. And
DiagMenu.BindCallback's bool return is not a success flag - it returns false for
a valid registered id with a valid signature, twice in a row on the same id,
which is why vanilla discards it at all ~100 of its call sites. A registration
canary replaces the wrapper that warned on it.

Squashed from 1 commit:
  e583a98  Turn the diag menu into a real developer toolbox

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 21 of 31 replaying the local history onto `main`.
