### PR TITLE
Stop the leaderboard zeroing every input lock, and pin auto_delete off

### DIFF
--- a/Party/Scripts/5_Mission/Client/VigridPartyMenu.c
+++ b/Party/Scripts/5_Mission/Client/VigridPartyMenu.c
@@ -108,7 +108,12 @@ class VigridPartyMenu extends UIScriptedMenu
     {
         super.OnHide();
 
-        GetGame().GetInput().ResetGameFocus();
+        //--- ChangeGameFocus(-1), not ResetGameFocus(): the reset SETS the shared additive input
+        //--- focus counter to zero across all devices (vanilla input.c:22-27), which releases every
+        //--- other holder's acquire and not just ours. Latent here - this menu only opens when no
+        //--- other menu is up - but it is the same shape that was live elsewhere, and the pair is
+        //--- balanced against the ChangeGameFocus(1) in OnShow either way.
+        GetGame().GetInput().ChangeGameFocus(-1);
         GetGame().GetUIManager().ShowUICursor(false);
     }
 

--- a/Scripts/Client/5_Mission/GUI/DeathScreenMenu.c
+++ b/Scripts/Client/5_Mission/GUI/DeathScreenMenu.c
@@ -16,10 +16,15 @@
  *                                                                     ------------------------
  *                                                                     net 0
  *
- *  So this class must add NO focus calls of its own - super handles its own half exactly. Note the
- *  mod's LeaderboardMenu does add ChangeGameFocus(1) / ResetGameFocus() on top of super; do not copy
- *  that here. ResetGameFocus zeroes the counter rather than decrementing it, which would eat the
- *  acquire that SimulateDeath still owns.
+ *  So this class must add NO focus calls of its own - super handles its own half exactly.
+ *
+ *  ResetGameFocus() is the specific thing never to reach for: it SETS the counter to zero across
+ *  every device rather than decrementing it, so it releases every other holder's acquire and not
+ *  just the caller's. LeaderboardMenu used to call it and that was reachable from this screen -
+ *  F4 over the death screen, twice, zeroed the counter while this menu was still up, and the
+ *  Spectate button then drove it negative. All three menus that pair with ChangeGameFocus(1) now
+ *  release with ChangeGameFocus(-1); VigridMapMenu takes the stricter line this class does and adds
+ *  no focus call at all.
  */
 class DeathScreenMenu extends UIScriptedMenu
 {

--- a/Scripts/Client/5_Mission/GUI/LeaderboardMenu.c
+++ b/Scripts/Client/5_Mission/GUI/LeaderboardMenu.c
@@ -143,8 +143,21 @@ class LeaderboardMenu extends UIScriptedMenu
     {
         super.OnHide();
 
-        //--- Both of these are mandatory. Skipping ResetGameFocus leaves the player unable to move.
-        GetGame().GetInput().ResetGameFocus();
+        //--- ChangeGameFocus(-1), NEVER ResetGameFocus(). Input focus is an ADDITIVE counter that
+        //--- every holder shares, and ResetGameFocus SETS IT TO ZERO across all devices
+        //--- (input.c:22-27) - so it does not release our acquire, it releases EVERYONE'S.
+        //---
+        //--- That was reachable in three keypresses: die (SimulateDeath +1, death screen +1), press
+        //--- F4 twice, and the reset dropped the counter to 0 with the death screen still up; the
+        //--- Spectate button then ran EnterSpectate's three releases and drove it NEGATIVE, which
+        //--- breaks input with no error and nothing on screen.
+        //---
+        //--- This pairs with the ChangeGameFocus(1) in OnShow, so the menu still runs one level
+        //--- above super's own LockControls acquire exactly as before - only the global zeroing is
+        //--- gone. (DeathScreenMenu takes the stricter line and adds no focus calls at all, letting
+        //--- super handle both halves; that is the tidier shape but a larger behavioural change
+        //--- than this fix needs to be.)
+        GetGame().GetInput().ChangeGameFocus(-1);
         GetGame().GetUIManager().ShowUICursor(false);
     }
 

--- a/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
+++ b/Scripts/Client/5_Mission/GUI/SpawnSelectionMenu.c
@@ -105,7 +105,12 @@ class SpawnSelectionMenu extends UIScriptedMenu
 		super.OnHide();
 
 		PPEffects.SetBlurMenu(0);
-		GetGame().GetInput().ResetGameFocus();
+		//--- ChangeGameFocus(-1), not ResetGameFocus(): the reset SETS the shared additive counter
+		//--- to zero on every device (input.c:22-27), releasing every other holder's acquire rather
+		//--- than our own. Latent here rather than live - spawn selection runs with no other menu
+		//--- up - but it is the same defect that was reachable through the leaderboard, and one
+		//--- copy left behind is how it comes back.
+		GetGame().GetInput().ChangeGameFocus(-1);
 	}
 
 	override Widget Init()

