### PR TITLE
Index the population once per frame instead of scanning it per lookup

### DIFF
--- a/Party/Scripts/4_World/VigridPartyAPI.c
+++ b/Party/Scripts/4_World/VigridPartyAPI.c
@@ -554,7 +554,32 @@ class VigridPartyAPI
 
     //--- position resolution, shared with VigridPartyNametags ----------------------------------
 
-    //! Locate a teammate's entity in the local network bubble. Null is normal, not an error.
+    //--- Per-frame uid -> entity index over ClientData.m_PlayerBaseList. See FindLocalPlayer.
+    private static ref map<string, PlayerBase> s_LocalByUid;
+    private static int s_LocalByUidMs = -1;
+    private static int s_LocalByUidCount = -1;
+
+    /**
+     *  Locate a teammate's entity in the local network bubble. Null is normal, not an error.
+     *
+     *  MEMOIZED PER FRAME, because the callers are per-frame renderers and there are several of
+     *  them. This was a linear scan of the whole population per call, and every call site asks it
+     *  once PER PARTY MEMBER: VigridPartyNametags and VigridMapCompass.CollectCarets both run every
+     *  frame, VigridMapMinimap and VigridMapMenu at 10 Hz. So a four-player party cost six-odd full
+     *  walks per frame, and each walk materialises a fresh string from GetPlainId() for every
+     *  candidate it rejects. That is O(members x population) string allocations per frame, and it is
+     *  worst exactly where the population is densest - the lobby, where everyone stands in one
+     *  clearing and so everyone is inside everyone else's bubble.
+     *
+     *  The index makes it one walk per frame plus a hash lookup per call. Built lazily, so a solo
+     *  player with no roster to draw never pays for it at all.
+     *
+     *  Invalidated on the millisecond AND on the population count. The clock alone is enough at any
+     *  real frame rate - 60 fps is 16 ms apart - but an entity entering or leaving the bubble within
+     *  the same millisecond would otherwise be missed for that frame, and the count is one integer
+     *  compare. Entries are still null-checked on the way out: an entity deleted after the index was
+     *  built reads as null through its reference, exactly as it did mid-walk before.
+     */
     static PlayerBase FindLocalPlayer(string uid)
     {
         if (uid == "")
@@ -563,6 +588,29 @@ class VigridPartyAPI
             return null;
 
         int count = ClientData.m_PlayerBaseList.Count();
+        int now = GetGame().GetTime();
+
+        if (now != s_LocalByUidMs || count != s_LocalByUidCount || !s_LocalByUid)
+            RebuildLocalIndex(count, now);
+
+        PlayerBase found = s_LocalByUid.Get(uid);
+        if (!found)
+            return null;
+
+        return found;
+    }
+
+    //! One walk of the population, keyed by uid. The only place the scan still happens.
+    private static void RebuildLocalIndex(int count, int now)
+    {
+        if (!s_LocalByUid)
+            s_LocalByUid = new map<string, PlayerBase>();
+        else
+            s_LocalByUid.Clear();
+
+        s_LocalByUidMs = now;
+        s_LocalByUidCount = count;
+
         for (int i = 0; i < count; i++)
         {
             PlayerBase candidate = PlayerBase.Cast(ClientData.m_PlayerBaseList.Get(i));
@@ -570,13 +618,19 @@ class VigridPartyAPI
                 continue;
             if (!candidate.GetIdentity())
                 continue;
-            if (candidate.GetIdentity().GetPlainId() != uid)
+
+            //--- Read out before the call that consumes it, per the container-aliasing rule.
+            string candidate_uid = candidate.GetIdentity().GetPlainId();
+
+            //--- FIRST WINS, because the linear scan this replaces returned on its first match.
+            //--- Two entities sharing a uid is not something we expect - but a corpse is never
+            //--- deleted by this mod and stays in the population list, so it is not obviously
+            //--- impossible either, and "same answer as before" is worth one Contains() per entry.
+            if (s_LocalByUid.Contains(candidate_uid))
                 continue;
 
-            return candidate;
+            s_LocalByUid.Set(candidate_uid, candidate);
         }
-
-        return null;
     }
 
     /**

--- a/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleSpectatorTags.c
+++ b/Scripts/Client/5_Mission/BattleRoyale/Client/BattleRoyaleSpectatorTags.c
@@ -193,7 +193,12 @@ class BattleRoyaleSpectatorTags
 
         string uid = br_rpc.admin_uids.Get(slot);
 
-        vector body_pos = ResolveBodyPos(br_rpc, slot, uid, can_lerp, lerp_t);
+        //--- Resolved ONCE and handed to both users of it. This used to be looked up twice per tag
+        //--- per frame - once for the body position and once for the head bone - and each lookup was
+        //--- a full scan of the local population. Same shape VigridPartyNametags already uses.
+        PlayerBase entity = FindLocalPlayer(uid);
+
+        vector body_pos = ResolveBodyPos(br_rpc, slot, entity, can_lerp, lerp_t);
         if (body_pos == vector.Zero)
         {
             tag.Show(false);
@@ -206,7 +211,7 @@ class BattleRoyaleSpectatorTags
         //--- from it changes when the camera turns and nobody has moved.
         float distance = vector.Distance(self_pos, body_pos);
 
-        vector screen_pos = GetGame().GetScreenPosRelative(ResolveAnchorPos(uid, body_pos));
+        vector screen_pos = GetGame().GetScreenPosRelative(ResolveAnchorPos(entity, body_pos));
         bool on_screen = IsOnScreen(screen_pos);
 
         //--- Shown before being measured: a widget that has never been displayed reports zero size,
@@ -303,10 +308,13 @@ class BattleRoyaleSpectatorTags
      *  2 Hz. Outside the network bubble there is no entity at all - which for a flying admin is most
      *  of the map - and the interpolated push is all there is. Same two-source shape as
      *  VigridPartyAPI.ResolveBodyPos, for the same reason.
+     *
+     *  `entity` is passed in rather than resolved here, so one lookup serves this and the anchor.
+     *  NULL is the normal case, not an error - it means "outside the bubble", which is the branch
+     *  the server push exists for.
      */
