### PR TITLE
Cull lobby name tags past 10 m, measured from the player body

### DIFF
--- a/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
+++ b/Scripts/Client/2_GameLib/BattleRoyaleConstants.c
@@ -448,12 +448,15 @@ static const float BR_LOBBY_TAG_GAP_PX = 6.0;
 static const float BR_LOBBY_TAG_HEAD_OFFSET = 0.22;
 //--- Fallback anchor when the head bone will not resolve, measured from the feet.
 static const float BR_LOBBY_TAG_HEIGHT_OFFSET = 1.9;
-//--- Past this there is no tag at all. The lobby is one clearing and everybody in it is within a
-//--- few dozen metres; the cap is what stops the far side of the map filling the screen with names
-//--- during the pre-match countdown, when players have started to spread out.
-static const float BR_LOBBY_TAG_MAX_DISTANCE_M = 80.0;
-//--- Fade over the last stretch of that range, so a tag thins out rather than blinking off.
-static const float BR_LOBBY_TAG_FADE_START_M = 55.0;
+//--- Past this there is no tag at all, and it is a PROXIMITY RULE rather than an anti-clutter cap:
+//--- you read the name of somebody you are standing next to, not of everybody in the clearing.
+//--- Measured from the local player's BODY (see the note on BattleRoyaleLobbyTags.Update), so the
+//--- figure means what it says in either camera mode.
+static const float BR_LOBBY_TAG_MAX_DISTANCE_M = 10.0;
+//--- Fade over the last stretch of that range, so a tag thins out rather than blinking off. Two
+//--- metres is about half a second at walking pace - short, but a hard edge at this range reads as
+//--- the tag flickering every time its owner shifts their weight.
+static const float BR_LOBBY_TAG_FADE_START_M = 8.0;
 //--- Bound on rows, matching the pooling everywhere else in this mod. A full lobby is 60 players
 //--- and every one of them is in the same clearing.
 static const int BR_LOBBY_TAG_MAX_ROWS = 64;

--- a/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleLobbyTags.c
+++ b/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleLobbyTags.c
@@ -127,8 +127,16 @@ class BattleRoyaleLobbyTags
     /**
      *  Called every frame from BattleRoyaleClient.Update.
      *
-     *  Distances are measured from the CAMERA rather than from the body, so a player in third person
-     *  gets the same answer as what they are looking at rather than one offset by the boom arm.
+     *  Distances are measured from the local player's BODY, feet to feet - so BR_LOBBY_TAG_MAX_DISTANCE_M
+     *  means that many metres between two characters, whatever the camera is doing.
+     *
+     *  REVERSED 2026-08-14, and the reasoning it replaced was not wrong so much as outgrown. This
+     *  measured from the CAMERA, on the grounds that a third-person player then gets the same answer
+     *  as what they are looking at rather than one offset by the boom arm. That holds - but the boom
+     *  is ~2 m, which was noise against the old 80 m cap and is 20% of the 10 m one. A "10 m" rule
+     *  that is really 8 m in third person and 10 m in first is not a rule anybody can reason about.
+     *  The trade accepted in exchange: in third person a tag can now appear on somebody fractionally
+     *  behind the camera. Do not re-derive the camera version from the shape of the fallback below.
      */
     void Update(bool active)
     {
@@ -156,7 +164,15 @@ class BattleRoyaleLobbyTags
         if (parent_w <= 0 || parent_h <= 0)
             return;
 
-        vector camera_pos = GetGame().GetCurrentCameraPosition();
+        //--- Body first, camera only as a fallback for the frames before the local player exists -
+        //--- this runs every frame, including during load-in. NOT the spectator case: UpdateLobbyTags
+        //--- gates on !IsSpectating(), so the "GetPlayer() keeps returning the corpse" trap is out of
+        //--- reach here.
+        vector reference_pos = GetGame().GetCurrentCameraPosition();
+
+        PlayerBase local_player = PlayerBase.Cast(GetGame().GetPlayer());
+        if (local_player)
+            reference_pos = local_player.GetPosition();
 
         int used = 0;
         int rows = br_rpc.lobby_names.Count();
@@ -205,7 +221,7 @@ class BattleRoyaleLobbyTags
             if (!other.GetIdentity())
                 no_identity++;
 
-            float distance = vector.Distance(camera_pos, other.GetPosition());
+            float distance = vector.Distance(reference_pos, other.GetPosition());
             if (distance > BR_LOBBY_TAG_MAX_DISTANCE_M)
             {
                 too_far++;


### PR DESCRIPTION
The lobby name tag overlay named every living non-teammate out to **80 m**, fading from 55 m. This tightens it to a proximity rule: a tag names somebody you are standing next to, not everybody in the clearing.

The cull and fade mechanism already existed and is measured-good, so this is a range change rather than new code.

## Changes

**`Scripts/Client/2_GameLib/BattleRoyaleConstants.c`**

- `BR_LOBBY_TAG_MAX_DISTANCE_M` 80.0 -> **10.0**
- `BR_LOBBY_TAG_FADE_START_M` 55.0 -> **8.0**

The comment above the cap is rewritten: it justified the old value as anti-clutter ("what stops the far side of the map filling the screen with names"), which is no longer what the number is for.

**`Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleLobbyTags.c`**

Distance now measured from the local player's **body**, feet to feet, instead of the camera.

Measuring from the camera was right at 80 m — it matches what a third-person player is looking at rather than an answer offset by the boom arm. But the boom is ~2 m, which was noise against 80 m and is 20% of 10 m. A "10 m" rule that is really 8 m in third person and 10 m in first is not one anybody can reason about. The camera read stays as a fallback for the frames before the local player exists; it cannot be the spectator case, since `UpdateLobbyTags` gates on `!IsSpectating()`.

The `Update()` doc comment argued explicitly for the camera, so it now records the reversal and why the old reasoning stopped holding — the trade accepted being that a tag can appear on somebody fractionally behind the camera in third person.

## Not changed

`FadeAlpha` (derives its span from the two constants), the server-side roster in `BattleRoyaleServer.SendLobbyNames`, and both layouts. Party tags are untouched — teammates are already excluded server-side before the packet is built.

## Verification

`Deploy.bat` reached `Build.success`, and the shipped `Scripts_Client.pbo` was grepped rather than the diff trusted — it carries `= 10.0`, `= 8.0` and `vector.Distance(reference_pos`.

`LaunchOffline.bat` as the compile gate (packing a PBO does not compile EnfusionScript): clean, `MissionGameplay::MissionGameplay` present, no script errors.

`LaunchLocalMP.bat 2`, two solo clients in the lobby, funnel diagnostic from both:

```
CLIENT A  11:49:19  rows=1 ... far=0 offscreen=0 drawn=1
CLIENT A  11:49:21  rows=1 ... far=1 offscreen=0 drawn=0     <- culled
CLIENT A  11:49:23  rows=1 ... far=0 offscreen=0 drawn=1     <- back

CLIENT B  11:49:19  rows=1 ... far=0 offscreen=1 drawn=0
CLIENT B  11:49:21  rows=1 ... far=1 offscreen=0 drawn=0     <- culled
CLIENT B  11:49:25  rows=1 ... far=0 offscreen=0 drawn=1     <- back
```

`far=1` firing within seconds of separation is the change itself — at 80 m that counter would essentially never move in a lobby clearing. Both clients flipped in the same 2 s window, which is a free cross-check on the body reference: body-to-body distance is symmetric, so two clients computing it independently should agree, and camera-based measurement would not necessarily.

In-game appearance confirmed by Myst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
