### PR TITLE
Add Extra/EarPlugs, a client-side ear plugs addon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Build result: `Workbench/Logs/Build.log`, plus marker files `Build.success` / `B
 | `_LaunchServer.bat <SteamID>` | Clear logs + storage, then start the dedicated server. |
 | `SetupLaunch.bat <MP\|SP>` | Preamble for every `Launch*.bat`: config, validation, mod list, kill running game. Deliberately no `setlocal` — it exports into the caller. |
 
-Each `config.cpp` with no ancestor `config.cpp` becomes one PBO — currently 8 mod PBOs (`Data`, `GUI`, `LanguageCore`, `Models_Shapes`, `Sounds`, `Scripts_Client`, `Scripts_Server`, `Party`) plus 15 `extra_*`. Renaming a top-level folder renames its PBO. PBO names are lowercased by the build, so `Extra/KillFeed` packs as `extra_killfeed.pbo`.
+Each `config.cpp` with no ancestor `config.cpp` becomes one PBO — currently 8 mod PBOs (`Data`, `GUI`, `LanguageCore`, `Models_Shapes`, `Sounds`, `Scripts_Client`, `Scripts_Server`, `Party`) plus 16 `extra_*`. Renaming a top-level folder renames its PBO. PBO names are lowercased by the build, so `Extra/KillFeed` packs as `extra_killfeed.pbo`.
 
 ## Testing
 
@@ -892,6 +892,8 @@ Layouts live in `GUI/layouts/`. The dominant pattern is imperative — `GetGame(
 
 Keybinds are declared in `Data/Inputs.xml` (`UADayZBRReadyUp` = F1, `UADayZBRUnstuck` = F2, `UADayZBRLeaderboard` = F4, plus the admin-spectate set `UADayZBRAdminSpectate` = F3, `UADayZBRSpectateMode` = F5, `UADayZBRSpectateNext`/`Prev` = →/←, `UADayZBRSpectateSkeleton` = F6), registered via `inputs = "Vigrid-BattleRoyale/Data/Inputs.xml"` in `Scripts/Client/config.cpp`. The admin keys are refused server-side for anyone outside `admins_steamid64`, so the client-side check on them is presentation only — **except F6, which has no server half at all** and is gated by COT's own `ESP.View` permission instead (see *Spectating → Admin spectate*).
 
+**Four `inputs=` declarations now ship**, which is supported — @DayZ-Expansion ships three. The full key map across them, so a fifth does not collide: **F1–F6** and **←/→** (Battle Royale, `Data/Inputs.xml`), **P/T/Y** (Party), **M/N/K** (Map), **J** (EarPlugs). Check Community-Online-Tools' own `Inputs.xml` before claiming another letter — that is what collided with Party's `Y`.
+
 #### Lobby name tags
 
 Every living non-teammate wears their name over their head while the players are still gathered
@@ -1293,6 +1295,27 @@ Note `alphaFadeStartScale`/`alphaFadeEndScale` are `2` (satellite at every zoom)
 
 The choice is purely a look, and the two layers are interchangeable as far as the addon is concerned: every overlay is a `CanvasWidget` child drawing in screen space over whatever the `MapWidget` renders, so none of the map work depends on which layer is underneath.
 
+### Ear plugs (`Extra/EarPlugs/`)
+
+`J` cycles the local client through Off → Light → Heavy. Builds into `extra_earplugs.pbo`, defines `VIGRID_EARPLUGS`, stages `3_Game` + `5_Mission`, every file `#ifndef SERVER`. **It is the one `Extra/` addon with no API at all** — nothing in the host mod calls it, so the discipline rule costs it only its own logger, constants, `stringtable.csv` and `Data/Inputs.xml`. Per-player level in `$profile:Vigrid-EarPlugs\earplugs_client.json`.
+
+**The idea is DaemonForge's `DayZ-EarPlugs`, which is GPLv3, and none of their code or art is here.** GPLv3 §7 forbids adding DSPL-SA's non-commercial / DayZ-only restrictions to a combined work — the same reasoning that blocked porting COT's `JMESPSkeleton`. That is why the indicator is a text badge rather than their `volume_*.edds`, and why the architecture below shares nothing with theirs.
+
+Two independent halves, either removable without the other:
+
+- **Volume** — `AbstractSoundScene.SetSoundVolume` / `SetRadioVolume`, scaled to a *fraction of the player's own setting* (×0.40 / ×0.12). Music, VOIP and SpeechEx are deliberately untouched: **this mod ships parties, so a player who plugs their ears must still hear their squad.**
+- **Muffle** — `Man.SetMasterAttenuation` (`P:\scripts\3_game\entities\man.c:41`) with two new classes under `CfgSoundEffects >> AttenuationsEffects` in the addon's `config.cpp`, modelled on vanilla's `BurlapSackAttenuation`. Both zero the `Echo` block, unlike every vanilla preset — those all model something wrapped round your head and therefore reverberate; earplugs only take the top off. ⚠️ It is a *master* filter, so it may reach VOIP regardless of the bus table; that is the one open question, and dropping it leaves the volume half intact.
+
+⚠️ **THE BASELINE IS MEASURED, NOT READ, AND THIS IS THE PART THAT LOOKS WRONG UNTIL YOU CHECK.** The obvious source is `g_Game.m_volume_sound`, and it is stale: those five fields are written in exactly one place, `DayZGame.DeferredInit` (`dayzgame.c:1130-1134`), and never again — so any Options change invalidates them, and **vanilla inherits its own bug**, since `MissionGameplay.OnPlayerRespawned` restores from them. Instead, *while the level is Off, whatever the engine reports is the baseline*, refreshed on the 4 Hz tick behind alive-and-above-zero guards (both of vanilla's zeroing paths would otherwise latch a baseline of 0 and leave the player permanently silent).
+
+⚠️ **THE TOGGLE WRITES, THE RECONCILER ONLY EVER LOWERS.** Vanilla moves these buses constantly — zeroes all five on death (`dayzplayerimplement.c:861`), zeroes sound on uncon start (`playerbase.c:3534`), restores from `m_volume_*` on uncon stop (`playerbase.c:3581`) and on unpause/respawn (`missiongameplay.c:1626`) — and **`BattleRoyaleClient.EnterSpectate` restores all five too**, which would blast a player who died with earplugs in. One rule covers every case: restored-to-baseline reads as `current > desired` and is re-lowered; a vanilla mute reads as `current < desired` and is left alone; Off is a no-op. The single path allowed to *raise* is the keypress. Corrections use `time = 0`, since a fade would read as above-target for its whole duration and re-fire each tick; the toggle's own fade is protected by a `VIGRID_EARPLUGS_FADE_MS` settle window.
+
+**The attenuation slot is global, single-valued and shared** with vanilla's uncon / burlap / flashbang / deafness. So: write only when it is empty or already ours, clear only when it is ours (clearing blindly un-muffles an unconscious player), and re-apply on the tick once it returns to `""`. Flashbang re-asserts behind a defer timer and wins; nothing flaps, because both sides only write when the slot is theirs or empty.
+
+**The badge is persistent by design** — full alpha for 2 s after a change, then eased to an idle alpha it never drops below. A fading-out indicator is the reference implementation's actual bug: a player who forgets is permanently half-deaf with no cue. A change *to* Off gets the inverse — flash "OUT", then hide.
+
+At trace level every reconciler decision logs its own reason (`corrected`, `already-at-target`, `below-target-leaving-alone`, `yielded-to:<name>`, `settling`) **but only when the reason changes** — unconditional logging at 4 Hz buries the one line that mattered.
+
 ### Vigrid API / webhooks
 
 `Scripts/Server/3_Game/BattleRoyale/Webhook/` — REST via `GetRestApi().GetRestContext(BATTLEROYALE_API_ENDPOINT)`. Every call site is gated on `BattleRoyaleConfig.GetConfig().GetServerData().enable_vigrid_api`; `use_autolock` is a separate, independent gate that is *not* covered by it. Each webhook pairs with a `RestCallback` subclass that retries from `i_TryLeft`.
@@ -1316,7 +1339,7 @@ Note the imageset's internal name is `battleroyale_gui`, not the filename `dayzb
 
 ## Notes
 
-- `Extra/` holds 16 independent single-purpose sub-addons, each its own PBO. 15 are built; `Extra/DisableFogChernarusPlus/` is parked as `config.cpp.disabled` and produces no PBO. Most are small script tweaks; the exceptions are `Extra/KillFeed/`, `Extra/SafeZone/` and `Extra/Map/`, self-contained addons documented under *Architecture → Kill feed*, *→ Safe zone / lobby truce* and *→ Map*. Each folder carries its own `README.md`, indexed by `Extra/README.md`.
+- `Extra/` holds 18 independent single-purpose sub-addons, each its own PBO. 16 are built; `Extra/DisableFogChernarusPlus/` and `Extra/DumpItemHeights/` are parked as `config.cpp.disabled` and produce no PBO. (This line said **16 folders** for a while where `Extra/README.md` said 17 — the two are reconciled here, and both need updating together.) Most are small script tweaks; the exceptions are `Extra/KillFeed/`, `Extra/SafeZone/`, `Extra/Map/` and `Extra/EarPlugs/`, self-contained addons documented under *Architecture → Kill feed*, *→ Safe zone / lobby truce*, *→ Map* and *→ Ear plugs*. Each folder carries its own `README.md`, indexed by `Extra/README.md`.
 - **An incremental `Deploy.bat` does not always delete the PBO of an addon you just disabled.** It cleans orphans only sometimes, so a `config.cpp` → `.disabled` rename can leave the previous PBO in `%ModBuildDirectory%` and the addon still loads — which silently invalidates a discipline negative-build. Check the output folder and delete the `.pbo` plus its `.bisign` by hand. **The same applies to `CopyExtraPBOs`**: turning it off does not remove the third-party PBOs a previous build already copied there.
 - **`Tools/edds.py` reads and rewrites the Enfusion `.edds` texture container**, whose format is documented in that file's header (decoded from scratch; two traps — the chunk table runs *smallest mip first*, and the LZ4 blocks inside a chunk are *linked*). `selftest` is its acceptance gate and is the thing to run first. It is what took the twelve loading screens from 120 MB of uncompressed BGRA8 to 15.4 MB of DXT1.
 - `Extra/RandomMenuGear/` re-dresses the main-menu intro character in a random outfit plus a slung rifle and a melee weapon, re-rolled on every menu show. It hooks vanilla `IntroSceneCharacter.CreateNewCharacterById` (creation, prev/next arrows) and `MainMenu.OnShow` (returning from a submenu — that path calls `OnChangeCharacter(false)` and never recreates the character). It is **not** a fix for the broken character save that makes the menu character render naked; it only decorates the spawned object. Gear is applied with `GameInventory.CreateAttachmentEx` and deliberately never written into `MenuDefaultCharacterData` — that map is serialized to the server on connect and saved locally, so writing to it would leak menu gear into the real spawn loadout. Same discipline rule as `Party/` and `Extra/KillFeed/`: no `BattleRoyale*` symbol may be referenced.

--- a/Extra/EarPlugs/Data/Inputs.xml
+++ b/Extra/EarPlugs/Data/Inputs.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<!--
+    One action, one key. No <exclude> group, and none is wanted: the toggle is a single press that
+    changes nothing about what the player can do, so there is nothing to suppress. See
+    Extra/Map/Data/Inputs.xml for the long version of why an exclude group is a trap when you DO
+    think you want one.
+
+    J is unbound in vanilla DayZ and free across this mod's other three Inputs.xml files - Battle
+    Royale takes F1-F6 and the arrows, Party takes P/T/Y, Map takes M/N/K. Community-Online-Tools is
+    the one to check if it ever does two things at once; its own Inputs.xml is what collided with
+    Party's Y.
+-->
+<modded_inputs>
+    <inputs>
+        <actions>
+            <!-- loc= takes a BARE stringtable key with no leading '#'. Keys live in this addon's own
+                 stringtable.csv - EarPlugs must not reference a STR_BR_* or STR_MAP_* key. -->
+            <input name="UAVigridEarPlugsToggle" loc="STR_EARPLUGS_KEYBIND_TOGGLE" />
+        </actions>
+
+        <sorting name="vigridearplugs" loc="STR_EARPLUGS_KEYBIND_CATEGORY">
+            <input name="UAVigridEarPlugsToggle" />
+        </sorting>
+    </inputs>
+    <preset>
+        <input name="UAVigridEarPlugsToggle">
+            <btn name="kJ" />
+        </input>
+    </preset>
+</modded_inputs>

--- a/Extra/EarPlugs/GUI/layouts/earplugs.layout
+++ b/Extra/EarPlugs/GUI/layouts/earplugs.layout
@@ -1,0 +1,100 @@
+// The ear plugs badge. Every child is POSITIONED AND SIZED FROM SCRIPT - see VigridEarPlugsHud.
+//
+// The numbers below are Workbench placeholders and nothing more. A widget's DECLARED position and
+// size are scaled by viewport/1920, while SetPos and SetSize take REAL screen pixels; mixing the two
+// shifts a whole group while its internal spacing stays perfectly correct, which reads as anything
+// but a coordinate bug. The rule that falls out is: if script places it, script sizes it too.
+//
+// The root is `size 1 1` with `hexactsize 0`, which is the one container shape this repo has proven:
+// m_Root.GetScreenSize() reports real pixels and children SetPos'd in those pixels land correctly.
+// VigridMapMarkers3D, VigridPartyNametags and VigridMapCompass all rely on exactly this.
+//
+// THREE ALPHA/STYLE TRAPS, all of which fail silently with a clean .rpt:
+//
+//  1. `color` on a PanelWidget TINTS ITS STYLE TEXTURE - it is not a fill. With no `style` line the
+//     panel draws NOTHING at all, colour and all, while still laying out and still hosting its
+//     children. `rover_sim_colorable` is vanilla's flat tintable surface. DayZDefaultPanel is the
+//     wrong one: a bordered 9-slice whose texture swallows the alpha and reads as a solid slab.
+//  2. A widget's colour alpha and its widget alpha are THE SAME VALUE, and every `inheritalpha 1`
+//     child multiplies by its parent's. That is deliberate here: the root is `color 1 1 1 1`, a pure
+//     alpha carrier that renders nothing, so one SetAlpha on it fades the whole badge together.
+//  3. Following from 2, the root must never be given alpha 0 to hide the badge - Show(false) it, or
+//     the next fade-in starts from a widget the engine has already decided not to draw.
+//
+// Contrast comes from the text shadow rather than from the backdrop, because the badge spends most
+// of its life at well under full alpha and a backdrop faded to 0.3 cannot carry a label on its own.
+// `SetOutline` is not the answer on this mod: it pairs with the sdf_* fonts and everything here is
+// bitmap metron.
+FrameWidgetClass EarPlugsRoot {
+ visible 1
+ ignorepointer 1
+ clipchildren 0
+ color 1 1 1 1
+ position 0 0
+ size 1 1
+ hexactpos 0
+ vexactpos 0
+ hexactsize 0
+ vexactsize 0
+ priority 40
+ {
+  PanelWidgetClass EarPlugsBackdrop {
+   visible 1
+   ignorepointer 1
+   inheritalpha 1
+   position 0 0
+   size 190 34
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   color 0 0 0 0.7
+   style rover_sim_colorable
+  }
+  // "EAR PLUGS" - the constant half, left aligned.
+  TextWidgetClass EarPlugsLabel {
+   visible 1
+   ignorepointer 1
+   inheritalpha 1
+   position 0 0
+   size 110 34
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   color 1 1 1 1
+   text "#STR_EARPLUGS_HUD_LABEL"
+   font "gui/fonts/metron-bold14"
+   "shadow size" 3
+   "shadow color" 0 0 0 1
+   "shadow offset" 1 1
+   "size to text h" 0
+   "size to text v" 0
+   "text halign" left
+   "text valign" center
+  }
+  // The level - the half that changes. Right aligned so the two never collide however long the
+  // localized level word turns out to be.
+  TextWidgetClass EarPlugsLevel {
+   visible 1
+   ignorepointer 1
+   inheritalpha 1
+   position 110 0
+   size 70 34
+   hexactpos 1
+   vexactpos 1
+   hexactsize 1
+   vexactsize 1
+   color 1 0.82 0.28 1
+   text "#STR_EARPLUGS_LEVEL_LIGHT"
+   font "gui/fonts/metron-bold22"
+   "shadow size" 3
+   "shadow color" 0 0 0 1
+   "shadow offset" 1 1
+   "size to text h" 0
+   "size to text v" 0
+   "text halign" right
+   "text valign" center
+  }
+ }
+}

--- a/Extra/EarPlugs/README.md
+++ b/Extra/EarPlugs/README.md
@@ -1,0 +1,164 @@
+# Vigrid Ear Plugs
+
+One key cycles the local client through **Off → Light → Heavy**. The effects bus comes down *and* a
+low-pass EQ goes on, so gunfire sounds muffled rather than merely distant. The level survives a
+reconnect, and a badge on screen says the plugs are in.
+
+It hooks nothing but vanilla `MissionGameplay`, so it works on **any** DayZ server — Battle Royale is
+not required.
+
+|                 |                                                                     |
+|-----------------|---------------------------------------------------------------------|
+| **PBO**         | `extra_earplugs.pbo`                                                |
+| **Side**        | client — every `.c` file is `#ifndef SERVER`                        |
+| **Stages**      | `3_Game`, `5_Mission` (no `4_World` — it owns no entity-stage code) |
+| **`defines[]`** | `VIGRID_EARPLUGS` — declared for consistency, unconsumed            |
+| **Requires**    | `DZ_Data`, `DZ_Scripts` (no CF — it uses no RPC)                     |
+| **Standalone**  | yes — no `BattleRoyale*` symbol referenced                           |
+| **Default key** | `J`                                                                  |
+
+It ships **no API**: nothing in the host mod needs to talk to it, so there is no call site to guard
+and no way for a server to reach in. Per-player state lives in
+`$profile:Vigrid-EarPlugs\earplugs_client.json`.
+
+## Credit and licence
+
+The idea comes from **[DaemonForge/DayZ-EarPlugs](https://github.com/DaemonForge/DayZ-EarPlugs)**,
+which is **GPLv3**. This repository is DSPL-SA, which adds non-commercial and DayZ-only restrictions
+that GPLv3 §7 forbids adding to a combined work — so **no code and no asset from that mod is present
+here.** Their four `volume_*.edds` icons in particular are why the indicator is a text badge built
+from widgets rather than an image.
+
+What is shared is the concept — one hotkey cycling muffle levels — which is not copyrightable
+expression, and the vanilla API signatures, which are Bohemia's. Everything else is written against
+declarations under `P:\` and this repo's own addons (`VigridMapPrefs` for the `$profile:` JSON,
+`VigridMapMinimap` for the HUD, `KillFeedMissionGameplay` for the mission hook, `VigridSafeZoneLog`
+for the logger). Same reasoning that blocked porting COT's `JMESPSkeleton` into this repo.
+
+## What it actually changes
+
+Two independent halves, both client-local. Either can be removed without touching the other.
+
+**1. Bus volume, as a fraction of the player's own setting.**
+
+| Bus | Scaled? | Why |
+|---|---|---|
+| `SetSoundVolume` | yes | World effects — the whole point |
+| `SetRadioVolume` | yes | Diegetic world audio; plugged ears do not distinguish |
+| `SetMusicVolume` | no | Non-diegetic, and it has its own Options slider |
+| `SetVOIPVolume` | no | **This mod ships parties.** A player who plugs their ears must still hear their squad, or the feature is a competitive liability rather than a comfort setting |
+| `SetSpeechExVolume` | no | Same reasoning |
+
+Light is ×0.40 and Heavy ×0.12 of whatever the player has set. Never absolute values — see *Design
+notes*.
+
+**2. A real muffle**, via `Man.SetMasterAttenuation` (`P:\scripts\3_game\entities\man.c:41`) and two
+new classes under `CfgSoundEffects >> AttenuationsEffects` in `config.cpp`, modelled on vanilla's
+`BurlapSackAttenuation`. Light takes ~6–12 dB off the top two octaves; Heavy takes 15–21 dB off and
+drops the mids 6 dB, with a touch of low-end lift — which is what plugged ears actually do, since
+bone conduction keeps the bottom end while the canal is blocked.
+
+Both presets zero the `Echo` section, unlike every vanilla preset. Vanilla is always modelling
+something wrapped around your head — a sack, a car cabin, a concussion — and those reverberate.
+Earplugs do not; they just take the top off.
+
+## Design notes
+
+### The baseline is measured, not read
+
+The obvious source for "the player's own volume" is `g_Game.m_volume_sound`. It is wrong. Those five
+fields are written in exactly **one** place — `DayZGame.DeferredInit`, `dayzgame.c:1130-1134` — and
+never again, so they are stale the moment the player touches the Options audio sliders. Vanilla
+inherits its own bug here: `MissionGameplay.OnPlayerRespawned` restores from them.
+
+So **while the level is Off, whatever the engine reports is the baseline**, refreshed on the 4 Hz
+tick and guarded on being alive and above zero. An Options change made with the plugs out is picked
+up within 250 ms, with no hook and no event.
+
+### The toggle writes, the reconciler only ever lowers
+
+That asymmetry is the whole answer to a problem the reference implementation does not attempt.
+Vanilla moves these buses out from under any mod that touches them:
+
+| What | Where |
+|---|---|
+| zeroes all five on death | `dayzplayerimplement.c:861` |
+| zeroes sound on uncon start | `playerbase.c:3534` |
+| restores from `m_volume_*` on uncon stop | `playerbase.c:3581` |
+| restores from `m_volume_*` on unpause / respawn | `missiongameplay.c:1626` |
+
+and in this mod set the host's spectate entry restores all five as well. Left alone, the level and
+the badge would go on claiming "Heavy" while the engine sat at full volume, and the player would have
+to press the key three more times to resync.
+
+Applying one rule — **the reconciler never raises** — makes all of it fall out:
+
+- vanilla restored to baseline → `current > desired` → re-lower ✔
+- vanilla zeroed for death/uncon → `current < desired` → leave it, it is theirs ✔
+- level is Off → `current == desired` → no write at all ✔
+
+and the one path allowed to raise is the player pressing the key, which is exactly what should
+restore their audio when they take the plugs out.
+
+Correction writes pass `time = 0` rather than a fade: a fade would keep `current > desired` true for
+its whole duration and re-fire the write on every tick of it. The toggle's own fade is protected by a
+short settle window for the same reason.
+
+### The attenuation slot is shared, so we yield
+
+`SetMasterAttenuation` is a single global slot with no stacking, shared with vanilla's unconscious,
+burlap sack, flashbang and complete-deafness effects. Two rules keep everyone honest:
+
+- only **write** when the slot is empty or already ours;
+- only **clear** when it is ours — clearing blindly is how you un-muffle somebody who is unconscious
+  or has a sack over their head.
+
+Because the tick re-applies, a slot that a vanilla effect borrowed and has since given back is picked
+up again within 250 ms without anyone having to notice. Flashbang re-asserts itself behind a defer
+timer, so it wins; there is no flapping, because both sides only write when the slot is theirs or
+empty.
+
+### The badge is persistent
+
+The reference implementation flashed an icon for about a second and faded it to nothing, which means
+a player who plugs their ears and forgets is permanently half-deaf with no cue explaining why they
+cannot hear footsteps. Here the badge stays up for as long as the plugs are in — full alpha for two
+seconds after a change, then eased to an idle alpha it never drops below. A change **to** Off gets
+the opposite treatment: nothing to show afterwards, so it flashes "OUT" and then hides.
+
+## Caveats
+
+- ⚠️ **`SetMasterAttenuation` is a *master* bus filter, so the muffle half may reach VOIP** whatever
+  the bus table above says. If that turns out to be audible and unwanted, the two halves are
+  independent by construction: drop the attenuation and keep the volume scaling.
+- **Nothing stops a player muting gunfire.** That is inherent to any client-side audio mod and is not
+  something a server can police.
+- A player whose effects volume is already 0 gets a no-op. It is logged at startup so it is not
+  mistaken for a broken addon.
+- `J` is free in vanilla and across this mod's other three `Inputs.xml` files.
+  **Community-Online-Tools is the one to check** if it ever does two things at once — its own
+  `Inputs.xml` is what collided with Party's `Y`.
+
+## Logging
+
+`-earplugs-trace` / `-earplugs-debug` / `-earplugs-info` / `-earplugs-warn` / `-earplugs-none` on the
+command line. Diag builds default to trace.
+
+**No `serverDZ.cfg` key**, unlike SafeZone and Map, and its absence is deliberate: this addon runs
+only on clients, and `ServerConfigGetInt` returns 0 on a client for every key, so such a branch would
+be dead code that looks like a supported way to configure the thing.
+
+At trace level every reconciler decision is logged **with its own reason** — `corrected`,
+`already-at-target`, `below-target-leaving-alone`, `yielded-to:<name>`, `settling` — but only when
+that reason **changes**. A guard that logs nothing cannot distinguish "this never ran" from "this ran
+and threw everything away"; one that logs unconditionally at 4 Hz buries the change that mattered.
+
+## Disabling
+
+Rename `config.cpp` → `config.cpp.disabled` and rebuild. Nothing in the mod references this addon, so
+there is no call site to guard and nothing else to do — **except deleting the stale
+`extra_earplugs.pbo` and its `.bisign` by hand**, since an incremental `Deploy.bat` does not reliably
+clean orphans.
+
+To keep the addon but ship it without the muffle, return `""` from
+`VigridEarPlugsLevels.Attenuation` — the volume half is untouched by that.

--- a/Extra/EarPlugs/Scripts/3_Game/VigridEarPlugsConstants.c
+++ b/Extra/EarPlugs/Scripts/3_Game/VigridEarPlugsConstants.c
@@ -1,0 +1,179 @@
+/**
+ *  EarPlugs - shared constants. No guard: this file compiles on both client and server.
+ *
+ *  Nothing here runs on a server - the whole feature is client-local, and every 5_Mission file is
+ *  #ifndef SERVER - but the constants themselves are side-agnostic and the logger beside them
+ *  follows the house shape, so neither is guarded.
+ */
+
+//--- Asset prefix. The ONLY hard-coded path in the addon - build every layout path from it.
+//--- CI1.bat derives each PBO's prefix as <PrefixLinkRoot>\<folder>, so this tracks the folder.
+static const string VIGRID_EARPLUGS_PREFIX = "Vigrid-BattleRoyale/Extra/EarPlugs/";
+
+//--- Logging. Diag builds are noisy by default, release builds are silent but for errors.
+#ifdef DIAG
+#define VIGRID_EARPLUGS_TRACE_ENABLED
+#endif
+
+#ifdef VIGRID_EARPLUGS_TRACE_ENABLED
+    static const int VIGRID_EARPLUGS_LOG_LEVEL = 4; // Trace
+#else
+    static const int VIGRID_EARPLUGS_LOG_LEVEL = 0; // Error only
+#endif
+
+//--- Preferences. The addon's own profile folder, deliberately not the host mod's, so that
+//--- extraction does not strand the file behind. $profile: on a client resolves to the CLIENT
+//--- profile directory, which is the only place a per-player choice can live.
+static const string VIGRID_EARPLUGS_SETTINGS_FOLDER = "$profile:Vigrid-EarPlugs\\";
+static const string VIGRID_EARPLUGS_PREFS_FILE = "$profile:Vigrid-EarPlugs\\earplugs_client.json";
+
+//--- Inputs. Resolved by name with GetUApi().GetInputByName rather than through the generated
+//--- constant, which comes from this PBO's own Inputs.xml and may not exist at compile time.
+static const string VIGRID_EARPLUGS_INPUT_TOGGLE = "UAVigridEarPlugsToggle";
+
+//--- Levels. Off is always 0 so an unwritable prefs file degrades to "no earplugs", never to
+//--- "silently deaf". Adding a fourth level (a full mute, say) means one more branch in each of
+//--- VigridEarPlugsLevels' three switches and one more entry in the stringtable - nothing else,
+//--- because every consumer asks that class rather than indexing a table.
+static const int VIGRID_EARPLUGS_LEVEL_OFF = 0;
+static const int VIGRID_EARPLUGS_LEVEL_LIGHT = 1;
+static const int VIGRID_EARPLUGS_LEVEL_HEAVY = 2;
+static const int VIGRID_EARPLUGS_LEVEL_COUNT = 3;
+
+//--- Volume multipliers, applied to the player's OWN volume rather than used as absolute values.
+//--- That distinction is the whole point: a player running at 40% effects volume must not be
+//--- blasted to 100% when they take the plugs out, and "45%" must not end up LOUDER than their
+//--- normal setting on a quiet setup.
+static const float VIGRID_EARPLUGS_FACTOR_LIGHT = 0.40;
+static const float VIGRID_EARPLUGS_FACTOR_HEAVY = 0.12;
+
+//--- Fade for a player-initiated change, in seconds - the second argument to every AbstractSoundScene
+//--- setter. Reconciler corrections deliberately use 0 instead; see VigridEarPlugsController.
+//---
+//--- The _MS twin is THE SAME FIGURE and must be kept in step: it is how long the reconciler holds
+//--- off after a toggle, and a fade outlasting that hold would be read as "above target" and
+//--- corrected mid-fade. Two constants rather than one arithmetic expression because GetTime() is
+//--- int milliseconds and the setters take float seconds.
+static const float VIGRID_EARPLUGS_FADE_S = 0.35;
+static const int VIGRID_EARPLUGS_FADE_MS = 350;
+
+//--- How often the reconciler runs. Fast enough that a vanilla volume restore is corrected before
+//--- the player registers it, slow enough to be free.
+static const int VIGRID_EARPLUGS_TICK_MS = 250;
+
+//--- Volume comparison tolerance. The engine's stored value is not bit-identical to what was written.
+static const float VIGRID_EARPLUGS_EPSILON = 0.01;
+
+//--- Which buses are scaled.
+//---
+//--- Effects is the whole point. Radio follows it because a radio is diegetic world audio - the same
+//--- kind of thing as a gunshot - and plugged ears do not distinguish.
+//---
+//--- Music, VOIP and SpeechEx are deliberately NOT scaled, and VOIP is the one that matters: this
+//--- mod ships parties, and a player who plugs their ears must still hear their squad. Muffling
+//--- comms would make the feature a competitive liability rather than a comfort setting. Music is
+//--- non-diegetic and already has its own Options slider.
+//---
+//--- ⚠️ SetMasterAttenuation is a MASTER bus filter, so the muffle half may reach VOIP whatever this
+//--- says. If that turns out to be audible and unwanted, the two halves are independent by
+//--- construction: drop the attenuation and keep the volume scaling.
+static const bool VIGRID_EARPLUGS_SCALE_RADIO = true;
+
+//--- HUD badge. Authored against a 1920-wide screen and scaled by parent_w / REFERENCE_W, because
+//--- SetPos and SetSize take REAL screen pixels while a layout's declared position and size are
+//--- scaled by viewport/1920. Mixing the two shifts a whole group while its spacing stays correct,
+//--- which reads as anything but a coordinate bug.
+static const float VIGRID_EARPLUGS_HUD_REFERENCE_W = 1920.0;
+static const float VIGRID_EARPLUGS_HUD_X = 26.0;
+static const float VIGRID_EARPLUGS_HUD_Y = 64.0;
+static const float VIGRID_EARPLUGS_HUD_W = 190.0;
+static const float VIGRID_EARPLUGS_HUD_H = 34.0;
+
+//--- Alpha while the plugs are simply in. Low enough to be furniture, high enough to be noticed -
+//--- this is the fix for a player forgetting they are deaf, so it must never fade to nothing.
+static const float VIGRID_EARPLUGS_HUD_IDLE_ALPHA = 0.55;
+static const float VIGRID_EARPLUGS_HUD_FLASH_ALPHA = 1.0;
+
+//--- How long the badge stays at full alpha after a change, and how long it then takes to ease back
+//--- to idle. The flash is also what announces a change TO Off, which is the one state with no
+//--- persistent badge at all.
+static const int VIGRID_EARPLUGS_HUD_FLASH_MS = 2000;
+static const int VIGRID_EARPLUGS_HUD_FADE_MS = 600;
+
+/**
+ *  Per-level lookup.
+ *
+ *  Deliberately three switches rather than three parallel arrays. Global const arrays are awkward in
+ *  EnfusionScript, an out-of-range index on one of them is a silent wrong answer rather than an
+ *  error, and this repo has already been bitten by an array read that returned entries from a
+ *  DIFFERENT array when it shared an expression with a call. A switch cannot do any of that: an
+ *  unknown level falls through to the Off answer, which is the safe one.
+ */
+class VigridEarPlugsLevels
+{
+    //! Multiplier applied to the player's own volume. 1.0 for Off, so Off needs no special case.
+    static float Factor(int level)
+    {
+        if (level == VIGRID_EARPLUGS_LEVEL_LIGHT)
+            return VIGRID_EARPLUGS_FACTOR_LIGHT;
+        if (level == VIGRID_EARPLUGS_LEVEL_HEAVY)
+            return VIGRID_EARPLUGS_FACTOR_HEAVY;
+
+        return 1.0;
+    }
+
+    //! CfgSoundEffects >> AttenuationsEffects classname, or "" for no muffle. See config.cpp.
+    static string Attenuation(int level)
+    {
+        if (level == VIGRID_EARPLUGS_LEVEL_LIGHT)
+            return "VigridEarPlugsLightAttenuation";
+        if (level == VIGRID_EARPLUGS_LEVEL_HEAVY)
+            return "VigridEarPlugsHeavyAttenuation";
+
+        return "";
+    }
+
+    //! Stringtable key for the badge. Bare "#KEY" - SetText resolves it.
+    static string LabelKey(int level)
+    {
+        if (level == VIGRID_EARPLUGS_LEVEL_LIGHT)
+            return "#STR_EARPLUGS_LEVEL_LIGHT";
+        if (level == VIGRID_EARPLUGS_LEVEL_HEAVY)
+            return "#STR_EARPLUGS_LEVEL_HEAVY";
+
+        return "#STR_EARPLUGS_LEVEL_OFF";
+    }
+
+    //! Untranslated, for the log only - a localized log line is a log line nobody can grep.
+    static string DebugName(int level)
+    {
+        if (level == VIGRID_EARPLUGS_LEVEL_LIGHT)
+            return "Light";
+        if (level == VIGRID_EARPLUGS_LEVEL_HEAVY)
+            return "Heavy";
+
+        return "Off";
+    }
+
+    //! Wraps back to Off past the last level.
+    static int Next(int level)
+    {
+        int next = level + 1;
+        if (next >= VIGRID_EARPLUGS_LEVEL_COUNT)
+            return VIGRID_EARPLUGS_LEVEL_OFF;
+
+        return next;
+    }
+
+    //! The prefs file is hand-editable, so a stale value from a build with more levels must not
+    //! reach Factor() and mean something unintended.
+    static int Clamp(int level)
+    {
+        if (level < VIGRID_EARPLUGS_LEVEL_OFF)
+            return VIGRID_EARPLUGS_LEVEL_OFF;
+        if (level >= VIGRID_EARPLUGS_LEVEL_COUNT)
+            return VIGRID_EARPLUGS_LEVEL_OFF;
+
+        return level;
+    }
+}

--- a/Extra/EarPlugs/Scripts/3_Game/VigridEarPlugsLog.c
+++ b/Extra/EarPlugs/Scripts/3_Game/VigridEarPlugsLog.c
@@ -1,0 +1,87 @@
+/**
+ *  EarPlugs - logging. No guard: compiles on both client and server.
+ *
+ *  A deliberate near-duplicate of the host mod's logger, and of SafeZone's and Map's. The discipline
+ *  rule keeps this addon free of BattleRoyale* symbols, so it carries its own, with its own CLI
+ *  flags so its verbosity can be tuned independently.
+ *
+ *  Runtime verbosity, highest priority first:
+ *    -earplugs-trace | -earplugs-debug | -earplugs-info | -earplugs-warn | -earplugs-none    (CLI)
+ *    VIGRID_EARPLUGS_LOG_LEVEL                                                (compile default)
+ *
+ *  ⚠️ NO serverDZ.cfg KEY HERE, unlike SafeZone and Map, and its absence is deliberate rather than
+ *  an omission. This addon runs only on clients, and GetGame().ServerConfigGetInt() returns 0 on a
+ *  client for EVERY key - measured - so a serverDZ.cfg branch would be dead code that looks like a
+ *  supported way to configure the thing. The CLI flags are the whole runtime surface.
+ */
+class VigridEarPlugsLog
+{
+    static const int NONE = 0;
+    static const int WARN = 1;
+    static const int INFO = 2;
+    static const int DEBUG = 3;
+    static const int TRACE = 4;
+
+    static void LogMessage(int level, string message)
+    {
+        if (!CheckLogLevel(level))
+            return;
+
+        int hour;
+        int minute;
+        int second;
+        GetHourMinuteSecond(hour, minute, second);
+
+        string stamp = hour.ToStringLen(2) + ":" + minute.ToStringLen(2) + ":" + second.ToStringLen(2);
+
+        if (level == NONE)
+        {
+            Error2("", stamp + " [EarPlugs] " + message);
+            return;
+        }
+
+        PrintFormat("%1 [EarPlugs][%2] %3", stamp, level, message);
+    }
+
+    static void Error(string message)
+    {
+        LogMessage(NONE, message);
+    }
+
+    static void Warn(string message)
+    {
+        LogMessage(WARN, message);
+    }
+
+    static void Info(string message)
+    {
+        LogMessage(INFO, message);
+    }
+
+    static void Debug(string message)
+    {
+        LogMessage(DEBUG, message);
+    }
+
+    static void Trace(string message)
+    {
+        LogMessage(TRACE, message);
+    }
+
+    static bool CheckLogLevel(int level)
+    {
+        //--- Command line wins.
+        if (IsCLIParam("earplugs-none"))
+            return false;
+        if (IsCLIParam("earplugs-trace"))
+            return TRACE >= level;
+        if (IsCLIParam("earplugs-debug"))
+            return DEBUG >= level;
+        if (IsCLIParam("earplugs-info"))
+            return INFO >= level;
+        if (IsCLIParam("earplugs-warn"))
+            return WARN >= level;
+
+        return VIGRID_EARPLUGS_LOG_LEVEL >= level;
+    }
+}

--- a/Extra/EarPlugs/Scripts/5_Mission/Client/EarPlugsMissionGameplay.c
+++ b/Extra/EarPlugs/Scripts/5_Mission/Client/EarPlugsMissionGameplay.c
@@ -1,0 +1,109 @@
+#ifndef SERVER
+/**
+ *  EarPlugs - client lifecycle and keybind.
+ *
+ *  A fifth `modded class MissionGameplay` alongside the Battle Royale, party, kill feed and map
+ *  ones. They all chain through super, so application order does not matter - but every override
+ *  here must keep calling super, or it silently cuts the other four out of the chain.
+ */
+modded class MissionGameplay
+{
+    protected ref VigridEarPlugsController m_EarPlugs;
+    protected ref VigridEarPlugsHud m_EarPlugsHud;
+
+    //! Latched so a missing bind is one line, not one line per frame. See HandleEarPlugsToggle.
+    protected bool m_EarPlugsBindMissing;
+
+    override void OnInit()
+    {
+        super.OnInit();
+
+        if (!m_EarPlugs)
+            m_EarPlugs = new VigridEarPlugsController();
+
+        //--- Built here but draws nothing until its first Update, which is where it creates its
+        //--- widgets - see VigridEarPlugsHud.EnsureRoot for why that cannot happen yet.
+        if (!m_EarPlugsHud)
+            m_EarPlugsHud = new VigridEarPlugsHud();
+
+        VigridEarPlugsLog.Debug("MissionGameplay::OnInit done");
+    }
+
+    override void OnMissionFinish()
+    {
+        //--- Give the buses and the attenuation slot back BEFORE the refs go, and before super
+        //--- tears the mission down. A master attenuation left set outlives this session: it would
+        //--- follow the player to the main menu and into the next server they join, with no UI
+        //--- anywhere to take it off again.
+        if (m_EarPlugs)
+            m_EarPlugs.Shutdown();
+
+        m_EarPlugs = NULL;
+        m_EarPlugsHud = NULL;
+
+        super.OnMissionFinish();
+    }
+
+    VigridEarPlugsController GetEarPlugs()
+    {
+        return m_EarPlugs;
+    }
+
+    override void OnUpdate(float timeslice)
+    {
+        super.OnUpdate(timeslice);
+
+        if (!m_EarPlugs)
+            return;
+
+        m_EarPlugs.Update(timeslice);
+
+        if (m_EarPlugsHud)
+            m_EarPlugsHud.Update(m_EarPlugs.GetLevel());
+
+        if (!GetUApi())
+            return;
+
+        //--- Chat only, deliberately - not "any menu". Plugging your ears while the inventory or the
+        //--- map is open is a perfectly reasonable thing to want, and unlike the map's own bind this
+        //--- one opens nothing and steals no focus, so there is nothing for an open menu to collide
+        //--- with. Chat is the exception because J is a letter somebody is trying to type.
+        if (m_UIManager.IsMenuOpen(MENU_CHAT_INPUT))
+            return;
+
+        HandleEarPlugsToggle();
+    }
+
+    /**
+     *  Cycle the level on the bind.
+     *
+     *  The bind is resolved BY NAME, so nothing here depends on the UAVigridEarPlugsToggle constant
+     *  generated from this PBO's Inputs.xml - which may not exist at compile time.
+     *
+     *  ⚠️ An unknown action name makes LocalPress return false forever, with no error anywhere. That
+     *  is exactly how the reference implementation died silently when its inputs.xml stopped being
+     *  declared, so the null check below logs once rather than failing quietly.
+     */
+    protected void HandleEarPlugsToggle()
+    {
+        UAInput toggle = GetUApi().GetInputByName(VIGRID_EARPLUGS_INPUT_TOGGLE);
+        if (!toggle)
+        {
+            if (!m_EarPlugsBindMissing)
+            {
+                m_EarPlugsBindMissing = true;
+                VigridEarPlugsLog.Error(VIGRID_EARPLUGS_INPUT_TOGGLE + " is not a registered input - check inputs= in Extra/EarPlugs/config.cpp");
+            }
+            return;
+        }
+
+        if (!toggle.LocalPress())
+            return;
+
+        m_EarPlugs.Cycle();
+
+        if (m_EarPlugsHud)
+            m_EarPlugsHud.Flash(m_EarPlugs.GetLevel());
+    }
+}
+#endif

--- a/Extra/EarPlugs/Scripts/5_Mission/Client/VigridEarPlugsController.c
+++ b/Extra/EarPlugs/Scripts/5_Mission/Client/VigridEarPlugsController.c
@@ -1,0 +1,401 @@
+#ifndef SERVER
+/**
+ *  EarPlugs - the whole feature.
+ *
+ *  Two independent halves, both client-local:
+ *
+ *    VOLUME   scale the effects (and radio) bus to a FRACTION OF THE PLAYER'S OWN SETTING;
+ *    MUFFLE   put a low-pass EQ on the master bus via Man.SetMasterAttenuation.
+ *
+ *  Either can be removed without touching the other - which matters, because the muffle half is the
+ *  one with an open question against it (see the VOIP note in VigridEarPlugsConstants.c).
+ *
+ *  ══ THE BASELINE IS MEASURED, NOT READ ═════════════════════════════════════════════════════════
+ *
+ *  The obvious source for "the player's own volume" is g_Game.m_volume_sound. It is wrong. Those
+ *  five fields are written in exactly ONE place - DayZGame.DeferredInit, dayzgame.c:1130-1134 - and
+ *  never again, so they are stale the moment the player touches the Options audio sliders. (Vanilla
+ *  inherits its own bug here: MissionGameplay.OnPlayerRespawned restores from them.)
+ *
+ *  So while the level is Off, WHATEVER THE ENGINE REPORTS IS THE BASELINE, refreshed on the tick.
+ *  An Options change made with the plugs out is picked up within 250 ms with no hook and no event.
+ *
+ *  ══ THE TOGGLE WRITES, THE RECONCILER ONLY EVER LOWERS ═════════════════════════════════════════
+ *
+ *  That asymmetry is the entire answer to a problem the reference implementation does not attempt.
+ *  Vanilla moves these buses out from under any mod that touches them:
+ *
+ *    zeroes all five on death            dayzplayerimplement.c:861
+ *    zeroes sound on uncon start         playerbase.c:3534
+ *    restores from m_volume_* on:        playerbase.c:3581 (uncon stop)
+ *                                        missiongameplay.c:1626 (unpause / respawn)
+ *
+ *  and in this mod set the host's spectate entry restores all five as well. Left alone, the level
+ *  and the badge would both go on claiming "Heavy" while the engine sat at full volume, and the
+ *  player would have to press the key three more times to resync.
+ *
+ *  Applying the rule "the reconciler never raises" makes every one of those cases fall out for free:
+ *
+ *    vanilla restored to baseline  ->  current > desired  ->  re-lower                     ✔
+ *    vanilla zeroed for death/uncon->  current < desired  ->  leave it alone, it is theirs ✔
+ *    level is Off                  ->  current == desired ->  no write at all              ✔
+ *
+ *  and the ONE path allowed to raise is the player pressing the key, which is exactly what should
+ *  restore their audio when they take the plugs out.
+ *
+ *  ══ THE ATTENUATION SLOT IS SHARED, SO WE YIELD ════════════════════════════════════════════════
+ *
+ *  SetMasterAttenuation is a single global slot with no stacking, shared with vanilla's unconscious,
+ *  burlap sack, flashbang and complete-deafness effects. Two rules keep everyone honest: only write
+ *  when the slot is empty or already ours, and only clear when it is ours. Clearing blindly would
+ *  un-muffle a player who is unconscious or wearing a sack over their head.
+ */
+class VigridEarPlugsController
+{
+    private int m_Level;
+
+    //--- The player's own volumes, measured rather than read. See the header.
+    private float m_BaselineSound;
+    private float m_BaselineRadio;
+
+    private bool m_Initialised;
+    private int m_LastTickMs;
+
+    //--- Reconciler writes are suppressed until this instant so they do not fight the toggle's own
+    //--- fade. Without it, a fade in progress reads as "above target" on every tick of its duration.
+    private int m_SettleUntilMs;
+
+    //--- Last reason logged per decision point. A no-op decision is only logged when its reason
+    //--- CHANGES, which is what keeps "log every rejection" from meaning twelve lines a second.
+    private string m_ReasonSound;
+    private string m_ReasonRadio;
+    private string m_ReasonAtten;
+
+    void VigridEarPlugsController()
+    {
+        m_Level = VigridEarPlugsPrefs.GetLevel();
+        VigridEarPlugsLog.Debug("Controller created, stored level " + VigridEarPlugsLevels.DebugName(m_Level));
+    }
+
+    int GetLevel()
+    {
+        return m_Level;
+    }
+
+    /**
+     *  Advance to the next level, persist it, and write it out.
+     *
+     *  This is the only path permitted to RAISE a bus volume - which is precisely what taking the
+     *  plugs out has to do.
+     */
+    void Cycle()
+    {
+        AbstractSoundScene scene = GetGame().GetSoundScene();
+        if (!scene)
+        {
+            VigridEarPlugsLog.Warn("Toggle ignored: no sound scene");
+            return;
+        }
+
+        //--- A toggle before the first Update would apply a level against a baseline nobody has
+        //--- measured yet. Measure it now instead of guessing.
+        if (!m_Initialised)
+            Initialise(scene);
+
+        int previous = m_Level;
+        m_Level = VigridEarPlugsLevels.Next(m_Level);
+        VigridEarPlugsPrefs.SetLevel(m_Level);
+
+        ApplyLevel(scene, VIGRID_EARPLUGS_FADE_S);
+        m_SettleUntilMs = GetGame().GetTime() + VIGRID_EARPLUGS_FADE_MS;
+
+        string line = "Level " + VigridEarPlugsLevels.DebugName(previous);
+        line = line + " -> " + VigridEarPlugsLevels.DebugName(m_Level);
+        line = line + " (x" + VigridEarPlugsLevels.Factor(m_Level).ToString() + ")";
+        VigridEarPlugsLog.Info(line);
+    }
+
+    void Update(float timeslice)
+    {
+        AbstractSoundScene scene = GetGame().GetSoundScene();
+        if (!scene)
+            return;
+
+        if (!m_Initialised)
+        {
+            Initialise(scene);
+            return;
+        }
+
+        if ((GetGame().GetTime() - m_LastTickMs) < VIGRID_EARPLUGS_TICK_MS)
+            return;
+
+        m_LastTickMs = GetGame().GetTime();
+        Tick(scene);
+    }
+
+    /**
+     *  Give back what we took, on the way out of the mission.
+     *
+     *  A master attenuation left set would follow the player into the next session - the main menu,
+     *  then whatever server they join next - with no UI anywhere to remove it.
+     */
+    void Shutdown()
+    {
+        ClearAttenuationIfOurs();
+
+        AbstractSoundScene scene = GetGame().GetSoundScene();
+        if (!scene)
+            return;
+        if (!m_Initialised)
+            return;
+
+        scene.SetSoundVolume(m_BaselineSound, 0);
+        if (VIGRID_EARPLUGS_SCALE_RADIO)
+            scene.SetRadioVolume(m_BaselineRadio, 0);
+
+        VigridEarPlugsLog.Debug("Shutdown: buses restored to baseline, attenuation released");
+    }
+
+    /**
+     *  Measure the player's own volumes and put the stored level back on.
+     *
+     *  Deferred to the first tick rather than done in the constructor: that runs inside
+     *  MissionGameplay.OnInit, and the only timing proven to work in this mod is after
+     *  super.OnInit() has returned. By the time a local player exists, DeferredInit is long done and
+     *  whatever the scene reports is the player's Options setting.
+     */
+    private void Initialise(AbstractSoundScene scene)
+    {
+        if (!GetGame().GetPlayer())
+            return;
+
+        m_BaselineSound = scene.GetSoundVolume();
+        m_BaselineRadio = scene.GetRadioVolume();
+        m_Initialised = true;
+
+        //--- Zero here is legal - a player really can run the game silent - but it makes the whole
+        //--- feature a no-op, and that is worth a line so it is not mistaken for a broken addon.
+        if (m_BaselineSound <= 0)
+            VigridEarPlugsLog.Warn("Effects volume is already 0 at startup - ear plugs will have nothing to do");
+
+        string line = "Baseline measured: sound=" + m_BaselineSound.ToString();
+        line = line + " radio=" + m_BaselineRadio.ToString();
+        line = line + ", restoring level " + VigridEarPlugsLevels.DebugName(m_Level);
+        VigridEarPlugsLog.Info(line);
+
+        //--- Applied with no fade: this is the session starting, not a change the player made.
+        ApplyLevel(scene, 0);
+    }
+
+    private void Tick(AbstractSoundScene scene)
+    {
+        if (GetGame().GetTime() < m_SettleUntilMs)
+        {
+            Note("sound", "settling");
+            return;
+        }
+
+        RefreshBaseline(scene);
+
+        float desired_sound = m_BaselineSound * VigridEarPlugsLevels.Factor(m_Level);
+        if (NeedsLowering(scene.GetSoundVolume(), desired_sound, "sound"))
+            scene.SetSoundVolume(desired_sound, 0);
+
+        if (VIGRID_EARPLUGS_SCALE_RADIO)
+        {
+            float desired_radio = m_BaselineRadio * VigridEarPlugsLevels.Factor(m_Level);
+            if (NeedsLowering(scene.GetRadioVolume(), desired_radio, "radio"))
+                scene.SetRadioVolume(desired_radio, 0);
+        }
+
+        ApplyAttenuation();
+    }
+
+    /**
+     *  While the plugs are out, the engine's value IS the player's setting.
+     *
+     *  Guarded on being alive and above zero, because both of the ways vanilla zeroes these buses -
+     *  death and going unconscious - would otherwise latch a baseline of 0 and leave the player
+     *  permanently silent with nothing on screen to explain it.
+     */
+    private void RefreshBaseline(AbstractSoundScene scene)
+    {
+        if (m_Level != VIGRID_EARPLUGS_LEVEL_OFF)
+            return;
+
+        PlayerBase player = PlayerBase.Cast(GetGame().GetPlayer());
+        if (!player)
+            return;
+        if (!player.IsAlive())
+            return;
+
+        float sound = scene.GetSoundVolume();
+        if (sound > 0 && Math.AbsFloat(sound - m_BaselineSound) > VIGRID_EARPLUGS_EPSILON)
+        {
+            VigridEarPlugsLog.Debug("Baseline sound follows the player's Options change: " + m_BaselineSound.ToString() + " -> " + sound.ToString());
+            m_BaselineSound = sound;
+        }
+
+        float radio = scene.GetRadioVolume();
+        if (radio > 0 && Math.AbsFloat(radio - m_BaselineRadio) > VIGRID_EARPLUGS_EPSILON)
+            m_BaselineRadio = radio;
+    }
+
+    /**
+     *  The never-raise rule, and the reason each answer was given.
+     *
+     *  Correction writes pass time = 0 rather than a fade, deliberately: a fade would keep
+     *  `current > desired` true for its whole duration and re-fire the write on every tick of it.
+     */
+    private bool NeedsLowering(float current, float desired, string bus)
+    {
+        if (current > desired + VIGRID_EARPLUGS_EPSILON)
+        {
+            string line = "corrected " + current.ToString();
+            line = line + " -> " + desired.ToString();
+            Note(bus, line);
+            return true;
+        }
+
+        if (current < desired - VIGRID_EARPLUGS_EPSILON)
+        {
+            //--- Something else - vanilla's death or unconsciousness handling - has taken it below
+            //--- where we want it. That is theirs to undo, not ours to fight.
+            Note(bus, "below-target-leaving-alone");
+            return false;
+        }
+
+        Note(bus, "already-at-target");
+        return false;
+    }
+
+    private void ApplyLevel(AbstractSoundScene scene, float fade)
+    {
+        float factor = VigridEarPlugsLevels.Factor(m_Level);
+
+        scene.SetSoundVolume(m_BaselineSound * factor, fade);
+        if (VIGRID_EARPLUGS_SCALE_RADIO)
+            scene.SetRadioVolume(m_BaselineRadio * factor, fade);
+
+        ApplyAttenuation();
+    }
+
+    /**
+     *  Take, hold or release the shared attenuation slot.
+     *
+     *  Called from both the toggle and the tick, so a slot that a vanilla effect borrowed and has
+     *  since given back is picked up again within 250 ms without anyone having to notice.
+     */
+    private void ApplyAttenuation()
+    {
+        PlayerBase player = PlayerBase.Cast(GetGame().GetPlayer());
+        if (!player)
+            return;
+
+        string want = VigridEarPlugsLevels.Attenuation(m_Level);
+        string have = player.GetMasterAttenuation();
+
+        if (want == "")
+        {
+            if (have == "")
+            {
+                Report("already-clear");
+                return;
+            }
+
+            if (!IsOurs(have))
+            {
+                //--- Not ours to clear. Clearing here is how you accidentally un-muffle somebody
+                //--- who is unconscious or has a burlap sack on their head.
+                Report("foreign-left-alone:" + have);
+                return;
+            }
+
+            player.SetMasterAttenuation("");
+            Report("cleared");
+            return;
+        }
+
+        if (have == want)
+        {
+            Report("already-applied:" + want);
+            return;
+        }
+
+        if (have != "" && !IsOurs(have))
+        {
+            Report("yielded-to:" + have);
+            return;
+        }
+
+        player.SetMasterAttenuation(want);
+        Report("applied:" + want);
+    }
+
+    private void ClearAttenuationIfOurs()
+    {
+        PlayerBase player = PlayerBase.Cast(GetGame().GetPlayer());
+        if (!player)
+            return;
+
+        if (!IsOurs(player.GetMasterAttenuation()))
+            return;
+
+        player.SetMasterAttenuation("");
+    }
+
+    //! Derived from the level table rather than a second list, so a new level cannot be forgotten here.
+    private bool IsOurs(string attenuation)
+    {
+        if (attenuation == "")
+            return false;
+
+        for (int i = 0; i < VIGRID_EARPLUGS_LEVEL_COUNT; i++)
+        {
+            string mine = VigridEarPlugsLevels.Attenuation(i);
+            if (mine != "" && mine == attenuation)
+                return true;
+        }
+
+        return false;
+    }
+
+    //--- Reason bookkeeping. Split out so the three decision points read as decisions rather than as
+    //--- logging. A no-op is logged only when its reason changes: a guard that never logs cannot
+    //--- distinguish "this never ran" from "this ran and threw everything away", but one that logs
+    //--- unconditionally at 4 Hz buries the change that mattered.
+
+    private void Report(string reason)
+    {
+        Note("attenuation", reason);
+    }
+
+    private void Note(string subject, string reason)
+    {
+        if (subject == "radio")
+        {
+            if (m_ReasonRadio == reason)
+                return;
+
+            m_ReasonRadio = reason;
+        }
+        else if (subject == "attenuation")
+        {
+            if (m_ReasonAtten == reason)
+                return;
+
+            m_ReasonAtten = reason;
+        }
+        else
+        {
+            if (m_ReasonSound == reason)
+                return;
+
+            m_ReasonSound = reason;
+        }
+
+        VigridEarPlugsLog.Trace(subject + ": " + reason);
+    }
+}
+#endif

--- a/Extra/EarPlugs/Scripts/5_Mission/Client/VigridEarPlugsHud.c
+++ b/Extra/EarPlugs/Scripts/5_Mission/Client/VigridEarPlugsHud.c
@@ -1,0 +1,222 @@
+#ifndef SERVER
+/**
+ *  EarPlugs - the on-screen badge.
+ *
+ *  ⚠️ THIS IS PERSISTENT, AND THAT IS THE POINT. The reference implementation flashed an icon for
+ *  about a second and then faded it to nothing, which means a player who plugs their ears and then
+ *  forgets is permanently half-deaf with no cue anywhere on screen explaining why they cannot hear
+ *  footsteps. So the badge stays up for as long as the plugs are in - full alpha for a couple of
+ *  seconds after a change, then eased back to a quiet idle alpha it never drops below.
+ *
+ *  The one state with no persistent badge is Off, which needs the opposite treatment: nothing to
+ *  show afterwards, but the player still has to be told the plugs came OUT. So a change to Off
+ *  flashes "EAR PLUGS / OUT" for the same couple of seconds and then hides.
+ *
+ *  Shape is VigridMapMinimap's throughout - widgets built on the first Update rather than in the
+ *  constructor, a latch so a failed build logs once instead of every tick, Show() only on an edge,
+ *  and Unlink() in the destructor.
+ */
+class VigridEarPlugsHud
+{
+    private Widget m_Root;
+    private bool m_RootFailed;
+
+    private Widget m_Backdrop;
+    private TextWidget m_Label;
+    private TextWidget m_Level;
+
+    private bool m_Shown;
+
+    //--- Cached so the layout arithmetic only re-runs when the viewport actually moves.
+    private float m_ParentW;
+
+    private int m_FlashUntilMs;
+    private int m_DisplayLevel = -1;
+
+    void ~VigridEarPlugsHud()
+    {
+        if (m_Root)
+            m_Root.Unlink();
+    }
+
+    /**
+     *  Announce a change the player just made.
+     *
+     *  Called from the keybind handler rather than polled off the controller: the controller has no
+     *  business knowing there is a HUD, and an edge the caller already has is not worth rediscovering
+     *  by diffing a field every frame.
+     */
+    void Flash(int level)
+    {
+        //--- Deliberately does NOT touch m_DisplayLevel or the widget. This can be called before the
+        //--- layout exists, and half-applying the change would leave Update's diff believing the
+        //--- text was already repainted. Setting the deadline alone keeps one owner for the text.
+        m_FlashUntilMs = GetGame().GetTime() + VIGRID_EARPLUGS_HUD_FLASH_MS;
+    }
+
+    void Update(int level)
+    {
+        if (!EnsureRoot())
+            return;
+
+        //--- Covers the level being restored from prefs at session start, which reaches the HUD
+        //--- through nobody's Flash() call.
+        if (level != m_DisplayLevel)
+        {
+            m_DisplayLevel = level;
+            m_Level.SetText(VigridEarPlugsLevels.LabelKey(level));
+        }
+
+        bool flashing = GetGame().GetTime() < m_FlashUntilMs;
+
+        if (!ShouldShow(level, flashing))
+        {
+            if (m_Shown)
+            {
+                m_Root.Show(false);
+                m_Shown = false;
+            }
+            return;
+        }
+
+        ApplyScale();
+
+        if (!m_Shown)
+        {
+            m_Root.Show(true);
+            m_Shown = true;
+        }
+
+        m_Root.SetAlpha(ResolveAlpha(level, flashing));
+    }
+
+    /**
+     *  Built on the first Update rather than in the constructor: that runs inside
+     *  MissionGameplay.OnInit, and the only timing proven to work in this mod is after
+     *  super.OnInit() has returned.
+     */
+    private bool EnsureRoot()
+    {
+        if (m_Root)
+            return true;
+        if (m_RootFailed)
+            return false;
+
+        m_Root = GetGame().GetWorkspace().CreateWidgets(VIGRID_EARPLUGS_PREFIX + "GUI/layouts/earplugs.layout");
+
+        if (!m_Root)
+        {
+            //--- Latched: retrying every tick would spam the log for the whole session.
+            m_RootFailed = true;
+            VigridEarPlugsLog.Error("Could not create earplugs.layout - badge disabled");
+            return false;
+        }
+
+        m_Backdrop = m_Root.FindAnyWidget("EarPlugsBackdrop");
+        m_Label = TextWidget.Cast(m_Root.FindAnyWidget("EarPlugsLabel"));
+        m_Level = TextWidget.Cast(m_Root.FindAnyWidget("EarPlugsLevel"));
+
+        if (!m_Backdrop || !m_Label || !m_Level)
+        {
+            //--- Fatal rather than a warning: with any of the three missing there is no badge, only
+            //--- a fragment of one, and a fragment is worse than nothing for a cue whose whole job
+            //--- is to be unambiguous.
+            m_RootFailed = true;
+            m_Root.Unlink();
+            m_Root = NULL;
+            VigridEarPlugsLog.Error("earplugs.layout is missing a widget - badge disabled");
+            return false;
+        }
+
+        m_Root.Show(false);
+        VigridEarPlugsLog.Debug("Badge layout ready");
+        return true;
+    }
+
+    private bool ShouldShow(int level, bool flashing)
+    {
+        //--- Off and not announcing anything: there is nothing to say.
+        if (level == VIGRID_EARPLUGS_LEVEL_OFF && !flashing)
+            return false;
+
+        //--- Behind any full-screen menu. The map, the inventory and the death screen all deserve
+        //--- the room, and the badge is not urgent enough to sit on top of them.
+        UIManager ui = GetGame().GetUIManager();
+        if (ui && ui.GetMenu())
+            return false;
+
+        return GetGame().GetPlayer() != NULL;
+    }
+
+    /**
+     *  Full alpha while announcing, then an ease down to the idle floor.
+     *
+     *  It never reaches zero: the floor IS the feature, and a badge that fades out is the reference
+     *  implementation's bug.
+     */
+    private float ResolveAlpha(int level, bool flashing)
+    {
+        if (flashing)
+            return VIGRID_EARPLUGS_HUD_FLASH_ALPHA;
+
+        //--- Off is only ever visible mid-flash, so anything past the flash is on its way out and
+        //--- the next Update will hide it. Holding full alpha until then avoids a one-frame dip.
+        if (level == VIGRID_EARPLUGS_LEVEL_OFF)
+            return VIGRID_EARPLUGS_HUD_FLASH_ALPHA;
+
+        //--- Held as a float from the start: `int / int` is integer division in EnfusionScript, so
+        //--- the progress term would only ever be 0 or 1 and the ease would be a hard cut.
+        float since = GetGame().GetTime() - m_FlashUntilMs;
+        if (since >= VIGRID_EARPLUGS_HUD_FADE_MS)
+            return VIGRID_EARPLUGS_HUD_IDLE_ALPHA;
+
+        float progress = since / VIGRID_EARPLUGS_HUD_FADE_MS;
+        float span = VIGRID_EARPLUGS_HUD_FLASH_ALPHA - VIGRID_EARPLUGS_HUD_IDLE_ALPHA;
+
+        return VIGRID_EARPLUGS_HUD_FLASH_ALPHA - (span * progress);
+    }
+
+    /**
+     *  Place and size the three children in REAL screen pixels.
+     *
+     *  Everything is authored against a 1920-wide screen and multiplied by parent_w / REFERENCE_W,
+     *  which is the same treatment VigridMapCompass gives its strip. Re-run only when the viewport
+     *  moves, since nothing else here changes.
+     */
+    private void ApplyScale()
+    {
+        float parent_w;
+        float parent_h;
+        m_Root.GetScreenSize(parent_w, parent_h);
+
+        if (parent_w <= 0)
+            return;
+        if (Math.AbsFloat(parent_w - m_ParentW) < 1.0)
+            return;
+
+        m_ParentW = parent_w;
+
+        float scale = parent_w / VIGRID_EARPLUGS_HUD_REFERENCE_W;
+        float x = VIGRID_EARPLUGS_HUD_X * scale;
+        float y = VIGRID_EARPLUGS_HUD_Y * scale;
+        float w = VIGRID_EARPLUGS_HUD_W * scale;
+        float h = VIGRID_EARPLUGS_HUD_H * scale;
+        float pad = 10.0 * scale;
+
+        m_Backdrop.SetPos(x, y);
+        m_Backdrop.SetSize(w, h);
+
+        //--- The label takes the left 55% and the level the right, so a long localized level word
+        //--- (Polish "ZATYCZKI", Czech "VYNDÁNO") has somewhere to go without overrunning the label.
+        float split = w * 0.55;
+
+        m_Label.SetPos(x + pad, y);
+        m_Label.SetSize(split - pad, h);
+
+        m_Level.SetPos(x + split, y);
+        m_Level.SetSize(w - split - pad, h);
+
+        VigridEarPlugsLog.Debug("Badge laid out for viewport " + parent_w.ToString());
+    }
+}
+#endif

--- a/Extra/EarPlugs/Scripts/5_Mission/Client/VigridEarPlugsPrefs.c
+++ b/Extra/EarPlugs/Scripts/5_Mission/Client/VigridEarPlugsPrefs.c
@@ -1,0 +1,114 @@
+#ifndef SERVER
+/**
+ *  EarPlugs - client-side preference.
+ *
+ *  One value: the level the player last chose. It is persisted because the reference implementation
+ *  did not, and re-plugging your ears after every reconnect is exactly the kind of small friction
+ *  that makes a comfort feature not get used.
+ *
+ *  Same shape as Extra/Map's VigridMapPrefs, which is the proven pattern in this repo for writing
+ *  JSON to $profile: from CLIENT script - every other JsonFileLoader write here is behind
+ *  #ifdef SERVER. It degrades rather than insists: if the file cannot be written the level still
+ *  works for the session, it simply does not survive a restart, and the failure is logged once
+ *  rather than on every keypress.
+ */
+class VigridEarPlugsPrefsData
+{
+    int version = 1;
+
+    //--- Off by default, and Off is 0, so a missing key, a corrupt file and an unwritable profile
+    //--- all degrade to "no earplugs" rather than to "silently deaf with no idea why".
+    int level = 0;
+
+    void Upgrade()
+    {
+        //--- No migrations yet. Bump `version` and add a branch here when a field changes meaning;
+        //--- adding a new scalar field needs nothing, since a missing key keeps its initialiser. A
+        //--- `ref array` WOULD need a branch - an array initialiser does not survive deserialization
+        //--- and would load back empty.
+        version = 1;
+    }
+}
+
+class VigridEarPlugsPrefs
+{
+    private static ref VigridEarPlugsPrefsData m_Data;
+
+    //--- Latched so a profile directory that cannot be written does not produce one log line per
+    //--- keypress for the rest of the session.
+    private static bool m_SaveFailed;
+
+    private static VigridEarPlugsPrefsData Data()
+    {
+        if (!m_Data)
+            Load();
+
+        return m_Data;
+    }
+
+    private static void Load()
+    {
+        m_Data = new VigridEarPlugsPrefsData();
+
+        if (!FileExist(VIGRID_EARPLUGS_PREFS_FILE))
+        {
+            VigridEarPlugsLog.Debug("No client prefs file, starting at Off");
+            //--- Written straight back out, so the file exists to be hand-edited and so a broken
+            //--- profile path is discovered now rather than on the first keypress.
+            Save();
+            return;
+        }
+
+        string error_message;
+        if (!JsonFileLoader<VigridEarPlugsPrefsData>.LoadFile(VIGRID_EARPLUGS_PREFS_FILE, m_Data, error_message))
+        {
+            //--- Warn, not ErrorEx: a fatal here would take the client down over a comfort setting.
+            //--- A corrupt file just means Off for the session.
+            VigridEarPlugsLog.Warn("Could not read client prefs: " + error_message);
+            m_Data = new VigridEarPlugsPrefsData();
+            return;
+        }
+
+        m_Data.Upgrade();
+
+        //--- The file is hand-editable and may predate a change in how many levels there are, so a
+        //--- stale value must not reach VigridEarPlugsLevels.Factor and mean something unintended.
+        m_Data.level = VigridEarPlugsLevels.Clamp(m_Data.level);
+
+        VigridEarPlugsLog.Debug("Client prefs loaded (level=" + VigridEarPlugsLevels.DebugName(m_Data.level) + ")");
+    }
+
+    private static void Save()
+    {
+        if (!m_Data)
+            return;
+
+        if (!FileExist(VIGRID_EARPLUGS_SETTINGS_FOLDER))
+            MakeDirectory(VIGRID_EARPLUGS_SETTINGS_FOLDER);
+
+        string error_message;
+        bool ok = JsonFileLoader<VigridEarPlugsPrefsData>.SaveFile(VIGRID_EARPLUGS_PREFS_FILE, m_Data, error_message);
+
+        //--- Checked on disk as well as by return value: a loader that reports success without
+        //--- producing a file would otherwise look like it worked.
+        if (ok && FileExist(VIGRID_EARPLUGS_PREFS_FILE))
+            return;
+        if (m_SaveFailed)
+            return;
+
+        m_SaveFailed = true;
+        VigridEarPlugsLog.Warn("Could not write " + VIGRID_EARPLUGS_PREFS_FILE + " (" + error_message + ") - the level will work this session but not survive a restart");
+    }
+
+    static int GetLevel()
+    {
+        return Data().level;
+    }
+
+    static void SetLevel(int level)
+    {
+        Data().level = VigridEarPlugsLevels.Clamp(level);
+        Save();
+    }
+}
+#endif

--- a/Extra/EarPlugs/config.cpp
+++ b/Extra/EarPlugs/config.cpp
@@ -1,0 +1,164 @@
+/**
+ *  EarPlugs - one key cycles the local client through Off -> Light -> Heavy. Bus volume comes down
+ *  AND a low-pass EQ goes on, so gunfire sounds muffled rather than merely distant.
+ *
+ *  This folder is its own PBO because the build packs every folder holding a config.cpp with no
+ *  ancestor config.cpp. Keep exactly ONE config.cpp here and do not nest another one below it.
+ *
+ *  DISCIPLINE RULE: nothing under Extra/EarPlugs/ may reference a BattleRoyale* symbol. This addon
+ *  has no API at all - nothing in the host mod needs to talk to it - so the rule costs nothing here
+ *  beyond its own logger, constants, stringtable and Inputs.xml. It hooks nothing but the vanilla
+ *  MissionGameplay, so it works on any DayZ server with or without Battle Royale loaded. That keeps
+ *  a later extraction into a standalone @Vigrid-EarPlugs mod a build-plumbing job rather than a
+ *  rewrite - and it keeps `config.cpp.disabled` working as a one-rename kill switch.
+ *
+ *  LICENCE NOTE. The idea comes from DaemonForge's DayZ-EarPlugs
+ *  (https://github.com/DaemonForge/DayZ-EarPlugs), which is GPLv3. This repository is DSPL-SA, which
+ *  adds non-commercial and DayZ-only restrictions that GPLv3 section 7 forbids adding to a combined
+ *  work - so no code and no asset from that mod is present here. The volume icons in particular are
+ *  theirs, which is why the indicator is a text badge built from widgets. Everything below is
+ *  written against vanilla declarations under P:\ and this repo's own addons. See README.md.
+ */
+class CfgPatches
+{
+    class Vigrid_EarPlugs
+    {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = 0.1;
+        requiredAddons[] =
+        {
+            "DZ_Data",
+            "DZ_Scripts"
+        };
+    };
+};
+
+class CfgMods
+{
+    class Vigrid_EarPlugs
+    {
+        dir = "Extra/EarPlugs";
+        credits = "Myst";
+        type = "mod";
+        name = "Vigrid Ear Plugs";
+
+        //--- A fourth inputs= alongside the Battle Royale, Party and Map ones is supported:
+        //--- @DayZ-Expansion ships three PBOs that each declare their own.
+        inputs = "Vigrid-BattleRoyale/Extra/EarPlugs/Data/Inputs.xml";
+
+        dependencies[] =
+        {
+            "Game",
+            "Mission"
+        };
+
+        //--- Declared for consistency with the other Extra/ addons and unconsumed: the host mod has
+        //--- no call sites to guard, because there is no API to call. defines[] are visible across
+        //--- CfgMods entries, so it is there if that ever changes.
+        defines[] =
+        {
+            "VIGRID_EARPLUGS"
+        };
+
+        //--- Only declare a script module once its folder actually exists: the engine registers
+        //--- files by directory, and pointing a module at a missing folder is a load-time error.
+        //--- There is no 4_World folder here on purpose - SetMasterAttenuation is called on the
+        //--- local PlayerBase from 5_Mission, which needs no entity-stage code of its own.
+        class defs
+        {
+            class gameScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/EarPlugs/Scripts/3_Game"
+                };
+            };
+            class missionScriptModule
+            {
+                value = "";
+                files[] =
+                {
+                    "Vigrid-BattleRoyale/Extra/EarPlugs/Scripts/5_Mission"
+                };
+            };
+        };
+    };
+};
+
+/**
+ *  The muffle itself. Man.SetMasterAttenuation(string) - P:\scripts\3_game\entities\man.c:41 -
+ *  resolves a classname under CfgSoundEffects >> AttenuationsEffects and applies a client-local EQ
+ *  to the master bus. "" clears it. Vanilla drives the same slot for HouseAttenuation,
+ *  CarAttenuation, UnconsciousAttenuation, BurlapSackAttenuation and FlashbangAttenuation
+ *  (P:\DZ\sounds\hpp\config.cpp:2145).
+ *
+ *  ⚠️ THESE ARE NEW CHILD CLASSES, NOT REDECLARATIONS. CfgSoundEffects and AttenuationsEffects are
+ *  parentless in vanilla, so there is no parent to carry - but the repo's config-override rule still
+ *  binds for the five vanilla presets: do NOT restate BurlapSackAttenuation or any sibling here.
+ *  Redeclaring an existing class without its parent REPLACES it rather than merge-patching it, and
+ *  that is what hard-froze every client with `class RscMapControl` in 2026-08-07. Only add ours.
+ *
+ *  Reading the numbers: `center` is Hz, `bandwidth` octaves, `gain` a LINEAR multiplier - so under 1
+ *  is a cut. Vanilla's values are dB conversions, and ours are written the same way with the dB in
+ *  the comment, because 0.17782794 is unreadable and -15 dB is not.
+ *
+ *  Echo is deliberately zeroed in both. Every vanilla preset carries some, because they are all
+ *  modelling something wrapped around your head - a sack, a car cabin, a concussion. Earplugs do not
+ *  reverberate; they just take the top off. Delay is 1 rather than 0, matching CarAttenuation, which
+ *  is the vanilla preset that also wants no echo.
+ */
+class CfgSoundEffects
+{
+    class AttenuationsEffects
+    {
+        //--- Light: foam-plug territory. Highs are gone, speech and footsteps still read clearly.
+        class VigridEarPlugsLightAttenuation
+        {
+            class Equalizer0
+            {
+                center[] = {98, 1568, 6272, 12544};
+                bandwidth[] = {2, 2, 1.8, 2};
+                gain[] = {1, 0.79432821, 0.50118721, 0.25118864};        // 0 / -2 / -6 / -12 dB
+            };
+            class Equalizer1
+            {
+                center[] = {60, 500, 3000, 15000};
+                bandwidth[] = {2, 2, 2, 2};
+                gain[] = {1, 1, 0.70794578, 0.25118864};                 // 0 / 0 / -3 / -12 dB
+            };
+            class Echo
+            {
+                WetDryMix = 0;
+                Feedback = 0;
+                Delay = 1;
+            };
+        };
+
+        //--- Heavy: range-defender territory. The top two octaves are essentially gone and the mids
+        //--- are well down, with a touch of low-end lift - which is what plugged ears actually do,
+        //--- since bone conduction keeps the bottom end while the canal is blocked.
+        class VigridEarPlugsHeavyAttenuation
+        {
+            class Equalizer0
+            {
+                center[] = {98, 1568, 6272, 12544};
+                bandwidth[] = {2, 2, 1.8, 2};
+                gain[] = {1.1220185, 0.50118721, 0.17782794, 0.08912509}; // +1 / -6 / -15 / -21 dB
+            };
+            class Equalizer1
+            {
+                center[] = {60, 500, 3000, 15000};
+                bandwidth[] = {2, 2, 2, 2};
+                gain[] = {1, 0.79432821, 0.31622777, 0.08912509};        // 0 / -2 / -10 / -21 dB
+            };
+            class Echo
+            {
+                WetDryMix = 0;
+                Feedback = 0;
+                Delay = 1;
+            };
+        };
+    };
+};

--- a/Extra/EarPlugs/stringtable.csv
+++ b/Extra/EarPlugs/stringtable.csv
@@ -1,0 +1,7 @@
+"Language","original","english","czech","german","russian","polish","hungarian","italian","spanish","french","chinese","japanese","portuguese","chinesesimp"
+"STR_EARPLUGS_KEYBIND_CATEGORY","EAR PLUGS","EAR PLUGS","ŠPUNTY DO UŠÍ","OHRSTÖPSEL","БЕРУШИ","ZATYCZKI DO USZU","FÜLDUGÓ","TAPPI PER ORECCHIE","TAPONES","BOUCHONS D'OREILLE","耳塞","耳栓","TAMPÕES","耳塞"
+"STR_EARPLUGS_KEYBIND_TOGGLE","Toggle Ear Plugs","Toggle Ear Plugs","Přepnout špunty do uší","Ohrstöpsel umschalten","Переключить беруши","Przełącz zatyczki do uszu","Füldugó be/ki","Attiva/disattiva tappi per orecchie","Alternar tapones para los oídos","Basculer les bouchons d'oreille","切換耳塞","耳栓の切り替え","Alternar tampões de ouvido","切换耳塞"
+"STR_EARPLUGS_HUD_LABEL","EAR PLUGS","EAR PLUGS","ŠPUNTY","OHRSTÖPSEL","БЕРУШИ","ZATYCZKI","FÜLDUGÓ","TAPPI","TAPONES","BOUCHONS","耳塞","耳栓","TAMPÕES","耳塞"
+"STR_EARPLUGS_LEVEL_OFF","OUT","OUT","VYNDÁNO","RAUS","СНЯТЫ","WYJĘTE","KIVÉVE","TOLTI","FUERA","RETIRÉS","已取出","解除","FORA","已取出"
+"STR_EARPLUGS_LEVEL_LIGHT","LIGHT","LIGHT","SLABÉ","LEICHT","СЛАБО","SŁABE","GYENGE","LEGGERI","SUAVE","LÉGER","輕度","弱","LEVE","轻度"
+"STR_EARPLUGS_LEVEL_HEAVY","HEAVY","HEAVY","SILNÉ","STARK","СИЛЬНО","MOCNE","ERŐS","FORTI","FUERTE","FORT","重度","強","FORTE","重度"

--- a/Extra/README.md
+++ b/Extra/README.md
@@ -4,7 +4,7 @@
 be lifted out of this repository and shipped on its own; none is required for the Battle Royale mod to
 function.
 
-**17 folders, 15 of which build** — `DisableFogChernarusPlus` and `DumpItemHeights` are currently
+**18 folders, 16 of which build** — `DisableFogChernarusPlus` and `DumpItemHeights` are currently
 parked.
 
 ## How this folder works
@@ -32,6 +32,7 @@ own PBO automatically. See the root `CLAUDE.md` for the script-module and stage 
 | [DefaultFullAuto](DefaultFullAuto/README.md) | `extra_defaultfullauto.pbo` | server | Weapons spawn already set to full auto where they have one |
 | [DisableFogChernarusPlus](DisableFogChernarusPlus/README.md) | *disabled* | — | Removes fog on Chernarus+. Parked: it does nothing on Vigrid |
 | [DumpItemHeights](DumpItemHeights/README.md) | *disabled* | — | **Throwaway diagnostic.** Dumps every loot item's bounding box (CfgVehicles + CfgWeapons + CfgMagazines) to a CSV on an offline Diag client. Parked: it has served its purpose, re-enable when heights need re-measuring |
+| [EarPlugs](EarPlugs/README.md) | `extra_earplugs.pbo` | client | One key cycles Off / Light / Heavy — scales the effects bus to a fraction of the player's own volume and applies a low-pass EQ |
 | [KillFeed](KillFeed/README.md) | `extra_killfeed.pbo` | both | On-screen death feed with weapon models, attachments and range |
 | [LimitUnconsciousTime](LimitUnconsciousTime/README.md) | `extra_limitunconscioustime.pbo` | server | Force-wakes an unconscious player after 5 seconds. **Not standalone** |
 | [Map](Map/README.md) | `extra_map.pbo` | both | Fullscreen map, HUD minimap, HUD compass, party-shared markers and zone circles |
@@ -52,6 +53,7 @@ Most of these have no settings at all. The ones that do:
 
 | Addon | Where |
 |---|---|
+| EarPlugs | `$profile:Vigrid-EarPlugs\earplugs_client.json` — per player, one value: the level last chosen. Not a server setting; there is none |
 | KillFeed | `$profile:KillFeed\killfeed_settings.json` — 4 options |
 | Map | `$profile:Vigrid-Map\map_settings.json` (server) and `map_client.json` (per player) |
 | MapSatellite | none, and it cannot have any — `MapWidget` exposes no satellite API, so the `config.cpp` rename is the whole control surface |
@@ -62,12 +64,13 @@ Most of these have no settings at all. The ones that do:
 
 ## Compile-time defines
 
-Only five addons declare a `defines[]`, which is what lets the mod guard its call sites with
+Only six addons declare a `defines[]`, which is what lets the mod guard its call sites with
 `#ifdef`:
 
 | Define | Addon | Used by the mod? |
 |---|---|---|
 | `DUMP_ITEM_HEIGHTS` | DumpItemHeights | no — declared for consistency only, and **not defined in a normal build** since the addon is parked |
+| `VIGRID_EARPLUGS` | EarPlugs | no — declared for consistency only; the addon exposes no API to call |
 | `KILLFEED` | KillFeed | yes — 5 call sites |
 | `VIGRID_SAFEZONE` | SafeZone | yes — 2 call sites |
 | `VIGRID_MAP` | Map | yes — client zone pushes and two server calls |
@@ -81,3 +84,7 @@ Comment either out of `Extra/Map/config.cpp` and that feature's class, its widge
 handler leave the PBO, while the fullscreen map is untouched.
 
 The other twelve declare none, so nothing can `#ifdef`-guard against them.
+
+`VIGRID_EARPLUGS` is a third kind again: it guards nothing anywhere, because EarPlugs is the one
+addon here with no API at all. It is declared so that a future host-mod call site has something to
+test, and so the addon does not look like an oversight beside the others.

--- a/Tools/Checks/stringtable.py
+++ b/Tools/Checks/stringtable.py
@@ -40,6 +40,7 @@ OWNERS = {
     "STR_PARTY_": "Party/stringtable.csv",
     "STR_KF_": "Extra/KillFeed/stringtable.csv",
     "STR_MAP_": "Extra/Map/stringtable.csv",
+    "STR_EARPLUGS_": "Extra/EarPlugs/stringtable.csv",
 }
 
 #  Preceded by `"` (a bare key, the form server script sends over the wire) or `#` (the localised


### PR DESCRIPTION
`J` cycles the local client through **Off → Light → Heavy**. Two independent halves, either removable without the other: the effects and radio buses are scaled to a *fraction of the player's own volume*, and a low-pass EQ goes on via `Man.SetMasterAttenuation` — so gunfire sounds muffled rather than merely distant.

New standalone addon `Extra/EarPlugs/` → `extra_earplugs.pbo`, client-only, stages `3_Game` + `5_Mission`. It is the one `Extra/` addon with **no API at all** — nothing in the host mod calls it.

## Licence — why this is a rewrite, not a port

The idea comes from [DaemonForge/DayZ-EarPlugs](https://github.com/DaemonForge/DayZ-EarPlugs), which is **GPLv3**. This repo is DSPL-SA, which adds non-commercial and DayZ-only restrictions that GPLv3 §7 forbids adding to a combined work — the same reasoning that blocked porting COT's `JMESPSkeleton`. **No code and no asset of theirs is present.** Their `volume_*.edds` icons in particular are why the indicator is a text badge built from widgets. Credited in the addon README.

## What the reference gets wrong, and this does not

Two of these were live breakages in the copy at `F:\DayZ Projects\VigridClient-Mod\EarPlugs\`: after the January refactor, both the layout path and the `inputs=` declaration still point at the `Data` PBO, so it works only off a stale 2025-03-14 artifact. Rebuild `Data` and the layout returns NULL (constructor null-derefs, mission module dies) and the keybind vanishes — the latter **silently**, since `LocalPress` on an unknown action name just returns false forever. Here everything lives in one PBO with one prefix.

The design faults:

- **The baseline is measured, not read.** `g_Game.m_volume_*` is written in exactly one place — `DayZGame.DeferredInit`, `dayzgame.c:1130-1134` — and never again, so it is stale the moment the player touches the Options sliders. *Vanilla inherits its own bug here*, since `OnPlayerRespawned` restores from it. Instead: while the level is Off, whatever the engine reports **is** the baseline, refreshed on the 4 Hz tick behind alive-and-above-zero guards. Levels are multipliers (×0.40 / ×0.12), never absolute — the reference restored to a hardcoded `SetSoundVolume(1, 1)`, blasting anyone running below full volume.
- **The toggle writes, the reconciler only ever lowers.** Vanilla moves these buses constantly (death `dayzplayerimplement.c:861`, uncon start `playerbase.c:3534`, uncon stop `playerbase.c:3581`, unpause/respawn `missiongameplay.c:1626`) — and `BattleRoyaleClient.EnterSpectate` restores all five, which would blast a player who died with earplugs in. That one asymmetry covers every case: a restore reads as above-target and is re-lowered; a vanilla mute reads as below-target and is left alone; Off is a no-op. The single path allowed to *raise* is the keypress.
- **The badge is persistent.** Full alpha for 2 s after a change, then eased to an idle alpha it never drops below. A one-second fade-out is the reference's actual bug: a player who forgets is permanently half-deaf with no cue.
- Level persists to `$profile:Vigrid-EarPlugs\earplugs_client.json`, following `VigridMapPrefs` including its save-failure latch and post-write `FileExist` re-check.

VOIP and SpeechEx are deliberately **not** scaled: this mod ships parties, and muffling squad comms would make the feature a competitive liability rather than a comfort setting.

The attenuation slot is global and shared with vanilla's uncon / burlap / flashbang / deafness, so it **yields** — write only when the slot is empty or ours, clear only when it is ours (clearing blindly un-muffles an unconscious player).

## Verification

- **All 13 static checks green** — but only after finding both my first runs were vacuous: `python -m Checks.stringtable` never calls `run()`, and `tracked()` only sees git-tracked files. A deliberate bogus-key probe was used to make the checker actually fire before trusting a clean result.
- Also registers `STR_EARPLUGS_` in `Tools/Checks/stringtable.py`, so a misfiled key is an **error** rather than an unowned-prefix warning.
- Build packs, binarizes and signs; `config.cpp` rapified, so the `CfgSoundEffects` block is syntactically valid. PBO file table confirmed to carry the layout, `stringtable.csv`, `Inputs.xml` and all six scripts under prefix `Vigrid-BattleRoyale\Extra\EarPlugs`.

⚠️ **Runtime is unverified.** Packing a PBO does not compile EnfusionScript, and the game was not launched. Nothing about the badge, the keybind resolving, the reconciler or whether the muffle is audible has been exercised. Draft for that reason.

Test with `LaunchOffline.bat -earplugs-trace` — this addon has no `#ifdef SERVER` code, so offline covers all of it. First thing to check is **Options → Controls**: an `EAR PLUGS` category bound to J is the proof that `inputs=` and the `loc=` key resolve.

## Open question

`SetMasterAttenuation` is a *master* bus filter, so the muffle half may reach VOIP whatever the bus table says. Needs `LaunchLocalMP.bat 2` to measure. If it does and that is unwanted, the two halves are independent by construction — drop the attenuation, keep the volume scaling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
