### PR TITLE
Remove the F3 debug key, and note why CI1 must not list config.cpp twice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ Slot colours live in `Party/Scripts/3_Game/VigridPartyPalette.c`, unguarded, so 
 
 Layouts live in `GUI/layouts/`. The dominant pattern is imperative — `GetGame().GetWorkspace().CreateWidgets("Vigrid-BattleRoyale/GUI/layouts/....layout")` then `FindAnyWidget("Name")`; most layouts have no `scriptclass`. `SpawnSelectionMenu` is a `UIScriptedMenu` (`MENU_SPAWN_SELECTION = 75` in `Scripts/Client/3_Game/Constants.c`, instantiated in `MissionBase.CreateScriptedMenu`). The only declarative `scriptclass` binding is the COT `master_controls.layout` → `BRMasterControlsForm`.
 
-Keybinds are declared in `Data/Inputs.xml` (`UADayZBRReadyUp` = F1, `UADayZBRUnstuck` = F2, `UADayZBRDebug` = F3), registered via `inputs = "Vigrid-BattleRoyale/Data/Inputs.xml"` in `Scripts/Client/config.cpp`.
+Keybinds are declared in `Data/Inputs.xml` (`UADayZBRReadyUp` = F1, `UADayZBRUnstuck` = F2), registered via `inputs = "Vigrid-BattleRoyale/Data/Inputs.xml"` in `Scripts/Client/config.cpp`.
 
 ### Kill feed (`Extra/KillFeed/`)
 

--- a/Data/Inputs.xml
+++ b/Data/Inputs.xml
@@ -4,7 +4,6 @@
         <actions>
             <input name="UADayZBRReadyUp" loc="BR Ready Up" />
             <input name="UADayZBRUnstuck" loc="BR Unstuck" />
-            <input name="UADayZBRDebug" loc="BR Debug" />
             <input name="UADayZBRLeaderboard" loc="BR Leaderboard" />
             <!--            <input name="UADayZBRToggleMiniMap" loc="BR Mini Map Toggle" />-->
             <!--            <input name="UADayZBRMiniMapZoomPlus" loc="BR Mini Map Increase Zoom" />-->
@@ -14,7 +13,6 @@
         <sorting name="dayzbr" loc="BATTLE ROYALE">
             <input name="UADayZBRReadyUp" />
             <input name="UADayZBRUnstuck" />
-            <input name="UADayZBRDebug" />
             <input name="UADayZBRLeaderboard" />
             <!--            <input name="UADayZBRToggleMiniMap" />-->
             <!--            <input name="UADayZBRMiniMapZoomPlus" />-->
@@ -27,9 +25,6 @@
         </input>
         <input name="UADayZBRUnstuck">
             <btn name="kF2" />
-        </input>
-        <input name="UADayZBRDebug">
-            <btn name="kF3" />
         </input>
         <input name="UADayZBRLeaderboard">
             <btn name="kF4" />

--- a/Scripts/Client/5_Mission/Mission/MissionGameplay.c
+++ b/Scripts/Client/5_Mission/Mission/MissionGameplay.c
@@ -274,13 +274,6 @@ modded class MissionGameplay
 					GetUIManager().EnterScriptedMenu(MENU_BR_LEADERBOARD, GetUIManager().GetMenu());
 				}
 			}
-#ifdef DIAG
-			// Debug key. Shares its implementation with the diag menu's "Open Spawn Menu" entry -
-			// two copies of the same hardcoded fake data is how they drift apart.
-			if (GetUApi().GetInputByID(UADayZBRDebug).LocalPress()) {
-				BR_DiagOpenSpawnSelection();
-			}
-#endif
 #ifdef BR_MINIMAP
 			if (GetUApi().GetInputByID(UADayZBRToggleMiniMap).LocalPress()) {
 				b_MiniMapShow = !b_MiniMapShow;
@@ -303,7 +296,7 @@ modded class MissionGameplay
 	/**
 	 *  Open spawn selection with plausible made-up data, with no server involved.
 	 *
-	 *  Reached from the F3 key and from the diag menu's "Open Spawn Menu" entry. It is the same
+	 *  Reached from the diag menu's "Open Spawn Menu" entry. It is the same
 	 *  opening sequence ShowSpawnSelection uses - parentless, on a cleared stack, for the reason
 	 *  spelled out there - so what is exercised is the real menu, not a lookalike.
 	 */

--- a/Workbench/Batchfiles/CI1.bat
+++ b/Workbench/Batchfiles/CI1.bat
@@ -172,6 +172,12 @@ IF EXIST "%~dp1IGNORE" IF %noIgnore%==0 (
 	exit /B
 )
 
+REM A path is added to the list ONLY by the parent-check below. Do not append it here as well:
+REM the entry would be duplicated, every PBO would be built twice, and with rebuildAll (which packs
+REM unconditionally rather than only on change) the second pass repacks after the temp config.bin
+REM has already been deleted - shipping a PBO with no config, hence no CfgPatches, hence a mod that
+REM silently does not load at all.
+
 IF NOT EXIST "%~dp1..\config.cpp" (
 	IF NOT EXIST "%~dp1..\..\config.cpp" (
 		IF NOT EXIST "%~dp1..\..\..\config.cpp" (


### PR DESCRIPTION
The UADayZBRDebug input and its DIAG-only handler are removed - an unused debug
hotkey and its documentation reference.

Deploy.bat rebuildAll had produced a mod that did not load at all: no lobby, no
inputs, and no error anywhere. The build logged success and every PBO was
present, correctly prefixed and a plausible size - they just had no config.bin
in them, so no CfgPatches, so the engine mounted nothing. The cause was already
fixed; what was missing was any note saying why the line must not come back.

Worth knowing alongside it: the generated path list lives in P:\Temp, is shared
by every worktree, and is REUSED whenever the enumerated paths are unchanged. So
a stale list survived the fix and every PBO was still being built twice. Verify
the artifact, not the diff.

Squashed from 2 commits:
  97bd408  Remove Battle Royale debug F3 key
  4d46752  Stop CI1 listing every config.cpp twice, which made rebuildAll ship broken PBOs

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---
PR 23 of 31 replaying the local history onto `main`.