--- a/Scripts/Client/5_Mission/Mission/MissionGameplay.c
+++ b/Scripts/Client/5_Mission/Mission/MissionGameplay.c
@@ -200,11 +200,21 @@ modded class MissionGameplay
 			}
 			//--- Toggle, so the same key closes the board again. Answerable in any state, though it
 			//--- is mostly a lobby feature.
+			//---
+			//--- OPENING is gated on nothing else being open, and the parent is NULL - the same two
+			//--- rules VigridPartyMenu and VigridMapMenu already follow. Without the gate F4 stacked
+			//--- the board over the death screen, the map, the inventory and the Esc menu; passing
+			//--- GetMenu() as the parent then made whatever was underneath the board's parent and
+			//--- handed focus back to it on close. The gate is deliberately "any menu at all" rather
+			//--- than a list of ids, because a list is what drifted last time.
+			//---
+			//--- Closing is NOT gated: while the board is open GetMenu() returns it, so testing the
+			//--- gate first would make the key one-way.
 			if (GetUApi().GetInputByID(UADayZBRLeaderboard).LocalPress()) {
 				if (m_UIManager.IsMenuOpen(MENU_BR_LEADERBOARD)) {
 					m_UIManager.CloseMenu(MENU_BR_LEADERBOARD);
-				} else {
-					GetUIManager().EnterScriptedMenu(MENU_BR_LEADERBOARD, GetUIManager().GetMenu());
+				} else if (!m_UIManager.GetMenu()) {
+					GetUIManager().EnterScriptedMenu(MENU_BR_LEADERBOARD, NULL);
 				}
 			}
 		}

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/6_BattleRoyaleRound.c
@@ -320,7 +320,15 @@ class BattleRoyaleRound: BattleRoyaleState
                 	MessagePlayerUntranslated(player, "STR_BR_TAKING_DAMAGE");
 				    player.GetSymptomManager().QueueUpPrimarySymptom(SymptomIDs.SYMPTOM_PAIN_LIGHT);
                     //TODO: determine if this last health tick will kill the player
-                    player.DecreaseHealthCoef( f_Damage ); //TODO: delta this by the # of zones that have ticked (more zones = more damage)
+                    //--- auto_delete FALSE, explicitly, and never omitted. Vanilla's default is
+                    //--- `true`, which at health <= 0 queues ObjectDelete(player) - that would
+                    //--- destroy the corpse, which IS the victim's loot and is what the spectate,
+                    //--- kill-attribution and match-summary paths all read on the way out.
+                    //--- It does not fire today only because DecreaseHealthCoef accepts the flag
+                    //--- and never forwards it (object.c:1116 calls the 3-arg DecreaseHealth
+                    //--- overload, not the 4-arg one that honours it). That is a bug upstream, so
+                    //--- the safety is theirs to remove; say what we need instead of relying on it.
+                    player.DecreaseHealthCoef( f_Damage, false ); //TODO: delta this by the # of zones that have ticked (more zones = more damage)
                     //--- Same reason as the kill feed hint below, but BR-owned: the death recap has
                     //--- to name the zone on a server where Extra/KillFeed/ is not built at all.
                     //--- Consumed by BattleRoyaleKillAttribution.ConsumeZoneHint.

--- a/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
+++ b/Scripts/Server/5_Mission/BattleRoyale/Server/States/7_BattleRoyaleLastRound.c
@@ -202,7 +202,10 @@ class BattleRoyaleLastRound: BattleRoyaleState
                 //DAMAGE
                 MessagePlayerUntranslated(player, "STR_BR_TAKING_DAMAGE");
                 player.GetSymptomManager().QueueUpPrimarySymptom(SymptomIDs.SYMPTOM_PAIN_HEAVY);
