### PR TITLE
Draw the self heading dart in yellow on both maps

### DIFF
--- a/Extra/Map/Scripts/3_Game/VigridMapConstants.c
+++ b/Extra/Map/Scripts/3_Game/VigridMapConstants.c
@@ -215,11 +215,17 @@ static const float VIGRID_MAP_PING_LINE_WIDTH = 2.0;
 //--- map gets opened for). Raised to 16 for two reasons: a dart needs more pixels than a plus before
 //--- its direction is readable, and "you" should stay the easiest glyph to find on a big map, which
 //--- was the plus's one real virtue. 16 also keeps it clear of VIGRID_MAP_TEAM_PX (14), now the
-//--- closest silhouette on the map - colour separates them independently, since VIGRID_MAP_COLOR_SELF
-//--- is white and VigridPartyPalette contains no white.
+//--- closest silhouette on the map.
+//---
+//--- The dart is PURE yellow, and that matters: it was white until 2026-08-15, chosen then because
+//--- VigridPartyPalette contains no white and so colour separated you from a teammate on its own.
+//--- Yellow gives that up - the nearest palette entry is slot 0's amber (242,199,68), which is only
+//--- distinguishable because it is desaturated and darker. Separation is now carried mainly by
+//--- silhouette (a notched dart against a triangle) and size (16 against 14). Moving a palette entry
+//--- towards pure yellow would erode what is left of it.
 static const float VIGRID_MAP_SELF_PX = 16.0;
 static const float VIGRID_MAP_SELF_LINE_WIDTH = 2.0;
-static const int VIGRID_MAP_COLOR_SELF = 0xFFFFFFFF;
+static const int VIGRID_MAP_COLOR_SELF = 0xFFFFFF00;
 
 //--- Copy of VIGRID_PARTY_PING_BASE_ALPHA, so a ping reads at the same weight on the map as it does
 //--- in the world.


### PR DESCRIPTION
The local player's heading dart was white on the fullscreen map and the minimap. It is now pure yellow (`0xFFFFFF00`).

Both surfaces read the same constant, `VIGRID_MAP_COLOR_SELF`, so this is one value in `Extra/Map/Scripts/3_Game/VigridMapConstants.c` — the two call sites (`VigridMapMenu.RenderSelfGlyph`, `VigridMapMinimap`) needed no change. The compass strip has no self glyph and is unaffected.

### The comment above it was rewritten, not left alone

White had a documented justification: `VigridPartyPalette` contains no white, so colour separated "you" from a teammate independently of shape. Yellow gives that up — the nearest palette entry is slot 0's amber (242,199,68), distinguishable only because it is desaturated and darker. Separation is now carried mainly by silhouette (a notched dart against a triangle) and size (16 px against `VIGRID_MAP_TEAM_PX` 14).

The comment now says that, and records that moving a palette entry towards pure yellow would erode what is left. A stale justification sitting under a changed value has outlived its correction in this repo before.

### Verification

Built, then confirmed **in the artifact rather than the diff**: `Extra_Map.pbo` contains `0xFFFFFF00` exactly once and carries the new comment text, proving the build packed the worktree sources through the `P:` junction.

Offline (`LaunchOffline.bat`) loaded clean — `VigridMapClient created`, `MissionGameplay::OnInit done`, no compile errors in the client `script_*.log`. Myst confirmed both darts read yellow on screen.

### Note for a follow-up, not fixed here

`CLAUDE.md` states that `Build.success` lands in whichever tree the `P:` junction points at, and calls it "the proof of whose build it was". This run showed it landing in the **primary checkout** instead; the worktree has no `Workbench/Logs` folder at all. The PBO grep is what actually proved provenance. Left untouched so this PR stays one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