-    protected vector ResolveBodyPos(BattleRoyaleRPC br_rpc, int slot, string uid, bool can_lerp, float lerp_t)
+    protected vector ResolveBodyPos(BattleRoyaleRPC br_rpc, int slot, PlayerBase entity, bool can_lerp, float lerp_t)
     {
-        PlayerBase entity = FindLocalPlayer(uid);
         if (entity)
             return entity.GetPosition();
 
@@ -323,9 +331,8 @@ class BattleRoyaleSpectatorTags
     }
 
     //! Head height when the entity is present, an estimate when it is not.
-    protected vector ResolveAnchorPos(string uid, vector body_pos)
+    protected vector ResolveAnchorPos(PlayerBase entity, vector body_pos)
     {
-        PlayerBase entity = FindLocalPlayer(uid);
         if (entity)
         {
             //--- GetBoneIndexByName, not GetBoneIndex - the latter resolves a proxy SELECTION, which
@@ -338,7 +345,23 @@ class BattleRoyaleSpectatorTags
         return body_pos + Vector(0, BR_SPECTATE_TAG_HEIGHT_OFFSET, 0);
     }
 
-    //! The entity for a uid inside the local network bubble, or NULL. NULL is normal, not an error.
+    /**
+     *  The entity for a uid inside the local network bubble, or NULL. NULL is normal, not an error.
+     *
+     *  MEMOIZED PER FRAME, for the same reason as VigridPartyAPI.FindLocalPlayer - and this is the
+     *  heavier of the two, because admin_uids is the whole LIVING ROSTER rather than one party. A
+     *  full scan per tag meant O(roster x population) per frame with a string materialised from
+     *  GetPlainId() for every candidate rejected; at a 60-player count that is both figures at their
+     *  maximum at once. The index makes it one walk per frame plus a hash lookup per tag.
+     *
+     *  Reimplemented here rather than calling Party's, per the rule at the top of this file: neither
+     *  addon may depend on the other. Invalidation is the millisecond plus the population count, and
+     *  entries are null-checked on the way out - see the Party copy for why both.
+     */
+    protected ref map<string, PlayerBase> m_LocalByUid;
+    protected int m_LocalByUidMs = -1;
+    protected int m_LocalByUidCount = -1;
+
     protected PlayerBase FindLocalPlayer(string uid)
     {
         if (uid == "")
@@ -347,6 +370,29 @@ class BattleRoyaleSpectatorTags
             return NULL;
 
         int count = ClientData.m_PlayerBaseList.Count();
+        int now = GetGame().GetTime();
+
+        if (now != m_LocalByUidMs || count != m_LocalByUidCount || !m_LocalByUid)
+            RebuildLocalIndex(count, now);
+
+        PlayerBase found = m_LocalByUid.Get(uid);
+        if (!found)
+            return NULL;
+
+        return found;
+    }
+
+    //! One walk of the population, keyed by uid. The only place the scan still happens.
+    protected void RebuildLocalIndex(int count, int now)
+    {
+        if (!m_LocalByUid)
+            m_LocalByUid = new map<string, PlayerBase>();
+        else
+            m_LocalByUid.Clear();
+
+        m_LocalByUidMs = now;
+        m_LocalByUidCount = count;
+
         for (int i = 0; i < count; i++)
         {
             PlayerBase candidate = PlayerBase.Cast(ClientData.m_PlayerBaseList.Get(i));
@@ -354,13 +400,18 @@ class BattleRoyaleSpectatorTags
                 continue;
             if (!candidate.GetIdentity())
                 continue;
-            if (candidate.GetIdentity().GetPlainId() != uid)
+
+            //--- Read out before the call that consumes it, per the container-aliasing rule.
+            string candidate_uid = candidate.GetIdentity().GetPlainId();
+
+            //--- FIRST WINS, matching the linear scan this replaces, which returned on its first
+            //--- match. Corpses are never deleted by this mod and stay in the population list, so a
+            //--- uid appearing twice is not obviously impossible - see the Party copy.
+            if (m_LocalByUid.Contains(candidate_uid))
                 continue;
 
-            return candidate;
+            m_LocalByUid.Set(candidate_uid, candidate);
         }
-
-        return NULL;
     }
 
     //--------------------------------------------------------------------------------------------


### PR DESCRIPTION
## The problem

`FindLocalPlayer` was a **linear scan of the whole local population**, and every caller asks it once *per player it draws*. Per candidate it rejects it does a `PlayerBase.Cast`, two `GetIdentity()` proto calls, and a `GetPlainId()` — which materialises a fresh string.

Four of those callers are per-frame or near-per-frame renderers:

| Caller | Rate | Calls per pass |
|---|---|---|
| `VigridPartyNametags` | every frame | per party member |
| `VigridMapCompass.CollectCarets` | every frame | per party member |
| `VigridMapMinimap` / `VigridMapMenu` | 10 Hz | per party member |
| `BattleRoyaleSpectatorTags` | every frame | **twice** per living player |

So the cost was O(members × population) per frame, and it peaks exactly where the population is densest — the lobby, where everyone stands in one clearing and so everyone is inside everyone else's bubble.

A 4-player party at 60 players ran ~360 iterations and ~360 string allocations per frame. The admin spectator overlay, whose roster is *every living player*, ran 2 × 60 × 60 = **7,200 per frame**.

## The change

Both copies of the scan now build a **uid → entity index once per frame** and answer each lookup from it — one walk plus a hash lookup per call, instead of a walk per call.

- **Built lazily**, so a solo player with no roster to draw pays nothing at all.
- **Invalidated on the millisecond *and* the population count.** The clock alone is enough at any real frame rate (60 fps is 16 ms apart), but an entity entering or leaving the bubble within the same millisecond would otherwise be missed for that frame, and the count is one integer compare.
- **First-wins on a duplicate uid**, matching the scan it replaces, which returned on its first match. Corpses are never deleted by this mod and stay in the population list, so a repeated uid is not obviously impossible — "same answer as before" is worth one `Contains()` per entry.
- Entries are still **null-checked on the way out**: an entity deleted after the index was built reads as null through its reference, exactly as it did mid-walk before.

`BattleRoyaleSpectatorTags` additionally resolved the entity **twice per tag** — once for the body position, once for the head bone. It now resolves once and hands it to both, which is the shape `VigridPartyNametags` already used.

The two copies stay separate on purpose: `Party/` and the BR mod must not depend on each other.

## Behaviour

Unchanged in every case — same answer, same NULL-means-outside-the-bubble contract, same null-check on a deleted entity.

## Verification

**Static** — 12/12 repo checks pass, including `discipline` (Party still names no `BattleRoyale` symbol) and `enfusion` (syntax constraints).

**API idioms checked against vanilla, not assumed** — `map<string,EntityAI>` is used at `componentenergymanager.c:71`; `Get`/`Contains`/`Clear` are declared at `P:\scripts\1_Core\proto\enscript.c:827-898`, with `Get` documented as returning NULL for a missing key, which the null-check relies on.

**Build** — `Successfully packaged all mods`. Artifact verified rather than the diff: `party.pbo` and `scripts_client.pbo` both carry the new symbols, and the old scan line `GetPlainId() != uid` is gone from `party.pbo`.

**Compile / load (`LaunchOffline.bat`)** — zero compile errors; `MissionGameplay::MissionGameplay` present and `IdleMode` count 0, so it loaded properly rather than freezing; both owning classes constructed.

**Live party (`LaunchLocalMP.bat 3`)** — this is what offline could not reach, since with no roster `FindLocalPlayer` is never called at all:

- Server created party `p1-15709`; client received `VP_Roster v2 members=2` → `v3 members=3` → `v4 members=2`.
- Non-zero rosters mean the memoized lookup ran **every frame**, and the roster changing size also exercised the **cache-invalidation** path.
- Confirmed by eye: **nametags track their teammate correctly and compass carets point the right way** — i.e. the index returns the *right* entity per uid. The failure mode of this change was a tag landing on the wrong player, and it does not.
- Error sweep across server + 3 clients: clean. The two `error_*.log` files produced are pre-existing DayZ-Expansion connect-race noise (`ExpansionSettings::WarnNotLoaded`, every stack frame inside `DayZExpansion/`), stamped 95 s before the party existed.

## Not included

The server has the same idiom in `VigridPartyManager.GetPlayerByUid`, called twice per member per party on every `PushTeamState`, allocating a fresh `array<Man>` each time. It is a timer rather than a frame loop, so it is meaningfully smaller, and it is being handled separately rather than widened into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