-                player.DecreaseHealthCoef( f_Damage );
+                //--- auto_delete FALSE - see the identical call in 6_BattleRoyaleRound for why the
+                //--- vanilla default (true) would delete the corpse, and why the fact that it
+                //--- currently does not is an upstream bug rather than a guarantee.
+                player.DecreaseHealthCoef( f_Damage, false );
                 //--- Same reason as the kill feed hint below, but BR-owned: the death recap has to
                 //--- name the zone on a server where Extra/KillFeed/ is not built at all.
                 //--- Consumed by BattleRoyaleKillAttribution.ConsumeZoneHint.


### PR DESCRIPTION
Two defects found by sweeping every vanilla call for an optional parameter left at a default that means something the caller did not intend — the same question that turned up the COT and CF findings earlier.

## `ResetGameFocus()` released *everyone's* input lock

Input focus is an additive counter shared by every holder. `ResetGameFocus()` **sets it to zero across all devices** (`P:\scripts\3_Game\tools\input.c:22-27`) rather than decrementing, so it released every other holder's acquire and not just the caller's.

Reachable in three keypresses:

| step | counter |
|---|---|
| die — `SimulateDeath` +1, death screen +1 | 2 |
| press **F4** — leaderboard `OnShow` (+1 super, +1 explicit) | 4 |
| press **F4** — `OnHide` −1, then `ResetGameFocus()` | **0** ← death screen still up |
| press **Spectate** — `EnterSpectate`'s three releases | **−1 per device** |

A negative counter breaks input with no error, no log line and nothing on screen.

All three menus that paired `ChangeGameFocus(1)` with `ResetGameFocus()` now release with `ChangeGameFocus(-1)`. `LeaderboardMenu` was the live one; `SpawnSelectionMenu` and `VigridPartyMenu` carried the same shape latently. `VigridMapMenu` had already avoided it and is unchanged.

F4 also gains the guard the party and map menus already have: it opens only when no other menu is up, and passes `NULL` as the parent instead of `GetMenu()`, which had made whatever was underneath the board's parent. The **close** branch is deliberately left ungated, or the key becomes one-way.

> The minimal fix was taken over the tidier one. Dropping the redundant `ChangeGameFocus(1)` entirely — what `DeathScreenMenu` and `VigridMapMenu` do — is the better end state, but it changes the menu's focus level *while open*. Swapping only the release keeps the observable state identical, which is what made it safely testable.

## `auto_delete` pinned off on the zone damage

Both zone-damage sites now pass `auto_delete = false` explicitly. Vanilla's default is `true`, which at `health <= 0` queues `ObjectDelete` on the player — destroying the corpse that *is* the victim's loot and that spectate, kill attribution and the match summary all read on the way out.

**This is a no-op today and is meant to be.** `DecreaseHealthCoef` is declared exactly once in all of `P:\scripts`, is overridden nowhere, and its body drops the flag (`object.c:1116` calls the 3-arg `DecreaseHealth` overload, not the 4-arg one that honours it). That is an upstream bug, so the safety is theirs to remove — state the requirement instead of relying on it.

## Verification

- `Tools/check.py` — 13 checks, no errors.
- Built and checked **on the artifact**: `scripts_client.pbo` carries the new release and the F4 gate and contains no `ResetGameFocus()` call; `scripts_server.pbo` carries `DecreaseHealthCoef( f_Damage, false )`.
- Dedicated server booted to `BattleRoyaleState::Activate: Debug Zone State`, no VM exception (the one log warning is third-party `ReduceCarDamage`).
- Both clients compiled with zero errors across 4,305 / 7,386 script-log lines.
- **Play-tested with two connected clients:** F4 opens and closes the leaderboard normally with movement intact afterwards, and the death screen now ignores F4 entirely. The first is the regression that mattered — the old comment claimed the reset was mandatory *"or the player is unable to move"*, which was an artefact of the +2/−1 imbalance, not a real requirement.
- Not separately exercised, low risk: the party-menu and spawn-selection paths took the identical one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)