### PR TITLE
Cover every player-placed trap in the lobby truce, not just landmines

### DIFF
--- a/Extra/SafeZone/Scripts/4_World/Entities/ManBase/PlayerBase.c
+++ b/Extra/SafeZone/Scripts/4_World/Entities/ManBase/PlayerBase.c
@@ -115,13 +115,16 @@ modded class PlayerBase
 
         //--- Explosives have no player left in their hierarchy once thrown or placed, but nothing
         //--- else leaves one lying around either. Classified by type, the same way the host mod's
-        //--- own kill reporting does it. IsExplosive() covers Grenade_Base via ExplosivesBase;
-        //--- LandMineTrap descends from TrapBase instead and needs naming separately.
+        //--- own kill reporting does it - and at the vanilla PARENTS, never at a leaf class.
+        //--- IsExplosive() is declared on ItemBase and only ExplosivesBase overrides it to true, so
+        //--- it covers Grenade_Base, Claymore, IED and Plastic Explosive; TrapBase sits outside that
+        //--- branch entirely and needs naming separately. Naming LandMineTrap there let every other
+        //--- player-placed trap - BearTrap and friends - still land damage during the truce.
         ItemBase item = ItemBase.Cast(source);
         if (item && item.IsExplosive())
             return true;
 
-        if (source.IsInherited(LandMineTrap))
+        if (source.IsInherited(TrapBase))
             return true;
 
         return false;


### PR DESCRIPTION
`VigridSafeZone_IsPlayerInflicted()` classified trap damage by naming the leaf class `LandMineTrap`. Vanilla parents `LandMineTrap`, `BearTrap` and the rest under `TrapBase`, so every player-placed trap other than a landmine still inflicted damage during the lobby truce — exactly what the truce exists to prevent.

Test the vanilla parent instead. This is the same fix the host mod's kill attribution needed: devices have to be recognised at `ExplosivesBase` and `TrapBase`, never at a leaf.

## Why the two checks stay separate

Verified against vanilla rather than assumed:

- `TrapBase extends ItemBase`; both `LandMineTrap` and `BearTrap` extend `TrapBase`.
- `IsExplosive()` is declared on `ItemBase` and overridden to `true` only by `ExplosivesBase`.

So the whole `TrapBase` branch — landmine included — falls outside `IsExplosive()` and genuinely needs its own test. The two checks remain disjoint and together cover both device families. The comment above them was rewritten to explain the parent-vs-leaf rule instead of the old `LandMineTrap`-vs-`ExplosivesBase` split.

## Discipline rule

`Extra/SafeZone/` still references no `BattleRoyale*` symbol — `TrapBase` is a vanilla class.

## Verification

- `Deploy.bat` → `Build.success`, no `Build.failure`.
- Checked the **built artifact**, not the diff: `extra_safezone.pbo` carries `IsInherited(TrapBase)` and no longer carries `IsInherited(LandMineTrap)`.
- `LaunchServer.bat` → all four script modules compiled (World: 2592 files / 6435 classes, where this file lives), no `Can't compile`, no crash dump. Server reached the lobby: `BattleRoyaleState::Activate: Debug Zone State`, then `[SafeZone][2] Truce active=true applied to 0 player(s)`.

The only error-level line in the server log is a pre-existing zone-tuning warning about POIs versus the opening circle on a 15360 m world, unrelated to this change.

Not verified in-game: actually placing a `BearTrap` in the lobby and stepping on it. The change is a one-line predicate widening on a path with no other behaviour, so the compile-and-boot check is what was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
